### PR TITLE
nix query string

### DIFF
--- a/apps/app/src/views/routes/PatientForm.tsx
+++ b/apps/app/src/views/routes/PatientForm.tsx
@@ -22,7 +22,7 @@ export const PatientForm = () => {
         if (e?.detail?.createPrescription) {
           navigate(`/prescriptions/new?patientId=${id}`);
         } else {
-          navigate(`/patients?reload=${id}-${ulid()}`);
+          navigate(`/patients`);
         }
       });
       ref.current.addEventListener('photon-patient-closed', () => {

--- a/apps/app/src/views/routes/UpdatePatientForm.tsx
+++ b/apps/app/src/views/routes/UpdatePatientForm.tsx
@@ -24,7 +24,7 @@ export const UpdatePatientForm = () => {
         if (e?.detail?.createPrescription) {
           navigate(`/prescriptions/new?patientId=${id}`);
         } else {
-          navigate(`/patients?reload=${id}-${ulid()}`);
+          navigate(`/patients`);
         }
       });
       ref.current.addEventListener('photon-patient-closed', () => {


### PR DESCRIPTION
when I create a new patient it get kicked back to something like this:
```
https://app.boson.health/patients?reload=pat_01GSE0VR7SG3QKNNV82A75AJZ3-01GSE0VRBKWQ4ACDG2RFWJ4P6G 
```
which when I refresh breaks the list populating 1 out of 3 ish times

but this doesn't break
```
https://app.boson.health/patients
```
Task Ref https://www.notion.so/photons/Adding-new-patient-loads-an-empty-patient-list-on-success-80019255ab964755bdeadf6faeeb80d1?pvs=4