### PR TITLE
Create order UI polishing

### DIFF
--- a/apps/app/src/views/components/FillsSelect.tsx
+++ b/apps/app/src/views/components/FillsSelect.tsx
@@ -111,7 +111,7 @@ export const FillsSelect = (props: FillsSelectProps) => {
   const borderColor = useColorModeValue('gray.200', 'gray.700');
 
   if (patientId && !loading && finished) {
-    return (
+    return options.length > 0 ? (
       <Box
         border="1px solid"
         borderColor={borderColor}
@@ -121,44 +121,42 @@ export const FillsSelect = (props: FillsSelectProps) => {
         onScroll={() => onScroll()}
         ref={listInnerRef}
       >
-        {options.length > 0 ? (
-          <Table size="sm">
-            <Tbody>
-              <CheckboxGroup size="lg" defaultValue={initialFills} onChange={setSelected}>
-                {/* TODO: We should really handle this a bit definitely from a semantic perspective */}
-                {options
-                  .filter((opt) => opt.fillsRemaining > 0)
-                  .map((opt: any) => (
-                    <Tr key={opt.value.prescriptionId + opt.value.treatmentId}>
-                      <Td paddingRight="0">
-                        <Checkbox size="lg" value={opt.value.prescriptionId} name={name} />
-                      </Td>
-                      <Td whiteSpace="pre-wrap">
-                        <Box minWidth={150} textOverflow="ellipsis">
-                          {opt.treatment}
-                        </Box>
-                      </Td>
-                      <Td isNumeric>{opt.fillsRemaining}</Td>
-                      <Td>{opt.effective}</Td>
-                    </Tr>
-                  ))}
-              </CheckboxGroup>
-            </Tbody>
-            <Thead position="sticky" top={0}>
-              <Tr borderTop="unset">
-                <Th borderTop="unset" />
-                <Th borderTop="unset">Treatment</Th>
-                <Th borderTop="unset">Fills</Th>
-                <Th borderTop="unset">Effective</Th>
-              </Tr>
-            </Thead>
-          </Table>
-        ) : (
-          <Text fontSize="1rem" paddingX="4" paddingY="2" color="gray.400">
-            The patient you selected has no prescriptions.
-          </Text>
-        )}
+        <Table size="sm">
+          <Tbody>
+            <CheckboxGroup size="lg" defaultValue={initialFills} onChange={setSelected}>
+              {/* TODO: We should really handle this a bit definitely from a semantic perspective */}
+              {options
+                .filter((opt) => opt.fillsRemaining > 0)
+                .map((opt: any) => (
+                  <Tr key={opt.value.prescriptionId + opt.value.treatmentId}>
+                    <Td paddingRight="0">
+                      <Checkbox size="lg" value={opt.value.prescriptionId} name={name} />
+                    </Td>
+                    <Td whiteSpace="pre-wrap">
+                      <Box minWidth={150} textOverflow="ellipsis">
+                        {opt.treatment}
+                      </Box>
+                    </Td>
+                    <Td isNumeric>{opt.fillsRemaining}</Td>
+                    <Td>{opt.effective}</Td>
+                  </Tr>
+                ))}
+            </CheckboxGroup>
+          </Tbody>
+          <Thead position="sticky" top={0}>
+            <Tr borderTop="unset">
+              <Th borderTop="unset" />
+              <Th borderTop="unset">Treatment</Th>
+              <Th borderTop="unset">Fills</Th>
+              <Th borderTop="unset">Effective</Th>
+            </Tr>
+          </Thead>
+        </Table>
       </Box>
+    ) : (
+      <Text fontSize="1rem" color="gray.400">
+        This patient has no prescriptions.
+      </Text>
     );
   }
 

--- a/apps/app/src/views/routes/NewOrder/components/PatientAddressCard.tsx
+++ b/apps/app/src/views/routes/NewOrder/components/PatientAddressCard.tsx
@@ -44,7 +44,7 @@ export const PatientAddressCard = ({
     <Card bg="bg-surface">
       <CardHeader>
         <HStack w="full" justify="space-between">
-          <Heading size="xxs">Patient Address</Heading>
+          <Heading size="xxs">{!showAddress ? 'Patient Address' : 'Set Patient Address'}</Heading>
           {!showAddress ? (
             <Button onClick={() => setShowAddress(true)} size="xs">
               Change

--- a/apps/app/src/views/routes/NewOrder/components/PatientAddressCard.tsx
+++ b/apps/app/src/views/routes/NewOrder/components/PatientAddressCard.tsx
@@ -54,7 +54,7 @@ export const PatientAddressCard = ({
       </CardHeader>
       <CardBody pt={0}>
         {!showAddress ? (
-          <Text fontSize="14px">{formatAddress(address)}</Text>
+          <Text>{formatAddress(address)}</Text>
         ) : (
           <VStack spacing={6} align="stretch" alignSelf="flex-start">
             <FormControl isInvalid={!!errors.address?.street1 && touched.address?.street1}>

--- a/apps/app/src/views/routes/NewOrder/components/SelectPharmacyCard/components/LocalPickup.tsx
+++ b/apps/app/src/views/routes/NewOrder/components/SelectPharmacyCard/components/LocalPickup.tsx
@@ -1,22 +1,26 @@
 import { useEffect, useState } from 'react';
 import {
   Button,
+  CardBody,
+  Checkbox,
   FormControl,
-  Text,
-  VStack,
-  Wrap,
-  WrapItem,
   FormErrorMessage,
   Tag,
   TagLeftIcon,
-  TagLabel
+  TagLabel,
+  Text,
+  VStack,
+  Wrap,
+  WrapItem
 } from '@chakra-ui/react';
 import { FiMapPin } from 'react-icons/fi';
 import { usePhoton, types } from '@photonhealth/react';
 import { AsyncSelect } from 'chakra-react-select';
 import { RepeatIcon, StarIcon } from '@chakra-ui/icons';
 import { useSearchParams } from 'react-router-dom';
+
 import { titleCase } from '../../../../../../utils';
+import { Pharmacy } from '../components/Pharmacy';
 
 const formatPharmacyOptions = (p: types.Pharmacy[], preferredIds: string[], previousId = '') => {
   // grab preferred and previous pharmacies and put them at the top of the list
@@ -33,7 +37,7 @@ const formatPharmacyOptions = (p: types.Pharmacy[], preferredIds: string[], prev
           {org.name}, {titleCase(org.address?.street1)}, {titleCase(org.address?.city)},{' '}
           {org.address?.state}{' '}
           {preferredIds.some((id) => id === org.id) ? (
-            <Tag size="sm" colorScheme="yellow" verticalAlign="text-center">
+            <Tag size="sm" colorScheme="yellow" verticalAlign="text-center" me={1}>
               <TagLeftIcon boxSize="12px" as={StarIcon} />
               <TagLabel>Preferred</TagLabel>
             </Tag>
@@ -58,8 +62,13 @@ interface LocalPickupProps {
   onOpen: any;
   errors: any;
   touched: any;
+  patient: any;
+  pharmacyId: string | undefined;
+  updatePreferredPharmacy: any;
+  setUpdatePreferredPharmacy: any;
   preferredPharmacyIds: string[];
   setFieldValue: (field: string, value: string) => void;
+  handleChangeBtnClick: any;
 }
 
 export const LocalPickup = (props: LocalPickupProps) => {
@@ -70,8 +79,13 @@ export const LocalPickup = (props: LocalPickupProps) => {
     longitude,
     errors,
     touched,
+    patient,
+    pharmacyId,
+    updatePreferredPharmacy,
+    setUpdatePreferredPharmacy,
     setFieldValue,
-    preferredPharmacyIds
+    preferredPharmacyIds,
+    handleChangeBtnClick
   } = props;
   const [params] = useSearchParams();
   const { getPharmacies, getOrders } = usePhoton();
@@ -117,6 +131,34 @@ export const LocalPickup = (props: LocalPickupProps) => {
       callback(await getPharmacyOptions(inputValue));
     }, 500);
   };
+
+  if (pharmacyId) {
+    const isPreferred =
+      pharmacyId &&
+      patient?.preferredPharmacies?.some(({ id }: { id: string }) => id === pharmacyId);
+
+    return (
+      <CardBody p={0}>
+        <Pharmacy
+          pharmacyId={pharmacyId}
+          isPreferred={isPreferred}
+          handleChangeBtnClick={handleChangeBtnClick}
+        />
+        {isPreferred ? null : (
+          <Checkbox
+            pt={2}
+            isChecked={updatePreferredPharmacy}
+            onChange={(e) => setUpdatePreferredPharmacy(e.target.checked)}
+          >
+            Save as Preferred{' '}
+            <Text as="span" fontSize="xs" color="gray.400">
+              Optional
+            </Text>
+          </Checkbox>
+        )}
+      </CardBody>
+    );
+  }
 
   return location ? (
     <>

--- a/apps/app/src/views/routes/NewOrder/components/SelectPharmacyCard/components/LocalPickup.tsx
+++ b/apps/app/src/views/routes/NewOrder/components/SelectPharmacyCard/components/LocalPickup.tsx
@@ -96,6 +96,7 @@ export const LocalPickup = (props: LocalPickupProps) => {
     patientId,
     first: 1
   });
+  const previousId = orders?.[0]?.pharmacy?.id || '';
 
   const [pharmOptions, setPharmOptions] = useState<any>([]);
 
@@ -113,7 +114,7 @@ export const LocalPickup = (props: LocalPickupProps) => {
     return formatPharmacyOptions(
       resultPharmacies.data.pharmacies,
       preferredPharmacyIds,
-      orders?.[0]?.pharmacy?.id || ''
+      previousId
     );
   };
 
@@ -136,12 +137,14 @@ export const LocalPickup = (props: LocalPickupProps) => {
     const isPreferred =
       pharmacyId &&
       patient?.preferredPharmacies?.some(({ id }: { id: string }) => id === pharmacyId);
+    const isPrevious = previousId === pharmacyId;
 
     return (
       <CardBody p={0}>
         <Pharmacy
           pharmacyId={pharmacyId}
           isPreferred={isPreferred}
+          isPrevious={isPrevious}
           handleChangeBtnClick={handleChangeBtnClick}
         />
         {isPreferred ? null : (

--- a/apps/app/src/views/routes/NewOrder/components/SelectPharmacyCard/components/LocalPickup.tsx
+++ b/apps/app/src/views/routes/NewOrder/components/SelectPharmacyCard/components/LocalPickup.tsx
@@ -33,13 +33,13 @@ const formatPharmacyOptions = (p: types.Pharmacy[], preferredIds: string[], prev
           {org.name}, {titleCase(org.address?.street1)}, {titleCase(org.address?.city)},{' '}
           {org.address?.state}{' '}
           {preferredIds.some((id) => id === org.id) ? (
-            <Tag size="sm" colorScheme="yellow" mt={1}>
+            <Tag size="sm" colorScheme="yellow" verticalAlign="text-center">
               <TagLeftIcon boxSize="12px" as={StarIcon} />
               <TagLabel>Preferred</TagLabel>
             </Tag>
           ) : null}
           {previousId === org.id ? (
-            <Tag size="sm" colorScheme="green" mt={1}>
+            <Tag size="sm" colorScheme="green" verticalAlign="text-center">
               <TagLeftIcon boxSize="12px" as={RepeatIcon} />
               <TagLabel>Previous</TagLabel>
             </Tag>

--- a/apps/app/src/views/routes/NewOrder/components/SelectPharmacyCard/components/Pharmacy.tsx
+++ b/apps/app/src/views/routes/NewOrder/components/SelectPharmacyCard/components/Pharmacy.tsx
@@ -12,7 +12,7 @@ import {
   Text,
   VStack
 } from '@chakra-ui/react';
-import { StarIcon } from '@chakra-ui/icons';
+import { RepeatIcon, StarIcon } from '@chakra-ui/icons';
 import { usePhoton, types } from '@photonhealth/react';
 
 import { formatAddress } from '../../../../../../utils';
@@ -20,6 +20,7 @@ import { formatAddress } from '../../../../../../utils';
 interface PharmacyProps {
   pharmacyId: string;
   isPreferred?: boolean;
+  isPrevious?: boolean;
   showTags?: boolean;
   handleChangeBtnClick?: any;
 }
@@ -27,6 +28,7 @@ interface PharmacyProps {
 export const Pharmacy = ({
   pharmacyId,
   isPreferred,
+  isPrevious,
   showTags,
   handleChangeBtnClick
 }: PharmacyProps) => {
@@ -61,40 +63,50 @@ export const Pharmacy = ({
   }
 
   return (
-    <HStack>
-      <VStack align="start" spacing={0}>
-        {showTags ? (
-          <Box>
-            {isPreferred ? (
-              <Tag size="sm" colorScheme="yellow" mb={1} me={2}>
-                <TagLeftIcon boxSize="12px" as={StarIcon} />
-                <TagLabel>Preferred</TagLabel>
-              </Tag>
-            ) : null}
-            {pharmacy?.fulfillmentTypes?.includes(types.FulfillmentType.MailOrder) ? (
-              <Tag size="sm" colorScheme="blue" mb={1}>
-                Mail Order
-              </Tag>
-            ) : null}
-            {pharmacy?.fulfillmentTypes?.includes(types.FulfillmentType.PickUp) ? (
-              <Tag size="sm" colorScheme="green" mb={1}>
-                Pick Up
-              </Tag>
-            ) : null}
-          </Box>
-        ) : null}
-        <Text>{pharmacy.name}</Text>
-        {pharmacy?.address ? <Text color="gray.500">{formatAddress(pharmacy.address)}</Text> : null}
-      </VStack>
-      <Spacer />
-      <Box>
-        {handleChangeBtnClick ? (
-          <Button onClick={() => handleChangeBtnClick()} size="xs">
-            Change
-          </Button>
-        ) : null}
-      </Box>
-    </HStack>
+    <VStack align="start" spacing={0}>
+      {showTags ? (
+        <Box>
+          {isPreferred ? (
+            <Tag size="sm" colorScheme="yellow" mb={1} me={1}>
+              <TagLeftIcon boxSize="12px" as={StarIcon} />
+              <TagLabel>Preferred</TagLabel>
+            </Tag>
+          ) : null}
+          {isPrevious ? (
+            <Tag size="sm" colorScheme="green" mb={1} me={1}>
+              <TagLeftIcon boxSize="12px" as={RepeatIcon} />
+              <TagLabel>Previous</TagLabel>
+            </Tag>
+          ) : null}
+          {pharmacy?.fulfillmentTypes?.includes(types.FulfillmentType.MailOrder) ? (
+            <Tag size="sm" colorScheme="blue" mb={1}>
+              Mail Order
+            </Tag>
+          ) : null}
+          {pharmacy?.fulfillmentTypes?.includes(types.FulfillmentType.PickUp) ? (
+            <Tag size="sm" colorScheme="purple" mb={1}>
+              Pick Up
+            </Tag>
+          ) : null}
+        </Box>
+      ) : null}
+      <HStack w="full">
+        <VStack align="start" spacing={0}>
+          <Text>{pharmacy.name}</Text>
+          {pharmacy?.address ? (
+            <Text color="gray.500">{formatAddress(pharmacy.address)}</Text>
+          ) : null}
+        </VStack>
+        <Spacer />
+        <Box>
+          {handleChangeBtnClick ? (
+            <Button onClick={() => handleChangeBtnClick()} size="xs" ms="auto">
+              Change
+            </Button>
+          ) : null}
+        </Box>
+      </HStack>
+    </VStack>
   );
 };
 

--- a/apps/app/src/views/routes/NewOrder/components/SelectPharmacyCard/components/Pharmacy.tsx
+++ b/apps/app/src/views/routes/NewOrder/components/SelectPharmacyCard/components/Pharmacy.tsx
@@ -1,6 +1,17 @@
 import { useState, useEffect } from 'react';
-import { Box, Skeleton, SkeletonText, Tag, Text, VStack } from '@chakra-ui/react';
+import {
+  Box,
+  Skeleton,
+  SkeletonText,
+  Tag,
+  TagLabel,
+  TagLeftIcon,
+  Text,
+  VStack
+} from '@chakra-ui/react';
+import { StarIcon } from '@chakra-ui/icons';
 import { usePhoton, types } from '@photonhealth/react';
+
 import { formatAddress } from '../../../../../../utils';
 
 interface PharmacyProps {
@@ -45,8 +56,9 @@ export const Pharmacy = ({ pharmacyId, isPreferred, showTags }: PharmacyProps) =
       {showTags ? (
         <Box>
           {isPreferred ? (
-            <Tag size="sm" colorScheme="orange" mb={1} me={2}>
-              Preferred
+            <Tag size="sm" colorScheme="yellow" mb={1} me={2}>
+              <TagLeftIcon boxSize="12px" as={StarIcon} />
+              <TagLabel>Preferred</TagLabel>
             </Tag>
           ) : null}
           {pharmacy?.fulfillmentTypes?.includes(types.FulfillmentType.MailOrder) ? (

--- a/apps/app/src/views/routes/NewOrder/components/SelectPharmacyCard/components/Pharmacy.tsx
+++ b/apps/app/src/views/routes/NewOrder/components/SelectPharmacyCard/components/Pharmacy.tsx
@@ -1,8 +1,11 @@
 import { useState, useEffect } from 'react';
 import {
   Box,
+  Button,
+  HStack,
   Skeleton,
   SkeletonText,
+  Spacer,
   Tag,
   TagLabel,
   TagLeftIcon,
@@ -18,9 +21,15 @@ interface PharmacyProps {
   pharmacyId: string;
   isPreferred?: boolean;
   showTags?: boolean;
+  handleChangeBtnClick?: any;
 }
 
-export const Pharmacy = ({ pharmacyId, isPreferred, showTags }: PharmacyProps) => {
+export const Pharmacy = ({
+  pharmacyId,
+  isPreferred,
+  showTags,
+  handleChangeBtnClick
+}: PharmacyProps) => {
   const { getPharmacy } = usePhoton();
   const { refetch, loading } = getPharmacy({ id: '' });
 
@@ -52,34 +61,45 @@ export const Pharmacy = ({ pharmacyId, isPreferred, showTags }: PharmacyProps) =
   }
 
   return (
-    <VStack align="start" spacing={0} wordBreak="break-all">
-      {showTags ? (
-        <Box>
-          {isPreferred ? (
-            <Tag size="sm" colorScheme="yellow" mb={1} me={2}>
-              <TagLeftIcon boxSize="12px" as={StarIcon} />
-              <TagLabel>Preferred</TagLabel>
-            </Tag>
-          ) : null}
-          {pharmacy?.fulfillmentTypes?.includes(types.FulfillmentType.MailOrder) ? (
-            <Tag size="sm" colorScheme="blue" mb={1}>
-              Mail Order
-            </Tag>
-          ) : null}
-          {pharmacy?.fulfillmentTypes?.includes(types.FulfillmentType.PickUp) ? (
-            <Tag size="sm" colorScheme="green" mb={1}>
-              Pick Up
-            </Tag>
-          ) : null}
-        </Box>
-      ) : null}
-      <Text>{pharmacy.name}</Text>
-      {pharmacy?.address ? <Text color="gray.500">{formatAddress(pharmacy.address)}</Text> : null}
-    </VStack>
+    <HStack>
+      <VStack align="start" spacing={0}>
+        {showTags ? (
+          <Box>
+            {isPreferred ? (
+              <Tag size="sm" colorScheme="yellow" mb={1} me={2}>
+                <TagLeftIcon boxSize="12px" as={StarIcon} />
+                <TagLabel>Preferred</TagLabel>
+              </Tag>
+            ) : null}
+            {pharmacy?.fulfillmentTypes?.includes(types.FulfillmentType.MailOrder) ? (
+              <Tag size="sm" colorScheme="blue" mb={1}>
+                Mail Order
+              </Tag>
+            ) : null}
+            {pharmacy?.fulfillmentTypes?.includes(types.FulfillmentType.PickUp) ? (
+              <Tag size="sm" colorScheme="green" mb={1}>
+                Pick Up
+              </Tag>
+            ) : null}
+          </Box>
+        ) : null}
+        <Text>{pharmacy.name}</Text>
+        {pharmacy?.address ? <Text color="gray.500">{formatAddress(pharmacy.address)}</Text> : null}
+      </VStack>
+      <Spacer />
+      <Box>
+        {handleChangeBtnClick ? (
+          <Button onClick={() => handleChangeBtnClick()} size="xs">
+            Change
+          </Button>
+        ) : null}
+      </Box>
+    </HStack>
   );
 };
 
 Pharmacy.defaultProps = {
   isPreferred: false,
-  showTags: true
+  showTags: true,
+  handleChangeBtnClick: undefined
 };

--- a/apps/app/src/views/routes/NewOrder/components/SelectPharmacyCard/components/SendToPatient.tsx
+++ b/apps/app/src/views/routes/NewOrder/components/SelectPharmacyCard/components/SendToPatient.tsx
@@ -28,6 +28,6 @@ export const SendToPatient = ({ patient }: any) => {
       </Card>
     </VStack>
   ) : (
-    <Text>Please select a patient to view this option.</Text>
+    <Text>Select a patient to view this option.</Text>
   );
 };

--- a/apps/app/src/views/routes/NewOrder/components/SelectPharmacyCard/index.tsx
+++ b/apps/app/src/views/routes/NewOrder/components/SelectPharmacyCard/index.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useState } from 'react';
 import {
-  Button,
   Card,
   CardHeader,
   Heading,
@@ -10,10 +9,7 @@ import {
   Tab,
   TabPanels,
   TabPanel,
-  useDisclosure,
-  CardBody,
-  Checkbox,
-  Text
+  useDisclosure
 } from '@chakra-ui/react';
 
 import { types } from '@photonhealth/react';
@@ -21,7 +17,6 @@ import { types } from '@photonhealth/react';
 import { LocationSearch } from '../../../../components/LocationSearch';
 import { LocalPickup } from './components/LocalPickup';
 import { MailOrder } from './components/MailOrder';
-import { Pharmacy } from './components/Pharmacy';
 import { Address } from '../../../../../models/general';
 import { SendToPatient } from './components/SendToPatient';
 
@@ -72,6 +67,11 @@ export const SelectPharmacyCard: React.FC<SelectPharmacyCardProps> = ({
     onClose();
   };
 
+  const handleChangeBtnClick = () => {
+    setFieldValue('pharmacyId', '');
+    setUpdatePreferredPharmacy(false);
+  };
+
   const tabsList = [
     {
       name: 'Local Pickup',
@@ -85,12 +85,23 @@ export const SelectPharmacyCard: React.FC<SelectPharmacyCardProps> = ({
           onOpen={onOpen}
           errors={errors}
           touched={touched}
+          patient={patient}
+          pharmacyId={pharmacyId}
+          updatePreferredPharmacy={updatePreferredPharmacy}
+          setUpdatePreferredPharmacy={setUpdatePreferredPharmacy}
           preferredPharmacyIds={
             patient?.preferredPharmacies?.map((pharmacy: any) => pharmacy.id) || []
           }
           setFieldValue={setFieldValue}
+          handleChangeBtnClick={handleChangeBtnClick}
         />
       )
+    },
+    {
+      name: 'Send to Patient',
+      fulfillmentType: undefined,
+      isDisabled: onlyCurexa,
+      comp: <SendToPatient patient={patient} />
     },
     {
       name: 'Mail Order',
@@ -104,23 +115,12 @@ export const SelectPharmacyCard: React.FC<SelectPharmacyCardProps> = ({
           touched={touched}
         />
       )
-    },
-    {
-      name: 'Send to Patient',
-      fulfillmentType: undefined,
-      isDisabled: onlyCurexa,
-      comp: <SendToPatient patient={patient} />
     }
   ];
 
   const handleTabChange = (index: number) => {
     setFieldValue('fulfillmentType', tabsList[index].fulfillmentType);
     setSelectedTab(index);
-  };
-
-  const handleChangeBtnClick = () => {
-    setFieldValue('pharmacyId', '');
-    setUpdatePreferredPharmacy(false);
   };
 
   useEffect(() => {
@@ -155,54 +155,28 @@ export const SelectPharmacyCard: React.FC<SelectPharmacyCardProps> = ({
     }
   }, [address]);
 
-  const isPreferred =
-    pharmacyId && patient?.preferredPharmacies?.some(({ id }: { id: string }) => id === pharmacyId);
-
   return (
     <Card bg="bg-surface">
       <LocationSearch isOpen={isOpen} onClose={handleModalClose} />
       <CardHeader>
         <HStack w="full" justify="space-between">
-          <Heading size="xxs">{pharmacyId ? 'Pharmacy' : 'Select a Pharmacy Option'}</Heading>
-          {pharmacyId ? (
-            <Button onClick={handleChangeBtnClick} size="xs">
-              Change
-            </Button>
-          ) : null}
+          <Heading size="xxs">Select a Pharmacy Option</Heading>
         </HStack>
       </CardHeader>
-      {pharmacyId ? (
-        <CardBody pt={0}>
-          <Pharmacy pharmacyId={pharmacyId} isPreferred={isPreferred} />
-          {isPreferred ? null : (
-            <Checkbox
-              pt={2}
-              isChecked={updatePreferredPharmacy}
-              onChange={(e) => setUpdatePreferredPharmacy(e.target.checked)}
-            >
-              Save as Patient's Preferred Pharmacy{' '}
-              <Text as="span" fontSize="xs" color="gray.400">
-                Optional
-              </Text>
-            </Checkbox>
-          )}
-        </CardBody>
-      ) : (
-        <Tabs index={selectedTab} onChange={handleTabChange} variant="enclosed">
-          <TabList px={5}>
-            {tabsList.map(({ isDisabled, name }) => (
-              <Tab key={`${name}-tab`} p={3} whiteSpace="nowrap" isDisabled={isDisabled}>
-                {name}
-              </Tab>
-            ))}
-          </TabList>
-          <TabPanels p={1}>
-            {tabsList.map(({ comp, name }) => (
-              <TabPanel key={`${name}-panel`}>{comp}</TabPanel>
-            ))}
-          </TabPanels>
-        </Tabs>
-      )}
+      <Tabs index={selectedTab} onChange={handleTabChange} variant="enclosed">
+        <TabList px={5}>
+          {tabsList.map(({ isDisabled, name }) => (
+            <Tab key={`${name}-tab`} p={3} whiteSpace="nowrap" isDisabled={isDisabled}>
+              {name}
+            </Tab>
+          ))}
+        </TabList>
+        <TabPanels p={1}>
+          {tabsList.map(({ comp, name }) => (
+            <TabPanel key={`${name}-panel`}>{comp}</TabPanel>
+          ))}
+        </TabPanels>
+      </Tabs>
     </Card>
   );
 };

--- a/apps/app/src/views/routes/NewOrder/components/SelectPharmacyCard/index.tsx
+++ b/apps/app/src/views/routes/NewOrder/components/SelectPharmacyCard/index.tsx
@@ -163,7 +163,7 @@ export const SelectPharmacyCard: React.FC<SelectPharmacyCardProps> = ({
       <LocationSearch isOpen={isOpen} onClose={handleModalClose} />
       <CardHeader>
         <HStack w="full" justify="space-between">
-          <Heading size="xxs">{pharmacyId ? 'Pharmacy' : 'Select a Pharmacy'}</Heading>
+          <Heading size="xxs">{pharmacyId ? 'Pharmacy' : 'Select a Pharmacy Option'}</Heading>
           {pharmacyId ? (
             <Button onClick={handleChangeBtnClick} size="xs">
               Change

--- a/apps/app/src/views/routes/NewOrder/components/SelectPharmacyCard/index.tsx
+++ b/apps/app/src/views/routes/NewOrder/components/SelectPharmacyCard/index.tsx
@@ -106,7 +106,7 @@ export const SelectPharmacyCard: React.FC<SelectPharmacyCardProps> = ({
       )
     },
     {
-      name: 'Send to patient',
+      name: 'Send to Patient',
       fulfillmentType: undefined,
       isDisabled: onlyCurexa,
       comp: <SendToPatient patient={patient} />

--- a/apps/app/src/views/routes/NewOrder/components/SelectPrescriptionsCard.tsx
+++ b/apps/app/src/views/routes/NewOrder/components/SelectPrescriptionsCard.tsx
@@ -39,7 +39,7 @@ export const SelectPrescriptionsCard = ({
             <FormErrorMessage>{errors.fills}</FormErrorMessage>
           </FormControl>
         ) : (
-          <Text>Select a patient to view prescriptions.</Text>
+          <Text>Select a patient to view their prescriptions.</Text>
         )}
       </CardBody>
     </Card>

--- a/apps/app/src/views/routes/NewOrder/components/SelectPrescriptionsCard.tsx
+++ b/apps/app/src/views/routes/NewOrder/components/SelectPrescriptionsCard.tsx
@@ -4,7 +4,8 @@ import {
   CardHeader,
   FormControl,
   FormErrorMessage,
-  Heading
+  Heading,
+  Text
 } from '@chakra-ui/react';
 
 import { FillsSelect } from '../../../components/FillsSelect';
@@ -28,14 +29,18 @@ export const SelectPrescriptionsCard = ({
         <Heading size="xxs">Select Prescriptions</Heading>
       </CardHeader>
       <CardBody pt={0}>
-        <FormControl isInvalid={!!errors.fills && touched.fills}>
-          <FillsSelect
-            name="fills"
-            patientId={patientId}
-            initialFills={prescriptionIds || undefined}
-          />
-          <FormErrorMessage>{errors.fills}</FormErrorMessage>
-        </FormControl>
+        {patientId ? (
+          <FormControl isInvalid={!!errors.fills && touched.fills}>
+            <FillsSelect
+              name="fills"
+              patientId={patientId}
+              initialFills={prescriptionIds || undefined}
+            />
+            <FormErrorMessage>{errors.fills}</FormErrorMessage>
+          </FormControl>
+        ) : (
+          <Text>Select a patient to view prescriptions.</Text>
+        )}
       </CardBody>
     </Card>
   );


### PR DESCRIPTION
A collection of small UI tweaks that mostly fell out of the pharmacy selection meeting today:

- show tabs all the time
- re-order tabs
- a bunch of small copy changes
- show previous tag on selected pharmacy
- align tag styling with dropdown options