### PR TITLE
Fix order not sending to patient

### DIFF
--- a/apps/app/src/views/routes/NewOrder/components/SelectPharmacyCard/components/LocalPickup.tsx
+++ b/apps/app/src/views/routes/NewOrder/components/SelectPharmacyCard/components/LocalPickup.tsx
@@ -68,7 +68,7 @@ interface LocalPickupProps {
   setUpdatePreferredPharmacy: any;
   preferredPharmacyIds: string[];
   setFieldValue: (field: string, value: string) => void;
-  handleChangeBtnClick: any;
+  resetSelection: any;
 }
 
 export const LocalPickup = (props: LocalPickupProps) => {
@@ -85,7 +85,7 @@ export const LocalPickup = (props: LocalPickupProps) => {
     setUpdatePreferredPharmacy,
     setFieldValue,
     preferredPharmacyIds,
-    handleChangeBtnClick
+    resetSelection
   } = props;
   const [params] = useSearchParams();
   const { getPharmacies, getOrders } = usePhoton();
@@ -145,7 +145,7 @@ export const LocalPickup = (props: LocalPickupProps) => {
           pharmacyId={pharmacyId}
           isPreferred={isPreferred}
           isPrevious={isPrevious}
-          handleChangeBtnClick={handleChangeBtnClick}
+          resetSelection={resetSelection}
         />
         {isPreferred ? null : (
           <Checkbox

--- a/apps/app/src/views/routes/NewOrder/components/SelectPharmacyCard/components/Pharmacy.tsx
+++ b/apps/app/src/views/routes/NewOrder/components/SelectPharmacyCard/components/Pharmacy.tsx
@@ -22,7 +22,7 @@ interface PharmacyProps {
   isPreferred?: boolean;
   isPrevious?: boolean;
   showTags?: boolean;
-  handleChangeBtnClick?: any;
+  resetSelection?: any;
 }
 
 export const Pharmacy = ({
@@ -30,7 +30,7 @@ export const Pharmacy = ({
   isPreferred,
   isPrevious,
   showTags,
-  handleChangeBtnClick
+  resetSelection
 }: PharmacyProps) => {
   const { getPharmacy } = usePhoton();
   const { refetch, loading } = getPharmacy({ id: '' });
@@ -99,8 +99,8 @@ export const Pharmacy = ({
         </VStack>
         <Spacer />
         <Box>
-          {handleChangeBtnClick ? (
-            <Button onClick={() => handleChangeBtnClick()} size="xs" ms="auto">
+          {resetSelection ? (
+            <Button onClick={() => resetSelection()} size="xs" ms="auto">
               Change
             </Button>
           ) : null}

--- a/apps/app/src/views/routes/NewOrder/components/SelectPharmacyCard/index.tsx
+++ b/apps/app/src/views/routes/NewOrder/components/SelectPharmacyCard/index.tsx
@@ -67,7 +67,7 @@ export const SelectPharmacyCard: React.FC<SelectPharmacyCardProps> = ({
     onClose();
   };
 
-  const handleChangeBtnClick = () => {
+  const resetSelection = () => {
     setFieldValue('pharmacyId', '');
     setUpdatePreferredPharmacy(false);
   };
@@ -93,7 +93,7 @@ export const SelectPharmacyCard: React.FC<SelectPharmacyCardProps> = ({
             patient?.preferredPharmacies?.map((pharmacy: any) => pharmacy.id) || []
           }
           setFieldValue={setFieldValue}
-          handleChangeBtnClick={handleChangeBtnClick}
+          resetSelection={resetSelection}
         />
       )
     },
@@ -119,6 +119,7 @@ export const SelectPharmacyCard: React.FC<SelectPharmacyCardProps> = ({
   ];
 
   const handleTabChange = (index: number) => {
+    resetSelection();
     setFieldValue('fulfillmentType', tabsList[index].fulfillmentType);
     setSelectedTab(index);
   };

--- a/apps/app/src/views/routes/Order.tsx
+++ b/apps/app/src/views/routes/Order.tsx
@@ -27,7 +27,7 @@ import {
 
 import { usePhoton, types } from '@photonhealth/react';
 
-import { FiArrowUpRight, FiCheck, FiClock, FiCopy, FiX } from 'react-icons/fi';
+import { FiArrowUpRight, FiCheck, FiClock, FiCopy, FiCornerUpRight, FiX } from 'react-icons/fi';
 import { Page } from '../components/Page';
 import PatientView from '../components/PatientView';
 
@@ -42,12 +42,14 @@ const ORDER_FULFILLMENT_TYPE_MAP = {
 
 const ORDER_STATE_MAP: object = {
   PLACED: 'Placed',
+  ROUTING: 'Routing',
   PENDING: 'Pending',
   CANCELED: 'Canceled',
   COMPLETED: 'Completed'
 };
 const ORDER_STATE_ICON_MAP: any = {
   PLACED: FiArrowUpRight,
+  ROUTING: FiCornerUpRight,
   PENDING: FiClock,
   CANCELED: FiX,
   COMPLETED: FiCheck
@@ -84,6 +86,8 @@ export const Order = () => {
 
   const isMobile = useBreakpointValue({ base: true, sm: false });
   const tableWidth = useBreakpointValue({ base: 'full', sm: '100%', md: '75%' });
+
+  console.log(order.state);
 
   return (
     <Page kicker="Order" header={order ? formatFills(order.fills) : ''} loading={loading}>

--- a/apps/app/src/views/routes/Order.tsx
+++ b/apps/app/src/views/routes/Order.tsx
@@ -87,8 +87,6 @@ export const Order = () => {
   const isMobile = useBreakpointValue({ base: true, sm: false });
   const tableWidth = useBreakpointValue({ base: 'full', sm: '100%', md: '75%' });
 
-  console.log(order.state);
-
   return (
     <Page kicker="Order" header={order ? formatFills(order.fills) : ''} loading={loading}>
       <VStack spacing={4} fontSize={{ base: 'md', md: 'lg' }} alignItems="start" w="100%" mt={0}>


### PR DESCRIPTION
I missed this while moving around the pharmacy selection component. I just need to reset pharmacy selection when the tab changes so that it doesn't submit with the pharmacyId even on send to patient.