### PR TITLE
Try getAccessToken

### DIFF
--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@photonhealth/elements",
-  "version": "0.0.88",
+  "version": "0.0.89",
   "description": "",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/elements/src/store.ts
+++ b/packages/elements/src/store.ts
@@ -12,6 +12,7 @@ import {
 import gql from 'graphql-tag';
 import { GraphQLError } from 'graphql';
 import jwtDecode from 'jwt-decode';
+import { Permission } from '../types';
 
 const defaultOnRedirectCallback = (appState?: any): void => {
   window.location.replace(appState?.returnTo || window.location.pathname);

--- a/packages/elements/src/store.ts
+++ b/packages/elements/src/store.ts
@@ -269,8 +269,14 @@ export class PhotonClientStore {
     const user = await this.sdk.authentication.getUser();
     const hasOrgs = !!this.sdk?.organization && !!user?.org_id;
 
-    const token = await this.sdk.authentication.getAccessToken();
-    const { permissions }: { permissions: Permission[] } = jwtDecode(token);
+    let permissions: Permission[];
+    try {
+      const token = await this.sdk.authentication.getAccessToken();
+      const decoded: { permissions: Permission[] } = jwtDecode(token);
+      permissions = decoded.permissions;
+    } catch (err) {
+      permissions = [];
+    }
 
     this.setStore('authentication', {
       ...this.store.authentication,

--- a/packages/elements/src/store.ts
+++ b/packages/elements/src/store.ts
@@ -274,7 +274,7 @@ export class PhotonClientStore {
     try {
       const token = await this.sdk.authentication.getAccessToken();
       const decoded: { permissions: Permission[] } = jwtDecode(token);
-      permissions = decoded.permissions;
+      permissions = decoded?.permissions || [];
     } catch (err) {
       permissions = [];
     }


### PR DESCRIPTION
Weekend was getting a bump in "login required" errors after upgrading to elements [0.0.87](https://github.com/Photon-Health/client/releases/tag/%40photonhealth%2Felements_v0.0.87) permissions check.

The reason is we needed to wrap `await this.sdk.authentication.getAccessToken();` in a try catch in `checkSessions`.

![image](https://user-images.githubusercontent.com/700617/222515489-5ad9c47e-6548-46c4-acaf-4b52a0b3ce95.png)
