### PR TITLE
Fix Mobile buttons

### DIFF
--- a/packages/elements/index.html
+++ b/packages/elements/index.html
@@ -31,7 +31,7 @@
       </photon-dialog> -->
 
       <!-- This is what is implemented in boson  without the hide-templates flag-->
-      <!-- <photon-multirx-form-wrapper hide-templates="false"/> -->
+      <photon-multirx-form-wrapper hide-templates="false" />
 
       <!-- To test the prescribe component only run this - idk who uses this but template creation doesnt work here so the add to templates option is hidden by default -->
       <!-- <photon-prescribe-workflow
@@ -39,10 +39,10 @@
           template-ids="tmp_01GHEYTMGWZZV3TDMYWR2ZW0ZB,tmp_01GHEYV0YCZVJW34253HKMY042"
         ></photon-prescribe-workflow> -->
 
-      <photon-patient-dialog
+      <!-- <photon-patient-dialog
         open="true"
         patient-id="pat_01G8VFW0X44YCW8KW7FW3FC0ZT"
-      ></photon-patient-dialog>
+      ></photon-patient-dialog> -->
     </photon-client>
   </body>
   <script>

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@photonhealth/elements",
-  "version": "0.0.90",
+  "version": "0.0.89",
   "description": "",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@photonhealth/elements",
-  "version": "0.0.89",
+  "version": "0.0.90",
   "description": "",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/elements/src/photon-button/index.tsx
+++ b/packages/elements/src/photon-button/index.tsx
@@ -61,14 +61,9 @@ customElement(
             'xs:w-fit': true,
             'w-full': true || props.full
           }}
-          class="rounded-lg font-sans transition ease-in-out delay-50 flex items-center gap-2"
+          class="rounded-lg font-sans transition ease-in-out delay-50 flex items-center gap-1 lg:gap-2"
         >
           <slot name="suffix"></slot>
-          {!props.loading ? (
-            <p class="w-full">
-              <slot></slot>
-            </p>
-          ) : null}
           {props.loading ? (
             <div class="pt-[3px]">
               <sl-spinner
@@ -80,7 +75,10 @@ customElement(
               ></sl-spinner>
             </div>
           ) : null}
-          {props.loading && props.loadingText ? <p class="w-full">{props.loadingText}</p> : null}
+
+          <p class="w-full">
+            <slot></slot>
+          </p>
           <slot name="postfix"></slot>
         </button>
       </>

--- a/packages/elements/src/photon-checkbox/index.tsx
+++ b/packages/elements/src/photon-checkbox/index.tsx
@@ -79,15 +79,17 @@ customElement(
               }}
             ></sl-checkbox>
           )}
-          <p class="text-gray-500 text-sm font-medium font-sans">
-            {props.label}
-            <Show when={props.tip}>
-              <PhotonTooltip tip={props.tip || ''} placement="right"></PhotonTooltip>
-            </Show>
-          </p>
-          <p class="text-gray-400 text-xs pt-1 pl-2 font-sans">
-            {props.required ? 'Required' : 'Optional'}
-          </p>
+          <div>
+            <p class="text-gray-500 text-sm font-medium font-sans">
+              {props.label}
+              <Show when={props.tip}>
+                <PhotonTooltip tip={props.tip || ''} placement="right"></PhotonTooltip>
+              </Show>
+            </p>
+            <p class="text-gray-400 text-xs font-sans">
+              {props.required ? 'Required' : 'Optional'}
+            </p>
+          </div>
         </div>
       </>
     );

--- a/packages/elements/src/photon-form-wrapper/index.tsx
+++ b/packages/elements/src/photon-form-wrapper/index.tsx
@@ -48,9 +48,11 @@ const PhotonFormWrapper = ({
 
       {/* Wrapper */}
       <div class="flex items-center px-4 py-2 md:px-8 md:py-3 bg-white fixed w-full z-10 shadow-card">
-        <div class="md:w-1/3 flex justify-start">
+        <div class="md:w-2/5 flex justify-start">
           <photon-button
             class="close-button"
+            size="small"
+            circle
             on:click={() => {
               if (checkShouldWarn()) {
                 setCloseDialogOpen(true);
@@ -65,8 +67,8 @@ const PhotonFormWrapper = ({
             </div>
           </photon-button>
         </div>
-        <div class="w-full md:w-2/3 flex flex-col md:flex-row">
-          <div class="mb-2 md:mb-0 flex-1 flex justify-end md:justify-center items-center">
+        <div class="w-full md:w-3/5 flex flex-col md:flex-row">
+          <div class="mb-2 md:mb-0 flex justify-end md:justify-center items-center">
             <Show when={titleIconName}>
               <sl-icon name={titleIconName} />
             </Show>

--- a/packages/elements/src/photon-form-wrapper/index.tsx
+++ b/packages/elements/src/photon-form-wrapper/index.tsx
@@ -68,7 +68,7 @@ const PhotonFormWrapper = ({
           </photon-button>
         </div>
         <div class="w-full md:w-3/5 flex flex-col md:flex-row">
-          <div class="mb-2 md:mb-0 flex justify-end md:justify-center items-center">
+          <div class="mb-2 md:mb-0 flex justify-center md:justify-center items-center">
             <Show when={titleIconName}>
               <sl-icon name={titleIconName} />
             </Show>

--- a/packages/elements/src/photon-form-wrapper/index.tsx
+++ b/packages/elements/src/photon-form-wrapper/index.tsx
@@ -79,7 +79,7 @@ const PhotonFormWrapper = ({
           </Show>
         </div>
       </div>
-      <div class="w-full h-full bg-[#f7f4f4] pt-28 xs:pt-28 lg:pt-20">
+      <div class="w-full min-h-screen bg-[#f7f4f4] pt-28 xs:pt-28 lg:pt-20">
         <div class="pt-4 pb-52 px-4 w-full h-full sm:w-[600px] xs:mx-auto">{form}</div>
       </div>
     </div>

--- a/packages/elements/src/photon-multirx-form-wrapper/index.tsx
+++ b/packages/elements/src/photon-multirx-form-wrapper/index.tsx
@@ -195,7 +195,7 @@ customElement(
           title="New Prescriptions"
           titleIconName="prescription"
           headerRight={
-            <div class="flex flex-row sm:flex-col md:flex-col lg:flex-row gap-2 justify-end items-end">
+            <div class="flex flex-row gap-1 lg:gap-2 justify-end items-end">
               <photon-button
                 size="sm"
                 variant="outline"
@@ -204,7 +204,7 @@ customElement(
                 loading={isLoading()}
                 on:photon-clicked={() => submitForm(form(), actions(), false)}
               >
-                Save prescriptions
+                <span className="text-xs lg:text-sm">Save prescriptions</span>
               </photon-button>
               <photon-button
                 size="sm"
@@ -215,7 +215,7 @@ customElement(
                   form()?.treatment?.value?.name ? setContinueSubmitOpen(true) : handleSubmit()
                 }
               >
-                Save and create order
+                <span className="text-xs lg:text-sm">Save and create order</span>
               </photon-button>
             </div>
           }

--- a/packages/elements/src/photon-multirx-form-wrapper/index.tsx
+++ b/packages/elements/src/photon-multirx-form-wrapper/index.tsx
@@ -199,23 +199,21 @@ customElement(
               <photon-button
                 size="sm"
                 variant="outline"
-                loading-text="Save prescriptions"
                 disabled={!canSubmit() || !canWritePrescription()}
                 loading={isLoading()}
                 on:photon-clicked={() => submitForm(form(), actions(), false)}
               >
-                <span className="text-xs lg:text-sm">Save prescriptions</span>
+                <span class="text-xs lg:text-sm">Save prescriptions</span>
               </photon-button>
               <photon-button
                 size="sm"
-                loading-text="Save and create order"
                 disabled={!canSubmit() || !canWritePrescription()}
                 loading={isLoading()}
                 on:photon-clicked={() =>
                   form()?.treatment?.value?.name ? setContinueSubmitOpen(true) : handleSubmit()
                 }
               >
-                <span className="text-xs lg:text-sm">Save and create order</span>
+                <span class="text-xs lg:text-sm">Save and create order</span>
               </photon-button>
             </div>
           }

--- a/packages/elements/src/photon-multirx-form/components/AddPrescriptionCard.tsx
+++ b/packages/elements/src/photon-multirx-form/components/AddPrescriptionCard.tsx
@@ -157,7 +157,7 @@ export const AddPrescriptionCard = (props: {
             ></photon-checkbox>
             <photon-med-search-dialog ref={medSearchRef}></photon-med-search-dialog>
           </div>
-          <div class="py-4 md:py-2">
+          <div class="py-4 md:py-2 text-right">
             <a
               class="font-sans text-gray-500 text-sm hover:text-black hover:cursor-pointer"
               onClick={() => (medSearchRef.open = true)}

--- a/packages/elements/src/photon-multirx-form/components/AddPrescriptionCard.tsx
+++ b/packages/elements/src/photon-multirx-form/components/AddPrescriptionCard.tsx
@@ -157,7 +157,7 @@ export const AddPrescriptionCard = (props: {
             ></photon-checkbox>
             <photon-med-search-dialog ref={medSearchRef}></photon-med-search-dialog>
           </div>
-          <div class="py-4 md:py-2 text-right">
+          <div class="py-4 md:py-2 text-left sm:text-right">
             <a
               class="font-sans text-gray-500 text-sm hover:text-black hover:cursor-pointer"
               onClick={() => (medSearchRef.open = true)}

--- a/packages/elements/src/photon-patient-dialog/index.tsx
+++ b/packages/elements/src/photon-patient-dialog/index.tsx
@@ -174,7 +174,7 @@ customElement(
             title={props?.patientId ? 'Update Patient' : 'Create Patient'}
             titleIconName={props?.patientId ? 'pencil-square' : 'person-plus'}
             headerRight={
-              <div class="flex space-x-2">
+              <div class="flex flex-row gap-1 lg:gap-2 justify-end items-end">
                 <photon-button
                   size="sm"
                   variant="outline"
@@ -182,7 +182,7 @@ customElement(
                   loading={loading()}
                   onClick={() => submitForm(formStore(), actions(), selectedStore(), true)}
                 >
-                  Save and Create Prescription
+                  <span class="text-xs lg:text-sm">Save and Create Prescription</span>
                 </photon-button>
                 <photon-button
                   size="sm"
@@ -190,7 +190,7 @@ customElement(
                   loading={loading()}
                   onClick={() => submitForm(formStore(), actions(), selectedStore(), false)}
                 >
-                  Save
+                  <span class="text-xs lg:text-sm">Save</span>
                 </photon-button>
               </div>
             }


### PR DESCRIPTION
- Fix button widths for mobile
min width 338
<img width="313" alt="Screen Shot 2023-03-03 at 2 53 34 PM" src="https://user-images.githubusercontent.com/700617/222813943-9499d646-6aee-4f77-9594-4856f7a5d284.png">

regular desktop
<img width="1332" alt="Screen Shot 2023-03-03 at 2 54 22 PM" src="https://user-images.githubusercontent.com/700617/222814083-c0b14950-7d7a-4c7c-afcf-823279490601.png">

ref https://www.notion.so/photons/Improve-layouts-for-mobile-layouts-40b89c1556c843a4b7fb91c00e003d51?pvs=4

- no empty spinner button 
![image](https://user-images.githubusercontent.com/700617/222961741-4494426b-1ec6-47ad-9fef-ed38dab06ab1.png)
should be 
![image](https://user-images.githubusercontent.com/700617/222961747-ca5f17cb-9738-4129-b55a-a2cb7fd7c1e1.png)

- fix form wrapper not being min height 100vh

- fix layout of dispense as written optional breaking on small modals and advanced search right aligned
<img width="548" alt="Screen Shot 2023-03-05 at 7 58 57 AM" src="https://user-images.githubusercontent.com/700617/222961810-152e8bb0-e9a8-4da4-99a8-78cfe44399c4.png">
