### PR TITLE
Make sure "at" exists

### DIFF
--- a/packages/elements/src/photon-dropdown/index.tsx
+++ b/packages/elements/src/photon-dropdown/index.tsx
@@ -89,7 +89,7 @@ export const PhotonDropdown = <T extends { id: string }>(props: {
   }, 250);
 
   const observer = new IntersectionObserver(async (a) => {
-    if (a.at(-1)?.isIntersecting && props.hasMore) {
+    if (a?.at(-1)?.isIntersecting && props.hasMore) {
       if (props.fetchMore) {
         await props.fetchMore(search());
       }

--- a/packages/elements/src/stores/patient.ts
+++ b/packages/elements/src/stores/patient.ts
@@ -125,7 +125,7 @@ const createPatientStore = () => {
       ? () =>
           fetchMorePatients(client, {
             ...args,
-            after: data.patients.at(-1)!.id
+            after: data.patients?.at(-1)!.id
           })
       : undefined;
   };
@@ -154,7 +154,7 @@ const createPatientStore = () => {
       ? () =>
           fetchMorePatients(client, {
             ...args,
-            after: data.patients.at(-1)!.id
+            after: data.patients?.at(-1)!.id
           })
       : undefined;
   };


### PR DESCRIPTION
If `r.at(-1)` isn't a function, we should check it:

```
a?.at(-1)?.isIntersecting && props.hasMore
```

![image](https://user-images.githubusercontent.com/700617/223451140-dc051be6-3b41-46d3-bd63-9083289bb621.png)

task ref https://www.notion.so/photons/Request-Error-r-at-1-for-Weekend-6ccd91e3c55d481c844f0b0182aaa743?pvs=4