### PR TITLE
Prescriptions Status Filter

### DIFF
--- a/apps/app/src/views/components/TablePage.tsx
+++ b/apps/app/src/views/components/TablePage.tsx
@@ -150,7 +150,7 @@ export const TablePage = (props: TablePageProps) => {
             <Stack direction={{ base: 'column', md: 'row' }}>
               <>
                 {filter ? filter : null}
-                <InputGroup maxW={{ base: '100%', md: 'xs' }}>
+                <InputGroup maxW={{ base: '100%', md: 'xs' }} minWidth={300}>
                   <InputLeftElement pointerEvents="none">
                     <Icon as={FiSearch} color="muted" boxSize="5" />
                   </InputLeftElement>

--- a/apps/app/src/views/components/TablePage.tsx
+++ b/apps/app/src/views/components/TablePage.tsx
@@ -46,6 +46,7 @@ interface TablePageProps {
   ctaColor?: string;
   ctaRoute?: string;
   ctaOnClick?: () => void;
+  filter?: Element | ReactElement;
   paginationIndicator?: Element | ReactElement;
   paginationActions?: Element | ReactElement;
   total?: number;
@@ -68,6 +69,7 @@ export const TablePage = (props: TablePageProps) => {
     ctaColor,
     ctaRoute,
     ctaOnClick,
+    filter,
     paginationIndicator,
     paginationActions,
     total,
@@ -145,17 +147,22 @@ export const TablePage = (props: TablePageProps) => {
                 {ctaText}
               </Button>
             )}
-            <InputGroup maxW={{ base: '100%', md: 'xs' }}>
-              <InputLeftElement pointerEvents="none">
-                <Icon as={FiSearch} color="muted" boxSize="5" />
-              </InputLeftElement>
-              <Input
-                type="text"
-                placeholder={searchPlaceholder}
-                onChange={handleInputChange}
-                value={filterText}
-              />
-            </InputGroup>
+            <Stack direction={{ base: 'column', md: 'row' }}>
+              <>
+                {filter ? filter : null}
+                <InputGroup maxW={{ base: '100%', md: 'xs' }}>
+                  <InputLeftElement pointerEvents="none">
+                    <Icon as={FiSearch} color="muted" boxSize="5" />
+                  </InputLeftElement>
+                  <Input
+                    type="text"
+                    placeholder={searchPlaceholder}
+                    onChange={handleInputChange}
+                    value={filterText}
+                  />
+                </InputGroup>
+              </>
+            </Stack>
           </Stack>
         </Box>
         <Box overflowX="auto">

--- a/apps/app/src/views/routes/Prescriptions.tsx
+++ b/apps/app/src/views/routes/Prescriptions.tsx
@@ -233,6 +233,7 @@ export const Prescriptions = () => {
         searchPlaceholder="Search by patient name"
         filter={
           <Select
+            flexShrink={2}
             placeholder="No Filter"
             onChange={(e) => setStatus((e.target.value as types.PrescriptionState) || undefined)}
           >

--- a/apps/app/src/views/routes/Prescriptions.tsx
+++ b/apps/app/src/views/routes/Prescriptions.tsx
@@ -265,7 +265,6 @@ export const Prescriptions = () => {
         searchPlaceholder="Search by patient name"
         filter={
           <Select
-            flexShrink={2}
             placeholder="No Filter"
             onChange={(e) => setStatus((e.target.value as types.PrescriptionState) || undefined)}
             value={status}

--- a/apps/app/src/views/routes/Prescriptions.tsx
+++ b/apps/app/src/views/routes/Prescriptions.tsx
@@ -213,12 +213,14 @@ export const Prescriptions = () => {
   const [finished, setFinished] = useState<boolean>(false);
   const [filterTextDebounce] = useDebounce(filterText, 250);
 
-  const { prescriptions, loading, error, refetch } = getPrescriptions({
-    patientId,
-    prescriberId,
+  const getPrescriptionsData = {
+    patientId: patientId || undefined,
+    prescriberId: prescriberId || undefined,
     state: status,
-    patientName: filterTextDebounce.length > 0 ? filterTextDebounce : null
-  });
+    patientName: filterTextDebounce.length > 0 ? filterTextDebounce : undefined
+  };
+
+  const { prescriptions, loading, error, refetch } = getPrescriptions(getPrescriptionsData);
 
   useEffect(() => {
     if (!loading) {
@@ -235,12 +237,7 @@ export const Prescriptions = () => {
     async function refetchData() {
       setRows([]);
       setFilterChangeLoading(true);
-      const { data } = await refetch({
-        patientId: patientId || undefined,
-        prescriberId: prescriberId || undefined,
-        patientName: filterTextDebounce.length > 0 ? filterTextDebounce : undefined,
-        state: status
-      });
+      const { data } = await refetch(getPrescriptionsData);
       setFilterChangeLoading(false);
       if (data?.prescriptions.length === 0) {
         setFinished(true);
@@ -280,10 +277,7 @@ export const Prescriptions = () => {
         }
         fetchMoreData={async () => {
           const { data } = await refetch({
-            patientId: patientId || undefined,
-            prescriberId: prescriberId || undefined,
-            patientName: filterTextDebounce.length > 0 ? filterTextDebounce : undefined,
-            state: status,
+            ...getPrescriptionsData,
             after: rows?.at(-1)?.id
           });
           if (data?.prescriptions.length === 0) {


### PR DESCRIPTION
On the prescriptions page there is now a filter that allows you to select between none, status active, status depleted, status expired. Also it adds a query string for the filter, works or refresh. Looks good on mobile (I think).

📽
https://www.loom.com/share/bd468ad6651d448894a7a41774280a33

task Ref https://www.notion.so/photons/Status-of-the-prescription-Filter-868fbe55da3e438ba4926399be1aab7d?pvs=4

Shout out to @photonsFardad for quick turn around providing the API to filter by prescription state