### PR TITLE
Save Patient's Address on New Order Page

### DIFF
--- a/apps/app/src/views/routes/NewOrder/components/OrderForm.tsx
+++ b/apps/app/src/views/routes/NewOrder/components/OrderForm.tsx
@@ -98,6 +98,7 @@ export const OrderForm = ({
 }: OrderFormProps) => {
   const { colorMode } = useColorMode();
   const [updatePreferredPharmacy, setUpdatePreferredPharmacy] = useState(false);
+  const [updateAddress, setUpdateAddress] = useState(false);
 
   const onCancel = async (dirty: Boolean) => {
     if (!dirty) onClose();
@@ -155,6 +156,16 @@ export const OrderForm = ({
           setSubmitting(true);
           createOrderMutation({ variables: values, onCompleted: onClose });
 
+          // if the user has selected to set the customer's address
+          if (updateAddress) {
+            updatePatientMutation({
+              variables: {
+                id: patient.id,
+                address: { ...values.address }
+              }
+            });
+          }
+
           // if the user has selected to save the pharmacy as their preferred pharmacy
           if (updatePreferredPharmacy) {
             if (patient?.preferredPharmacies?.length > 0) {
@@ -211,6 +222,8 @@ export const OrderForm = ({
                 touched={touched}
                 showAddress={showAddress}
                 setShowAddress={setShowAddress}
+                updateAddress={updateAddress}
+                setUpdateAddress={setUpdateAddress}
               />
 
               <SelectPharmacyCard

--- a/apps/app/src/views/routes/NewOrder/components/PatientAddressCard.tsx
+++ b/apps/app/src/views/routes/NewOrder/components/PatientAddressCard.tsx
@@ -115,9 +115,6 @@ export const PatientAddressCard = ({
               onChange={(e) => setUpdateAddress(e.target.checked)}
             >
               Save as Patient’s Address{' '}
-              <Text as="span" fontSize="xs" color="gray.400">
-                Optional
-              </Text>
             </Checkbox>
           </VStack>
         )}

--- a/apps/app/src/views/routes/NewOrder/components/PatientAddressCard.tsx
+++ b/apps/app/src/views/routes/NewOrder/components/PatientAddressCard.tsx
@@ -3,6 +3,7 @@ import {
   Card,
   CardBody,
   CardHeader,
+  Checkbox,
   FormControl,
   FormErrorMessage,
   FormHelperText,
@@ -29,6 +30,8 @@ interface PatientAddressCardProps {
   loading: boolean;
   showAddress: boolean;
   setShowAddress: any;
+  updateAddress: boolean;
+  setUpdateAddress: (value: boolean) => void;
 }
 
 export const PatientAddressCard = ({
@@ -38,7 +41,9 @@ export const PatientAddressCard = ({
   setFieldValue,
   loading,
   showAddress,
-  setShowAddress
+  setShowAddress,
+  updateAddress,
+  setUpdateAddress
 }: PatientAddressCardProps) => {
   return (
     <Card bg="bg-surface">
@@ -104,6 +109,16 @@ export const PatientAddressCard = ({
                 <FormErrorMessage>{errors.address?.postalCode}</FormErrorMessage>
               </FormControl>
             </HStack>
+            <Checkbox
+              pt={2}
+              isChecked={updateAddress}
+              onChange={(e) => setUpdateAddress(e.target.checked)}
+            >
+              Save as Patient’s Address{' '}
+              <Text as="span" fontSize="xs" color="gray.400">
+                Optional
+              </Text>
+            </Checkbox>
           </VStack>
         )}
       </CardBody>


### PR DESCRIPTION
<img width="539" alt="Screen Shot 2023-03-14 at 1 50 30 PM" src="https://user-images.githubusercontent.com/700617/225094040-e4c0de7e-cb3e-4e7f-8691-0b5b47cd952b.png">

task ref https://www.notion.so/photons/Add-save-to-patient-checkbox-for-address-input-on-create-order-3848b1334ebe492c8fe7334234d0db58?pvs=4