### PR TITLE
Enable send to patient for all MoPed prescribers

### DIFF
--- a/apps/app/src/configs/fulfillment.neutron.ts
+++ b/apps/app/src/configs/fulfillment.neutron.ts
@@ -46,12 +46,8 @@ export const fulfillmentSettings: FulfillmentSettings = {
     pickUp: true,
     mailOrder: false,
     mailOrderProviders: [],
-    sendToPatient: false, // disabled for org
-    sendToPatientUsers: [
-      // enabled for these users
-      'google-oauth2|105026997775584560678', // tim
-      'google-oauth2|102619324588558849301' // rado
-    ]
+    sendToPatient: true, // enable for org
+    sendToPatientUsers: []
   },
   // Peachy
   [process.env.REACT_APP_PEACHY_ORG_ID as string]: {

--- a/apps/app/src/configs/fulfillment.photon.ts
+++ b/apps/app/src/configs/fulfillment.photon.ts
@@ -24,12 +24,8 @@ export const fulfillmentSettings: FulfillmentSettings = {
     pickUp: true,
     mailOrder: false,
     mailOrderProviders: [],
-    sendToPatient: false, // disabled for org
-    sendToPatientUsers: [
-      // enabled for these users
-      'google-oauth2|105026997775584560678', // Tim
-      'google-oauth2|109799643677672225463' // Julie
-    ]
+    sendToPatient: true, // enable for org
+    sendToPatientUsers: []
   },
   // Peachy
   [process.env.REACT_APP_PEACHY_ORG_ID as string]: {


### PR DESCRIPTION
To make the send to patient fulfillment option available to the whole MoPed org