### PR TITLE
SDK: fix NPM publish

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@photonhealth/react",
-  "version": "1.0.10",
-  "main": "./dist/react.cjs.js",
+  "version": "1.0.11",
+  "main": "dist/react.cjs.js",
   "scripts": {
     "build": "rimraf dist && vite build",
     "prepublishOnly": "npm run build"

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@photonhealth/sdk",
-  "version": "1.0.10",
-  "main": "src/lib.js",
+  "version": "1.0.11",
+  "main": "dist/lib.js",
   "scripts": {
     "build": "rimraf dist && vite build",
     "docs": "find src -name \"*.ts\" | xargs npx typedoc --out docs",


### PR DESCRIPTION
NPM installing sdk was not including the dist folder with the expected js file.