### PR TITLE
Prescribe Workflow mobile Layout issues

### DIFF
--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@photonhealth/elements",
-  "version": "0.0.94",
+  "version": "0.0.95",
   "description": "",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/elements/src/photon-card/index.tsx
+++ b/packages/elements/src/photon-card/index.tsx
@@ -17,7 +17,7 @@ customElement(
     let titleElement = null;
     let collapsableElement = null;
     if (props.title) {
-      titleElement = <p class="font-sans text-l font-medium">{props.title}</p>;
+      titleElement = <p class="font-sans text-l font-medium mb-2">{props.title}</p>;
     }
     if (props.collapsable) {
       collapsableElement = (

--- a/packages/elements/src/photon-card/index.tsx
+++ b/packages/elements/src/photon-card/index.tsx
@@ -35,7 +35,7 @@ customElement(
       <>
         <style>{tailwind}</style>
         <div
-          class="rounded-lg bg-white p-3 sm:p-4 shadow-card border border-gray-200"
+          class="rounded-lg bg-white p-4 shadow-card border border-gray-200"
           classList={{
             'border-red-500': props.invalid,
             'border-2': props.invalid

--- a/packages/elements/src/photon-card/index.tsx
+++ b/packages/elements/src/photon-card/index.tsx
@@ -35,7 +35,7 @@ customElement(
       <>
         <style>{tailwind}</style>
         <div
-          class="rounded-lg bg-white p-4 shadow-card border border-gray-200"
+          class="rounded-lg bg-white p-3 sm:p-4 shadow-card border border-gray-200"
           classList={{
             'border-red-500': props.invalid,
             'border-2': props.invalid

--- a/packages/elements/src/photon-checkbox/index.tsx
+++ b/packages/elements/src/photon-checkbox/index.tsx
@@ -58,7 +58,7 @@ customElement(
         <style>{tailwind}</style>
         <style>{shoelaceDarkStyles}</style>
         <style>{shoelaceLightStyles}</style>
-        <div class="flex items-center py-2">
+        <div class="flex items-start py-2">
           {props.checked ? (
             <sl-checkbox
               ref={ref}
@@ -80,8 +80,8 @@ customElement(
             ></sl-checkbox>
           )}
           <div>
-            <p class="text-gray-500 text-sm font-medium font-sans">
-              {props.label}
+            <p class="flex items-center text-gray-500 text-sm font-medium font-sans">
+              <span class="mr-1">{props.label} </span>
               <Show when={props.tip}>
                 <PhotonTooltip tip={props.tip || ''} placement="right"></PhotonTooltip>
               </Show>

--- a/packages/elements/src/photon-dropdown/index.tsx
+++ b/packages/elements/src/photon-dropdown/index.tsx
@@ -170,13 +170,13 @@ export const PhotonDropdown = <T extends { id: string }>(props: {
   });
 
   return (
-    <div ref={ref}>
+    <div ref={ref} class="md:py-2">
       <style>{tailwind}</style>
       <style>{shoelaceDarkStyles}</style>
       <style>{shoelaceLightStyles}</style>
       <style>{styles}</style>
       {props.label ? (
-        <div class="flex items-center pt-2 pb-2">
+        <div class="flex items-center pb-2">
           <p class="text-gray-700 text-sm font-sans">{props.label}</p>
           {props.required ? <p class="pl-1 text-red-500">*</p> : null}
           {props.optional ? <p class="text-gray-400 text-xs pl-2 font-sans">Optional</p> : null}

--- a/packages/elements/src/photon-dropdown/index.tsx
+++ b/packages/elements/src/photon-dropdown/index.tsx
@@ -239,7 +239,7 @@ export const PhotonDropdown = <T extends { id: string }>(props: {
             slot="help-text"
             class="text-red-500 pt-2 font-sans"
             classList={{
-              'h-[28px]': props.forceLabelSize
+              'h-[21px]': props.forceLabelSize
             }}
           >
             {showHelpText(props.invalid ?? false)}

--- a/packages/elements/src/photon-form-wrapper/index.tsx
+++ b/packages/elements/src/photon-form-wrapper/index.tsx
@@ -80,7 +80,7 @@ const PhotonFormWrapper = ({
         </div>
       </div>
       <div class="w-full min-h-screen bg-[#f7f4f4] pt-28 xs:pt-28 lg:pt-20">
-        <div class="pb-10 md:pt-4 md:pb-52 md:px-4 w-full h-full sm:w-[600px] xs:mx-auto">
+        <div class="px-4 pb-10 md:pt-4 md:pb-52 md:px-4 w-full h-full sm:w-[600px] xs:mx-auto">
           {form}
         </div>
       </div>

--- a/packages/elements/src/photon-form-wrapper/index.tsx
+++ b/packages/elements/src/photon-form-wrapper/index.tsx
@@ -80,7 +80,9 @@ const PhotonFormWrapper = ({
         </div>
       </div>
       <div class="w-full min-h-screen bg-[#f7f4f4] pt-28 xs:pt-28 lg:pt-20">
-        <div class="pt-4 pb-52 px-4 w-full h-full sm:w-[600px] xs:mx-auto">{form}</div>
+        <div class="pb-10 md:pt-4 md:pb-52 md:px-4 w-full h-full sm:w-[600px] xs:mx-auto">
+          {form}
+        </div>
       </div>
     </div>
   );

--- a/packages/elements/src/photon-multirx-form-wrapper/index.tsx
+++ b/packages/elements/src/photon-multirx-form-wrapper/index.tsx
@@ -264,7 +264,7 @@ customElement(
                   )}
                 </For>
               </Show>
-              <div class="p-4 w-full h-full sm:w-[600px] xs:mx-auto">
+              <div class="px-3 md:p-4 w-full h-full sm:w-[600px] xs:mx-auto">
                 <photon-prescribe-workflow
                   hide-submit="true"
                   hide-templates={props.hideTemplates}

--- a/packages/elements/src/photon-multirx-form-wrapper/index.tsx
+++ b/packages/elements/src/photon-multirx-form-wrapper/index.tsx
@@ -264,7 +264,7 @@ customElement(
                   )}
                 </For>
               </Show>
-              <div class="px-3 md:p-4 w-full h-full sm:w-[600px] xs:mx-auto">
+              <div class="w-full h-full sm:w-[600px] xs:mx-auto">
                 <photon-prescribe-workflow
                   hide-submit="true"
                   hide-templates={props.hideTemplates}

--- a/packages/elements/src/photon-multirx-form/components/AddPrescriptionCard.tsx
+++ b/packages/elements/src/photon-multirx-form/components/AddPrescriptionCard.tsx
@@ -64,7 +64,7 @@ export const AddPrescriptionCard = (props: {
   return (
     <photon-card ref={ref} title={'Add Prescription'}>
       <div
-        class="flex flex-col gap-2 sm:gap-3"
+        class="flex flex-col sm:gap-3"
         on:photon-medication-selected={(e: any) => {
           setOffCatalog(e.detail.medication);
           props.actions.updateFormValue({
@@ -94,7 +94,7 @@ export const AddPrescriptionCard = (props: {
             });
           }}
         ></photon-treatment-select>
-        <div class="flex flex-col sm:flex-none	sm:grid sm:grid-cols-2 sm:gap-4">
+        <div class="flex flex-col sm:flex-none sm:grid sm:grid-cols-2 sm:gap-4">
           <div class="order-last sm:order-first">
             <photon-checkbox
               label="Dispense as written"
@@ -120,7 +120,7 @@ export const AddPrescriptionCard = (props: {
             </a>
           </div>
         </div>
-        <div class="md:max-w-[50%] md:pr-2">
+        <div class="mt-2 sm:mt-0 md:max-w-[50%] md:pr-2">
           <photon-datepicker
             label="Effective Date"
             invalid={props.store['effectiveDate']?.error ?? false}
@@ -134,7 +134,7 @@ export const AddPrescriptionCard = (props: {
             }
           ></photon-datepicker>
         </div>
-        <div class="sm:grid sm:grid-cols-2 sm:gap-4">
+        <div class="mt-2 sm:mt-0 sm:grid sm:grid-cols-2 sm:gap-4">
           <div class="flex gap-2 sm:flex-col sm:gap-0">
             <photon-number-input
               class="flex-grow flex-1 w-2/5 sm:w-auto"

--- a/packages/elements/src/photon-multirx-form/components/AddPrescriptionCard.tsx
+++ b/packages/elements/src/photon-multirx-form/components/AddPrescriptionCard.tsx
@@ -135,7 +135,7 @@ export const AddPrescriptionCard = (props: {
           ></photon-datepicker>
         </div>
         <div class="sm:grid sm:grid-cols-2 sm:gap-4">
-          <div class="">
+          <div class="flex">
             <photon-number-input
               class="flex-grow flex-1"
               label="Quantity"

--- a/packages/elements/src/photon-multirx-form/components/AddPrescriptionCard.tsx
+++ b/packages/elements/src/photon-multirx-form/components/AddPrescriptionCard.tsx
@@ -64,7 +64,7 @@ export const AddPrescriptionCard = (props: {
   return (
     <photon-card ref={ref} title={'Add Prescription'}>
       <div
-        class="flex flex-col gap-3"
+        class="flex flex-col sm:gap-3"
         on:photon-medication-selected={(e: any) => {
           setOffCatalog(e.detail.medication);
           props.actions.updateFormValue({

--- a/packages/elements/src/photon-multirx-form/components/AddPrescriptionCard.tsx
+++ b/packages/elements/src/photon-multirx-form/components/AddPrescriptionCard.tsx
@@ -64,7 +64,7 @@ export const AddPrescriptionCard = (props: {
   return (
     <photon-card ref={ref} title={'Add Prescription'}>
       <div
-        class="flex flex-col sm:gap-3"
+        class="flex flex-col gap-2 sm:gap-3"
         on:photon-medication-selected={(e: any) => {
           setOffCatalog(e.detail.medication);
           props.actions.updateFormValue({

--- a/packages/elements/src/photon-multirx-form/components/AddPrescriptionCard.tsx
+++ b/packages/elements/src/photon-multirx-form/components/AddPrescriptionCard.tsx
@@ -135,9 +135,9 @@ export const AddPrescriptionCard = (props: {
           ></photon-datepicker>
         </div>
         <div class="sm:grid sm:grid-cols-2 sm:gap-4">
-          <div class="flex">
+          <div class="flex gap-2 sm:flex-col sm:gap-0">
             <photon-number-input
-              class="flex-grow flex-1"
+              class="flex-grow flex-1 w-2/5 sm:w-auto"
               label="Quantity"
               value={props.store['dispenseQuantity']?.value ?? 1}
               required="true"
@@ -167,16 +167,18 @@ export const AddPrescriptionCard = (props: {
                 }
               }}
             ></photon-dosage-calculator-dialog>
-            <photon-button
-              variant="outline"
-              class="w-fit"
-              on:photon-clicked={() => {
-                dosageCalculatorRef.open = true;
-              }}
-            >
-              <sl-icon slot="suffix" name="calculator"></sl-icon>
-              Dose Calculator
-            </photon-button>
+            <div class="pt-7 w-3/5 sm:w-auto sm:pt-0">
+              <photon-button
+                variant="outline"
+                class="w-fit"
+                on:photon-clicked={() => {
+                  dosageCalculatorRef.open = true;
+                }}
+              >
+                <sl-icon slot="suffix" name="calculator"></sl-icon>
+                Dose Calculator
+              </photon-button>
+            </div>
           </div>
           <photon-dispense-units
             label="Dispense Unit"

--- a/packages/elements/src/photon-multirx-form/components/AddPrescriptionCard.tsx
+++ b/packages/elements/src/photon-multirx-form/components/AddPrescriptionCard.tsx
@@ -94,8 +94,8 @@ export const AddPrescriptionCard = (props: {
             });
           }}
         ></photon-treatment-select>
-        <div class="sm:grid sm:grid-cols-2 sm:gap-4">
-          <div>
+        <div class="flex flex-col sm:flex-none	sm:grid sm:grid-cols-2 sm:gap-4">
+          <div class="order-last sm:order-first">
             <photon-checkbox
               label="Dispense as written"
               tip="This prescription will be filled generically unless this box is checked"
@@ -111,7 +111,7 @@ export const AddPrescriptionCard = (props: {
             ></photon-checkbox>
             <photon-med-search-dialog ref={medSearchRef}></photon-med-search-dialog>
           </div>
-          <div class="py-4 md:py-2 text-left sm:text-right">
+          <div class="pb-4 md:py-2 text-left sm:text-right">
             <a
               class="font-sans text-gray-500 text-sm hover:text-black hover:cursor-pointer"
               onClick={() => (medSearchRef.open = true)}

--- a/packages/elements/src/photon-multirx-form/index.tsx
+++ b/packages/elements/src/photon-multirx-form/index.tsx
@@ -328,7 +328,7 @@ customElement(
         <style>{shoelaceLightStyles}</style>
         <style>{styles}</style>
         <div>
-          <div class="flex flex-col gap-4 md:gap-8">
+          <div class="flex flex-col gap-8">
             <Show when={(!client || isLoading()) && !authenticated()}>
               <div class="w-full flex justify-center">
                 <sl-spinner style="font-size: 3rem;"></sl-spinner>

--- a/packages/elements/src/photon-multirx-form/index.tsx
+++ b/packages/elements/src/photon-multirx-form/index.tsx
@@ -328,7 +328,7 @@ customElement(
         <style>{shoelaceLightStyles}</style>
         <style>{styles}</style>
         <div>
-          <div class="flex flex-col gap-8">
+          <div class="flex flex-col gap-4 md:gap-8">
             <Show when={(!client || isLoading()) && !authenticated()}>
               <div class="w-full flex justify-center">
                 <sl-spinner style="font-size: 3rem;"></sl-spinner>

--- a/packages/elements/src/photon-number-input/index.tsx
+++ b/packages/elements/src/photon-number-input/index.tsx
@@ -60,7 +60,7 @@ customElement(
         <style>{shoelaceDarkStyles}</style>
         <style>{shoelaceLightStyles}</style>
         <style>{styles}</style>
-        <div class="py-2 flex flex-col font-sans" ref={ref}>
+        <div class="md:py-2 flex flex-col font-sans" ref={ref}>
           {props.label ? (
             <div class="flex items-center pb-2">
               <p class="text-gray-700 text-sm">{props.label}</p>

--- a/packages/elements/src/photon-phone-input/index.tsx
+++ b/packages/elements/src/photon-phone-input/index.tsx
@@ -70,7 +70,7 @@ customElement(
         <style>{shoelaceDarkStyles}</style>
         <style>{shoelaceLightStyles}</style>
         <style>{styles}</style>
-        <div class="py-2 flex flex-col font-sans" ref={ref}>
+        <div class="md:py-2 flex flex-col font-sans" ref={ref}>
           {props.label ? (
             <div class="flex items-center pb-2">
               <p class="text-gray-700 text-sm">{props.label}</p>

--- a/packages/elements/src/photon-textarea/index.tsx
+++ b/packages/elements/src/photon-textarea/index.tsx
@@ -58,7 +58,7 @@ customElement(
         <style>{shoelaceDarkStyles}</style>
         <style>{shoelaceLightStyles}</style>
         <style>{styles}</style>
-        <div class="py-2 flex flex-col" ref={ref}>
+        <div class="sm:py-2 flex flex-col" ref={ref}>
           {props.label ? (
             <div class="flex items-center pb-2 font-sans">
               <p class="text-gray-700 text-sm">{props.label}</p>


### PR DESCRIPTION
cc @mrado1 
- reduce padding around the form 
- reduce card padding
- checkboxes align to the top not center
- "advanced search" should be under treatment on mobile when stacked
- remove gap when on mobile, it adds weird spacing when stacked in column

before:
<img width="362" alt="Screen Shot 2023-03-23 at 10 59 59 AM" src="https://user-images.githubusercontent.com/700617/227244480-6390437f-261d-4c89-8a60-5df097228f1c.png">

after:
![image](https://user-images.githubusercontent.com/700617/227341743-c3e530b2-d180-4f99-9ba5-b7fc08353d4a.png)
