### PR TITLE
Elements: allow for editing preconfigured template-ids

### DIFF
--- a/packages/elements/src/photon-multirx-form/components/DraftPrescriptionCard.tsx
+++ b/packages/elements/src/photon-multirx-form/components/DraftPrescriptionCard.tsx
@@ -13,6 +13,7 @@ export const DraftPrescriptionCard = (props: {
   actions: Record<string, Function>;
   store: Record<string, any>;
   isLoading: boolean;
+  setIsEditing: (isEditing: boolean) => void;
 }) => {
   const [deleteDialogOpen, setDeleteDialogOpen] = createSignal<boolean>(false);
   const [editDialogOpen, setEditDialogOpen] = createSignal<boolean>(false);
@@ -54,6 +55,7 @@ export const DraftPrescriptionCard = (props: {
     setEditDraft(draft);
 
     if (!props.store['treatment'].value) {
+      props.setIsEditing(true);
       editPrescription();
     } else {
       setEditDialogOpen(true);

--- a/packages/elements/src/photon-multirx-form/index.tsx
+++ b/packages/elements/src/photon-multirx-form/index.tsx
@@ -92,6 +92,7 @@ customElement(
     const client = usePhoton();
     const [showForm, setShowForm] = createSignal<boolean>(!props.templateIds);
     const [isLoading, setIsLoading] = createSignal<boolean>(true);
+    const [isEditing, setIsEditing] = createSignal<boolean>(false);
     const [isLoadingTemplates, setIsLoadingTemplates] = createSignal<boolean>(false);
     const [authenticated, setAuthenticated] = createSignal<boolean>(
       client?.authentication.state.isAuthenticated || false
@@ -342,7 +343,7 @@ customElement(
                 client={client!}
                 enableOrder={props.enableOrder}
               ></PatientCard>
-              <Show when={showForm()}>
+              <Show when={showForm() || isEditing()}>
                 <div ref={prescriptionRef}>
                   <AddPrescriptionCard
                     hideAddToTemplates={props.hideTemplates}
@@ -356,6 +357,7 @@ customElement(
                 actions={actions}
                 store={store}
                 isLoading={isLoadingTemplates()}
+                setIsEditing={setIsEditing}
               ></DraftPrescriptionCard>
               <Show when={props.enableOrder && !props.pharmacyId}>
                 <OrderCard store={store} actions={actions}></OrderCard>


### PR DESCRIPTION
If the prescribe workflow has `template-ids` the prescribe form is hidden. This will hide the ability to edit the prescription if the prescriber clicks the edit button.

Once the form is opened it can't be closed again.