### PR TITLE
Elements: Fix dosage button layout on mobile

### DIFF
--- a/packages/elements/src/photon-multirx-form/components/AddPrescriptionCard.tsx
+++ b/packages/elements/src/photon-multirx-form/components/AddPrescriptionCard.tsx
@@ -135,7 +135,7 @@ export const AddPrescriptionCard = (props: {
           ></photon-datepicker>
         </div>
         <div class="mt-2 sm:mt-0 sm:grid sm:grid-cols-2 sm:gap-4">
-          <div class="flex gap-2 sm:flex-col sm:gap-0">
+          <div class="flex items-end sm:items-stretch gap-2 sm:flex-col sm:gap-0">
             <photon-number-input
               class="flex-grow flex-1 w-2/5 sm:w-auto"
               label="Quantity"
@@ -167,7 +167,7 @@ export const AddPrescriptionCard = (props: {
                 }
               }}
             ></photon-dosage-calculator-dialog>
-            <div class="pt-7 w-3/5 sm:w-auto sm:pt-0">
+            <div class="pb-5 mb-0.5 w-3/5 sm:w-auto sm:pb-0 sm:mb-4">
               <photon-button
                 variant="outline"
                 class="w-fit"


### PR DESCRIPTION
before
<img width="336" alt="Screen Shot 2023-03-27 at 4 55 27 PM" src="https://user-images.githubusercontent.com/700617/228064505-6541432b-11b5-4330-901d-1913aaef9d88.png">

after
<img width="348" alt="Screen Shot 2023-03-27 at 4 55 47 PM" src="https://user-images.githubusercontent.com/700617/228064565-6933c106-9e20-47ea-9b38-24ce9ddeb424.png">
