### PR TITLE
Elements: Medication Search needs wider layout

### DIFF
--- a/packages/elements/src/photon-med-search/index.tsx
+++ b/packages/elements/src/photon-med-search/index.tsx
@@ -100,16 +100,18 @@ customElement('photon-med-search', {}, () => {
       <p class="font-sans text-lg text-gray-700 text-center pb-2">Advanced Medication Search</p>
       <div class="flex flex-col xs:flex-row gap-4">
         <MedicationNameDropdown></MedicationNameDropdown>
+      </div>
+      <div class="flex flex-col xs:flex-row gap-4">
         <MedicationStrengthDropdown
           medicationId={medicationId()}
           disabled={medicationId().length == 0}
         ></MedicationStrengthDropdown>
-      </div>
-      <div class="flex flex-col xs:flex-row gap-4">
         <MedicationRouteDropdown
           medicationId={strengthId()}
           disabled={strengthId().length == 0}
         ></MedicationRouteDropdown>
+      </div>
+      <div class="flex flex-col xs:flex-row gap-4">
         <MedicationFormDropdown
           medicationId={routeId()}
           disabled={routeId().length == 0}


### PR DESCRIPTION
<img width="533" alt="Screen Shot 2023-03-29 at 12 22 12 PM" src="https://user-images.githubusercontent.com/700617/228603776-49f553d4-8ad0-4408-8983-4eb238290df0.png">

<img width="290" alt="Screen Shot 2023-03-29 at 12 23 32 PM" src="https://user-images.githubusercontent.com/700617/228604170-0177dc74-3c02-4257-b410-fbb81d02316d.png">

closes #152 