### PR TITLE
SDK Bump Version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29477,7 +29477,7 @@
     },
     "packages/react": {
       "name": "@photonhealth/react",
-      "version": "1.0.11",
+      "version": "1.0.12",
       "license": "ISC",
       "dependencies": {
         "@photonhealth/sdk": "*"
@@ -29501,7 +29501,7 @@
     },
     "packages/sdk": {
       "name": "@photonhealth/sdk",
-      "version": "1.0.11",
+      "version": "1.0.12",
       "license": "ISC",
       "dependencies": {
         "@apollo/client": "^3.6.9",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@photonhealth/react",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "main": "dist/react.cjs.js",
   "scripts": {
     "build": "rimraf dist && vite build",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@photonhealth/sdk",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "main": "dist/lib.js",
   "scripts": {
     "build": "rimraf dist && vite build",


### PR DESCRIPTION
updated to SDK’s `getAccessToken` to first try silently, then if that fails and throws “consent required” it will try `getTokenWithPopup`