### PR TITLE
Display Blocking Order Address Errors

### DIFF
--- a/apps/app/src/hooks/usePrevious.ts
+++ b/apps/app/src/hooks/usePrevious.ts
@@ -1,0 +1,11 @@
+import { useRef, useEffect } from 'react';
+
+export default function usePrevious(value: any) {
+  const ref = useRef();
+
+  useEffect(() => {
+    ref.current = value;
+  }, [value]);
+
+  return ref.current;
+}

--- a/apps/app/src/hooks/usePrevious.ts
+++ b/apps/app/src/hooks/usePrevious.ts
@@ -1,7 +1,7 @@
 import { useRef, useEffect } from 'react';
 
-export default function usePrevious(value: any) {
-  const ref = useRef();
+export default function usePrevious<T>(value: T): T | undefined {
+  const ref = useRef<T | undefined>();
 
   useEffect(() => {
     ref.current = value;

--- a/apps/app/src/views/routes/NewOrder/components/OrderForm.tsx
+++ b/apps/app/src/views/routes/NewOrder/components/OrderForm.tsx
@@ -229,7 +229,7 @@ export const OrderForm = ({
         }
       }}
     >
-      {({ values, setFieldValue, handleSubmit, dirty, errors, touched }) => {
+      {({ values, setFieldValue, handleSubmit, dirty, errors, touched, setTouched }) => {
         return (
           <form onSubmit={handleSubmit} noValidate id="order-form">
             <ModalCloseButton
@@ -263,6 +263,7 @@ export const OrderForm = ({
                 setShowAddress={setShowAddress}
                 updateAddress={updateAddress}
                 setUpdateAddress={setUpdateAddress}
+                setTouched={setTouched}
               />
 
               <SelectPharmacyCard

--- a/apps/app/src/views/routes/NewOrder/components/OrderForm.tsx
+++ b/apps/app/src/views/routes/NewOrder/components/OrderForm.tsx
@@ -1,7 +1,7 @@
 import * as yup from 'yup';
 import { Formik } from 'formik';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { Alert, AlertIcon, ModalCloseButton, useColorMode, VStack } from '@chakra-ui/react';
 
@@ -13,6 +13,7 @@ import { SelectPatientCard } from './SelectPatientCard';
 import { SelectPrescriptionsCard } from './SelectPrescriptionsCard';
 import { SelectPharmacyCard } from './SelectPharmacyCard';
 import { PatientAddressCard } from './PatientAddressCard';
+import usePrevious from '../../../../hooks/usePrevious';
 
 const envName = process.env.REACT_APP_ENV_NAME as 'boson' | 'neutron' | 'photon';
 const { fulfillmentSettings } = require(`../../../../configs/fulfillment.${envName}.ts`);
@@ -100,6 +101,7 @@ export const OrderForm = ({
   showAddress,
   setShowAddress
 }: OrderFormProps) => {
+  const previousLoading = usePrevious(loading);
   const { colorMode } = useColorMode();
   const [updatePreferredPharmacy, setUpdatePreferredPharmacy] = useState(false);
   const [updateAddress, setUpdateAddress] = useState(false);
@@ -227,7 +229,22 @@ export const OrderForm = ({
         }
       }}
     >
-      {({ values, setFieldValue, handleSubmit, dirty, errors, touched, setTouched }) => {
+      {({
+        values,
+        setFieldValue,
+        handleSubmit,
+        dirty,
+        errors,
+        touched,
+        setTouched,
+        validateForm
+      }) => {
+        useEffect(() => {
+          if (previousLoading && !loading) {
+            validateForm();
+          }
+        }, [loading, previousLoading]);
+
         return (
           <form onSubmit={handleSubmit} noValidate id="order-form">
             <ModalCloseButton

--- a/apps/app/src/views/routes/NewOrder/components/OrderForm.tsx
+++ b/apps/app/src/views/routes/NewOrder/components/OrderForm.tsx
@@ -59,9 +59,7 @@ const orderSchema = yup.object({
       postalCode: yup
         .string()
         .required('Please enter a zip code...')
-        .matches(/^[0-9]+$/, 'Must be only digits')
-        .min(5, 'Must be exactly 5 digits')
-        .max(5, 'Must be exactly 5 digits'),
+        .matches(/^\d{5}(-\d{4})?$/, 'Must be a valid zip code...'),
       country: yup.string().required('Please enter a country...'),
       state: yup.string().required('Please enter a state...'),
       city: yup.string().required('Please enter a city...')

--- a/apps/app/src/views/routes/NewOrder/components/PatientAddressCard.tsx
+++ b/apps/app/src/views/routes/NewOrder/components/PatientAddressCard.tsx
@@ -60,7 +60,7 @@ export const PatientAddressCard = ({
         }, {})
       });
     }
-  }, [errors]);
+  }, [errors, setShowAddress, setTouched, showAddress, touched]);
 
   return (
     <Card bg="bg-surface">

--- a/apps/app/src/views/routes/NewOrder/components/PatientAddressCard.tsx
+++ b/apps/app/src/views/routes/NewOrder/components/PatientAddressCard.tsx
@@ -21,6 +21,7 @@ import { LoadingInputField } from '../../../components/LoadingInputField';
 import { formatAddress } from '../../../../utils';
 
 import { Address } from '../../../../models/general';
+import { useEffect } from 'react';
 
 interface PatientAddressCardProps {
   address: Address;
@@ -32,6 +33,7 @@ interface PatientAddressCardProps {
   setShowAddress: any;
   updateAddress: boolean;
   setUpdateAddress: (value: boolean) => void;
+  setTouched: (fields: { [field: string]: boolean }, shouldValidate?: boolean) => void;
 }
 
 export const PatientAddressCard = ({
@@ -44,7 +46,23 @@ export const PatientAddressCard = ({
   setShowAddress,
   updateAddress,
   setUpdateAddress
+  setUpdateAddress,
+  setTouched
 }: PatientAddressCardProps) => {
+  useEffect(() => {
+    const errorKeys = Object.keys(errors?.address || {});
+    if (errorKeys?.length > 0 && !showAddress) {
+      setShowAddress(true);
+      setTouched({
+        ...touched,
+        address: errorKeys.reduce((acc: { [key: string]: boolean }, key) => {
+          acc[key] = true;
+          return acc;
+        }, {})
+      });
+    }
+  }, [errors]);
+
   return (
     <Card bg="bg-surface">
       <CardHeader>

--- a/apps/app/src/views/routes/NewOrder/components/PatientAddressCard.tsx
+++ b/apps/app/src/views/routes/NewOrder/components/PatientAddressCard.tsx
@@ -115,9 +115,9 @@ export const PatientAddressCard = ({
                 <FormLabel htmlFor="address.postalCode">Zip Code</FormLabel>
                 <LoadingInputField
                   name="address.postalCode"
-                  maxLength={5}
+                  maxLength={10}
                   onChange={(e: any) => {
-                    if (/^[0-9]+$/.test(e.target.value) || e.target.value === '') {
+                    if (/^[0-9-]+$/.test(e.target.value) || e.target.value === '') {
                       setFieldValue('address.postalCode', e.target.value);
                     }
                   }}

--- a/apps/app/src/views/routes/NewOrder/components/PatientAddressCard.tsx
+++ b/apps/app/src/views/routes/NewOrder/components/PatientAddressCard.tsx
@@ -45,7 +45,6 @@ export const PatientAddressCard = ({
   showAddress,
   setShowAddress,
   updateAddress,
-  setUpdateAddress
   setUpdateAddress,
   setTouched
 }: PatientAddressCardProps) => {

--- a/packages/elements/src/photon-patient-form/index.tsx
+++ b/packages/elements/src/photon-patient-form/index.tsx
@@ -6,7 +6,7 @@ import { createFormStore } from '../stores/form';
 import { PatientStore } from '../stores/patient';
 import { PharmacyStore } from '../stores/pharmacy';
 import tailwind from '../tailwind.css?inline';
-import { email, empty, message, numericString, notFutureDate } from '../validators';
+import { email, empty, message, zipString, notFutureDate } from '../validators';
 
 //Shoelace
 import '@shoelace-style/shoelace/dist/components/spinner/spinner';
@@ -88,10 +88,7 @@ customElement(
     });
     actions.registerValidator({
       key: 'address_zip',
-      validator: message(
-        union([size(numericString(), 0, 10), empty()]),
-        'Please enter a valid zip code...'
-      )
+      validator: message(union([zipString(), empty()]), 'Please enter a valid zip code...')
     });
 
     onMount(() => {

--- a/packages/elements/src/validators/index.ts
+++ b/packages/elements/src/validators/index.ts
@@ -35,6 +35,11 @@ export const numericString = () =>
     return /^\d+$/.test(value as string);
   });
 
+export const zipString = () =>
+  refine(string(), 'zipString', (value) => {
+    return /^\d{5}(-\d{4})?$/.test(value as string);
+  });
+
 export const email = () =>
   refine(string(), 'email', (value) => {
     if (value.length === 0) {


### PR DESCRIPTION
- Elements: fixes validation on the update / create so that incorrect zip codes don't get introduced
- zip codes use the format of either 12345 or 12345-1234
- App: the address form will open up and display the error if theres something blocking sending the order

Can use the below patient to test
<img width="541" alt="Screen Shot 2023-04-10 at 2 14 43 PM" src="https://user-images.githubusercontent.com/700617/230965370-537f252e-ca21-49ec-81a3-63ad3c5f6a3d.png">

closes #205 