### PR TITLE
Handle non-existent entities

### DIFF
--- a/apps/app/src/views/routes/Order.tsx
+++ b/apps/app/src/views/routes/Order.tsx
@@ -2,7 +2,9 @@ import { useParams } from 'react-router-dom';
 import { useState, useEffect } from 'react';
 import {
   Alert,
+  AlertDescription,
   AlertIcon,
+  AlertTitle,
   Badge,
   Button,
   Divider,
@@ -111,15 +113,6 @@ export const Order = () => {
     }
   }, [accessToken]);
 
-  if (error) {
-    return (
-      <Alert status="error">
-        <AlertIcon />
-        {error.message}
-      </Alert>
-    );
-  }
-
   const isMobile = useBreakpointValue({ base: true, sm: false });
   const rightColWidth = '75%';
   const { colorMode } = useColorMode();
@@ -152,6 +145,30 @@ export const Order = () => {
       </HStack>
     );
   };
+
+  if (error || (!loading && !order)) {
+    return (
+      <Alert
+        status="warning"
+        flexDirection="column"
+        alignItems="center"
+        justifyContent="center"
+        textAlign="center"
+        height="200px"
+      >
+        <AlertIcon />
+        <AlertTitle mt={4} mb={1} fontSize="lg">
+          Unknown Order
+        </AlertTitle>
+        <AlertDescription maxWidth="sm">
+          <div>Looks like we can't find an order with that ID. </div>
+          <Link textDecoration="underline" fontSize="md" href="/orders">
+            Go back to orders.
+          </Link>
+        </AlertDescription>
+      </Alert>
+    );
+  }
 
   return (
     <Page kicker="Order" header={order ? formatFills(order.fills) : ''} loading={loading}>

--- a/apps/app/src/views/routes/Patient.tsx
+++ b/apps/app/src/views/routes/Patient.tsx
@@ -3,6 +3,8 @@ import { useParams, Link as RouterLink, useNavigate } from 'react-router-dom';
 import {
   Alert,
   AlertIcon,
+  AlertTitle,
+  AlertDescription,
   Badge,
   Box,
   Button,
@@ -63,21 +65,6 @@ export const Patient = () => {
     UNKNOWN: 'Unknown'
   };
 
-  if (error) {
-    return (
-      <Alert status="error">
-        <AlertIcon />
-        {error.message}
-      </Alert>
-    );
-  }
-
-  useEffect(() => {
-    if (!loading && !patient) {
-      navigate('/patients');
-    }
-  }, [patient, loading, navigate]);
-
   const isMobile = useBreakpointValue({ base: true, sm: false });
   const tableWidth = useBreakpointValue({ base: 'full', sm: '100%', md: '75%' });
 
@@ -89,6 +76,30 @@ export const Patient = () => {
     };
     refetchData();
   }, [id]);
+
+  if (error || (!loading && !patient)) {
+    return (
+      <Alert
+        status="warning"
+        flexDirection="column"
+        alignItems="center"
+        justifyContent="center"
+        textAlign="center"
+        height="200px"
+      >
+        <AlertIcon />
+        <AlertTitle mt={4} mb={1} fontSize="lg">
+          Unknown Patient
+        </AlertTitle>
+        <AlertDescription maxWidth="sm">
+          <div>Looks like we can't find a patient with that ID. </div>
+          <Link textDecoration="underline" fontSize="md" href="/patients">
+            Go back to patients.
+          </Link>
+        </AlertDescription>
+      </Alert>
+    );
+  }
 
   return (
     <Page loading={loading} kicker="Patient" header={patient?.name.full}>

--- a/apps/app/src/views/routes/Prescription.tsx
+++ b/apps/app/src/views/routes/Prescription.tsx
@@ -10,6 +10,7 @@ import {
   IconButton,
   Stack,
   HStack,
+  Link,
   Table,
   TableContainer,
   Tbody,
@@ -22,7 +23,9 @@ import {
   SkeletonText,
   useBreakpointValue,
   useColorMode,
-  useToast
+  useToast,
+  AlertTitle,
+  AlertDescription
 } from '@chakra-ui/react';
 import { FiCopy } from 'react-icons/fi';
 import { gql, GraphQLClient } from 'graphql-request';
@@ -77,15 +80,6 @@ export const Prescription = () => {
     }
   }, [accessToken]);
 
-  if (error) {
-    return (
-      <Alert status="error">
-        <AlertIcon />
-        {error.message}
-      </Alert>
-    );
-  }
-
   const {
     prescriber,
     patient,
@@ -107,6 +101,30 @@ export const Prescription = () => {
   const isMobile = useBreakpointValue({ base: true, sm: false });
   const tableWidth = useBreakpointValue({ base: 'full', sm: '100%', md: '75%' });
   const { colorMode } = useColorMode();
+
+  if (error || (!loading && !prescription)) {
+    return (
+      <Alert
+        status="warning"
+        flexDirection="column"
+        alignItems="center"
+        justifyContent="center"
+        textAlign="center"
+        height="200px"
+      >
+        <AlertIcon />
+        <AlertTitle mt={4} mb={1} fontSize="lg">
+          Unknown Prescription
+        </AlertTitle>
+        <AlertDescription maxWidth="sm">
+          <div>Looks like we can't find a prescription with that ID.</div>
+          <Link textDecoration="underline" fontSize="md" href="/prescriptions">
+            Go back to prescriptions.
+          </Link>
+        </AlertDescription>
+      </Alert>
+    );
+  }
 
   return (
     <Page kicker="Prescription" header={prescription?.treatment.name} loading={loading}>


### PR DESCRIPTION
This prevents an incorrect patient, order, or prescription ID from crashing the app:

<img width="973" alt="Screen Shot 2023-04-11 at 5 02 23 PM" src="https://user-images.githubusercontent.com/700617/231287414-c373931b-66ff-4138-8e4f-5844db887953.png">

closes #71 