### PR TITLE
Fix Pharmacy autocomplete search

### DIFF
--- a/apps/app/src/views/routes/NewOrder/components/SelectPharmacyCard/components/LocalPickup.tsx
+++ b/apps/app/src/views/routes/NewOrder/components/SelectPharmacyCard/components/LocalPickup.tsx
@@ -102,7 +102,6 @@ export const LocalPickup = (props: LocalPickupProps) => {
 
   const getPharmacyOptions = async (inputValue?: string) => {
     const resultPharmacies: any = await refetchPharmacies({
-      name: inputValue?.toUpperCase() || undefined,
       location: {
         latitude,
         longitude,
@@ -111,11 +110,13 @@ export const LocalPickup = (props: LocalPickupProps) => {
       type: types.FulfillmentType.PickUp
     });
 
-    return formatPharmacyOptions(
-      resultPharmacies.data.pharmacies,
-      preferredPharmacyIds,
-      previousId
-    );
+    const filteredPharmacies = inputValue
+      ? resultPharmacies.data.pharmacies.filter((pharmacy: any) =>
+          pharmacy.name.toLowerCase().startsWith(inputValue.toLowerCase())
+        )
+      : resultPharmacies.data.pharmacies;
+
+    return formatPharmacyOptions(filteredPharmacies, preferredPharmacyIds, previousId);
   };
 
   useEffect(() => {


### PR DESCRIPTION
On the New order page under "local pickup" tab the search was breaking with anything more than one character.

closes #102 