### PR TITLE
Add Template Ids to New Prescription via Query Param

### DIFF
--- a/apps/app/src/App.tsx
+++ b/apps/app/src/App.tsx
@@ -56,7 +56,6 @@ export const App = () => {
               <Route path="new" element={<PrescriptionForm />} />
               <Route path=":prescriptionId" element={<Prescription />} />
             </Route>
-            <Route path="/prescriptions/new" element={<PrescriptionForm />} />
             <Route path="/orders">
               <Route path="/orders" element={<Orders />} />
               <Route path="new" element={<NewOrder />} />

--- a/apps/app/src/views/routes/PrescriptionForm.tsx
+++ b/apps/app/src/views/routes/PrescriptionForm.tsx
@@ -13,6 +13,7 @@ export const PrescriptionForm = () => {
   const ref: MutableRefObject<any> = useRef();
   const [params] = useSearchParams();
   const patientId = params.get('patientId') || '';
+  const templateIds = params.get('templateIds') || '';
 
   const navigate = useNavigate();
   const onClose = () => {
@@ -58,7 +59,7 @@ export const PrescriptionForm = () => {
         zIndex: 15
       }}
     >
-      <photon-multirx-form-wrapper ref={ref} />
+      <photon-multirx-form-wrapper ref={ref} template-ids={templateIds} />
     </div>
   );
 };


### PR DESCRIPTION
Attach one or many template ids when creating a new prescription in app.

```
/prescriptions/new?templateIds=tmp_01GQG3RD334GX1Z2Z2XXB59BM8,tmp_01GQGFHBZ8P0H52N62JKPBCHJH
```

cc @ottosipe 