### PR TITLE
Ability to set Address in Prescribe Workflow 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29750,7 +29750,7 @@
     },
     "packages/elements": {
       "name": "@photonhealth/elements",
-      "version": "0.0.98",
+      "version": "0.0.99",
       "license": "ISC",
       "dependencies": {
         "@photonhealth/components": "*",
@@ -33639,7 +33639,7 @@
         "react-dom": "^18.2.0",
         "solid-heroicons": "^3.1.1",
         "solid-js": "^1.6.11",
-        "solid-transition-group": "*",
+        "solid-transition-group": "^0.2.2",
         "storybook": "^7.0.0-beta.19",
         "superstruct": "^1.0.3",
         "tailwindcss": "^3.2.7",

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@photonhealth/elements",
-  "version": "0.0.98",
+  "version": "0.0.99",
   "description": "",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/elements/src/photon-multirx-form/components/PatientCard.tsx
+++ b/packages/elements/src/photon-multirx-form/components/PatientCard.tsx
@@ -55,7 +55,7 @@ export const PatientCard = (props: {
           selected={props.store['patient']?.value?.id ?? props.patientId}
           sdk={props.client!.getSDK()}
         ></photon-patient-select>
-        <Show when={props.store['patient']?.value?.id && props.enableOrder}>
+        <Show when={props.store['patient']?.value?.id && props.enableOrder && !props.hideAddress}>
           <photon-patient-dialog
             open={dialogOpen()}
             on:photon-patient-updated={() => {

--- a/packages/elements/src/photon-multirx-form/index.tsx
+++ b/packages/elements/src/photon-multirx-form/index.tsx
@@ -353,6 +353,7 @@ customElement(
                 patientId={props.patientId}
                 client={client!}
                 enableOrder={props.enableOrder}
+                hideAddress={!!props.address}
               ></PatientCard>
               <Show when={showForm() || isEditing()}>
                 <div ref={prescriptionRef}>

--- a/packages/elements/src/photon-multirx-form/index.tsx
+++ b/packages/elements/src/photon-multirx-form/index.tsx
@@ -14,7 +14,7 @@ import tailwind from '../tailwind.css?inline';
 import shoelaceLightStyles from '@shoelace-style/shoelace/dist/themes/light.css?inline';
 import shoelaceDarkStyles from '@shoelace-style/shoelace/dist/themes/dark.css?inline';
 import styles from './style.css?inline';
-import { createEffect, createSignal, onMount, Show } from 'solid-js';
+import { createEffect, createSignal, Show } from 'solid-js';
 import { createFormStore } from '../stores/form';
 import { usePhoton } from '../context';
 import { Order, Prescription, PrescriptionTemplate } from '@photonhealth/sdk/dist/types';
@@ -62,7 +62,8 @@ customElement(
     hideTemplates: true,
     enableOrder: false,
     pharmacyId: undefined,
-    loading: false
+    loading: false,
+    address: undefined
   },
   (
     props: {
@@ -73,6 +74,14 @@ customElement(
       enableOrder: boolean;
       pharmacyId?: string;
       loading: boolean;
+      address?: {
+        city: string;
+        postalCode: string;
+        state: string;
+        street1: string;
+        street2?: string;
+        country?: string;
+      };
     },
     options
   ) => {
@@ -287,14 +296,16 @@ customElement(
         }
         dispatchPrescriptionsCreated(data!.createPrescriptions);
         if (props.enableOrder) {
-          const address = Object.assign({}, store['patient']?.value.address);
-          delete address['__typename'];
-          delete address['name'];
+          const { __typename, name, ...patientAddress } =
+            (store['patient']?.value || {})?.address || {};
+
           const { data: data2, errors } = await orderMutation({
             variables: {
               patientId: store['patient']?.value.id,
               pharmacyId: props?.pharmacyId || store['pharmacy']?.value.id,
-              address: address,
+              address: props.address
+                ? { street2: '', country: 'US', ...props.address }
+                : patientAddress,
               fills: data?.createPrescriptions.map((x) => ({ prescriptionId: x.id }))
             },
             refetchQueries: [],


### PR DESCRIPTION
You can set the address like so:

``` jsx
function Photon() {
  const address = {
    postalCode: '11201',
    street1: '123 street st',
    state: 'NY',
    city: 'Brooklyn',
  };
  
  return (
    <photon-prescribe-workflow
      patient-id="pat_01G8VFW0X44YCW8KW7FW3FC0ZT"
      enable-order="true"
      address={JSON.stringify(address)}
    />
  );
}
```

If address is set, it will hide the ability for prescribers to set the address:
<img width="501" alt="Screen Shot 2023-04-24 at 1 10 07 PM" src="https://user-images.githubusercontent.com/700617/234067749-0fe10245-5eb4-4733-a0bc-b563a5064441.png">
