### PR TITLE
Display Validation Errors

### DIFF
--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@photonhealth/elements",
-  "version": "0.0.99",
+  "version": "0.0.100",
   "description": "",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/elements/src/photon-multirx-form/index.tsx
+++ b/packages/elements/src/photon-multirx-form/index.tsx
@@ -391,6 +391,8 @@ customElement(
                         <strong>Error with {key}: </strong>
                         <br />
                         {error}
+                        <br />
+                        {JSON.stringify(store?.[key]?.value || {})}
                       </sl-alert>
                     ))}
                   </div>

--- a/packages/elements/src/photon-multirx-form/index.tsx
+++ b/packages/elements/src/photon-multirx-form/index.tsx
@@ -15,6 +15,7 @@ import shoelaceLightStyles from '@shoelace-style/shoelace/dist/themes/light.css?
 import shoelaceDarkStyles from '@shoelace-style/shoelace/dist/themes/dark.css?inline';
 import styles from './style.css?inline';
 import { createEffect, createSignal, Show } from 'solid-js';
+import type { FormError } from '../stores/form';
 import { createFormStore } from '../stores/form';
 import { usePhoton } from '../context';
 import { Order, Prescription, PrescriptionTemplate } from '@photonhealth/sdk/dist/types';
@@ -100,6 +101,7 @@ customElement(
     );
     const client = usePhoton();
     const [showForm, setShowForm] = createSignal<boolean>(!props.templateIds);
+    const [errors, setErrors] = createSignal<FormError[]>([]);
     const [isLoading, setIsLoading] = createSignal<boolean>(true);
     const [isEditing, setIsEditing] = createSignal<boolean>(false);
     const [isLoadingTemplates, setIsLoadingTemplates] = createSignal<boolean>(false);
@@ -250,12 +252,13 @@ customElement(
     };
 
     const submitForm = async (enableOrder: boolean) => {
+      setErrors([]);
       const keys = enableOrder
         ? ['patient', 'draftPrescriptions', 'pharmacy', 'address']
         : ['patient', 'draftPrescriptions'];
       actions.validate(keys);
-      const errorsPresent = actions.hasErrors(keys);
-      if (!errorsPresent) {
+      const errors = actions.getErrors(keys);
+      if (errors.length === 0) {
         setIsLoading(true);
         actions.updateFormValue({
           key: 'errors',
@@ -320,6 +323,8 @@ customElement(
           }
           dispatchOrderCreated(data2!.createOrder);
         }
+      } else {
+        setErrors(errors);
       }
     };
 
@@ -378,6 +383,18 @@ customElement(
                 <PharmacyCard pharmacyId={props.pharmacyId}></PharmacyCard>
               </Show>
               <Show when={!props.hideSubmit}>
+                <Show when={errors().length > 0}>
+                  <div class="m-3">
+                    {errors().map(({ key, error }) => (
+                      <sl-alert variant="warning" open>
+                        <sl-icon slot="icon" name="exclamation-triangle"></sl-icon>
+                        <strong>Error with {key}: </strong>
+                        <br />
+                        {error}
+                      </sl-alert>
+                    ))}
+                  </div>
+                </Show>
                 <div class="flex flex-row justify-end gap-2">
                   <Show when={!showForm()}>
                     <photon-button

--- a/packages/elements/src/photon-multirx-form/index.tsx
+++ b/packages/elements/src/photon-multirx-form/index.tsx
@@ -383,7 +383,9 @@ customElement(
                 <PharmacyCard pharmacyId={props.pharmacyId}></PharmacyCard>
               </Show>
               <Show when={!props.hideSubmit}>
-                <Show when={errors().length > 0}>
+                {/* We're hiding this alert message if enable-order is set, a rough way to let us know this is not in the App.
+                The issue we're having is when props are passed and cards are hidden, the form is not showing validation errors. */}
+                <Show when={errors().length > 0 && props.enableOrder}>
                   <div class="m-3">
                     {errors().map(({ key, error }) => (
                       <sl-alert variant="warning" open>

--- a/packages/elements/src/stores/form.ts
+++ b/packages/elements/src/stores/form.ts
@@ -1,5 +1,6 @@
 import { createStore } from 'solid-js/store';
 import { Struct, assert, StructError } from 'superstruct';
+export type FormError = { key: string; error: string };
 
 export const createFormStore = (initalValue?: Record<string, any>) => {
   type StoreValue = { value: any; error?: string };
@@ -33,6 +34,16 @@ export const createFormStore = (initalValue?: Record<string, any>) => {
       }
     }
     return errors > 0;
+  };
+
+  const getErrors = (keys: string[]): FormError[] => {
+    let errors: FormError[] = [];
+    for (const member in store) {
+      if (keys.includes(member) && store[member]?.error) {
+        errors = [...errors, { key: member, error: store[member]?.error ?? '' }];
+      }
+    }
+    return errors;
   };
 
   const clearKeys = (keys: string[]) => {
@@ -92,6 +103,7 @@ export const createFormStore = (initalValue?: Record<string, any>) => {
       unRegisterValidator,
       validate,
       hasErrors,
+      getErrors,
       reset
     }
   };


### PR DESCRIPTION
With many of our forms hidden if preset with values, prescribers are getting in a stuck state where nothing happens on validation error.

<img width="601" alt="Screen Shot 2023-04-28 at 6 05 45 PM" src="https://user-images.githubusercontent.com/700617/235261812-b6d0d523-21c7-498d-a4ff-14334378fe24.png">
