### PR TITLE
Prescribe Workflow Address needs to be Added to Store for Validation

### DIFF
--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@photonhealth/elements",
-  "version": "0.0.100",
+  "version": "0.0.101",
   "description": "",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/elements/src/photon-multirx-form/components/PatientCard.tsx
+++ b/packages/elements/src/photon-multirx-form/components/PatientCard.tsx
@@ -47,6 +47,8 @@ export const PatientCard = (props: {
               value: e.detail.patient,
             });
             if (props.enableOrder && !props.hideAddress) {
+              // update address in the scenario where you want to allow send order
+              // but the address hasn't been manually overridden
               props.actions.updateFormValue({
                 key: 'address',
                 value: e.detail.patient.address,

--- a/packages/elements/src/photon-multirx-form/components/PatientCard.tsx
+++ b/packages/elements/src/photon-multirx-form/components/PatientCard.tsx
@@ -17,6 +17,7 @@ export const PatientCard = (props: {
   patientId?: string;
   client?: PhotonClientStore;
   enableOrder?: boolean;
+  hideAddress?: boolean;
 }) => {
   const [dialogOpen, setDialogOpen] = createSignal(false);
   const { actions } = PatientStore;
@@ -45,7 +46,7 @@ export const PatientCard = (props: {
               key: 'patient',
               value: e.detail.patient,
             });
-            if (props.enableOrder) {
+            if (props.enableOrder && !props.hideAddress) {
               props.actions.updateFormValue({
                 key: 'address',
                 value: e.detail.patient.address,

--- a/packages/elements/src/photon-multirx-form/index.tsx
+++ b/packages/elements/src/photon-multirx-form/index.tsx
@@ -14,7 +14,7 @@ import tailwind from '../tailwind.css?inline';
 import shoelaceLightStyles from '@shoelace-style/shoelace/dist/themes/light.css?inline';
 import shoelaceDarkStyles from '@shoelace-style/shoelace/dist/themes/dark.css?inline';
 import styles from './style.css?inline';
-import { createEffect, createSignal, Show } from 'solid-js';
+import { createEffect, onMount, createSignal, Show } from 'solid-js';
 import type { FormError } from '../stores/form';
 import { createFormStore } from '../stores/form';
 import { usePhoton } from '../context';
@@ -108,6 +108,15 @@ customElement(
     const [authenticated, setAuthenticated] = createSignal<boolean>(
       client?.authentication.state.isAuthenticated || false
     );
+
+    onMount(() => {
+      if (props.address) {
+        actions.updateFormValue({
+          key: 'address',
+          value: props.address
+        });
+      }
+    });
 
     createEffect(() => {
       if (
@@ -302,13 +311,15 @@ customElement(
           const { __typename, name, ...patientAddress } =
             (store['patient']?.value || {})?.address || {};
 
+          const address = store.address
+            ? { street2: '', country: 'US', ...props.address }
+            : patientAddress;
+
           const { data: data2, errors } = await orderMutation({
             variables: {
               patientId: store['patient']?.value.id,
               pharmacyId: props?.pharmacyId || store['pharmacy']?.value.id,
-              address: props.address
-                ? { street2: '', country: 'US', ...props.address }
-                : patientAddress,
+              address,
               fills: data?.createPrescriptions.map((x) => ({ prescriptionId: x.id }))
             },
             refetchQueries: [],

--- a/packages/elements/src/photon-multirx-form/index.tsx
+++ b/packages/elements/src/photon-multirx-form/index.tsx
@@ -111,6 +111,7 @@ customElement(
 
     onMount(() => {
       if (props.address) {
+        // if manually overriding address, update the store on mount
         actions.updateFormValue({
           key: 'address',
           value: props.address
@@ -308,12 +309,10 @@ customElement(
         }
         dispatchPrescriptionsCreated(data!.createPrescriptions);
         if (props.enableOrder) {
+          // remove unnecessary fields, and add country and street2 if missing
           const { __typename, name, ...patientAddress } =
-            (store['patient']?.value || {})?.address || {};
-
-          const address = store.address
-            ? { street2: '', country: 'US', ...props.address }
-            : patientAddress;
+            store?.address?.value || (store['patient']?.value || {})?.address || {};
+          const address = { street2: '', country: 'US', ...patientAddress };
 
           const { data: data2, errors } = await orderMutation({
             variables: {

--- a/packages/elements/src/photon-multirx-form/index.tsx
+++ b/packages/elements/src/photon-multirx-form/index.tsx
@@ -310,9 +310,9 @@ customElement(
         dispatchPrescriptionsCreated(data!.createPrescriptions);
         if (props.enableOrder) {
           // remove unnecessary fields, and add country and street2 if missing
-          const { __typename, name, ...patientAddress } =
-            store?.address?.value || (store['patient']?.value || {})?.address || {};
-          const address = { street2: '', country: 'US', ...patientAddress };
+          const patientAddress = store?.address?.value ?? store?.patient?.value?.address ?? {};
+          const { __typename, name, ...filteredPatientAddress } = patientAddress;
+          const address = { street2: '', country: 'US', ...filteredPatientAddress };
 
           const { data: data2, errors } = await orderMutation({
             variables: {


### PR DESCRIPTION
If the patient request in `PatientCard` came back with an empty {} for address, it was setting `address` in the store which was failing validation. Even though the address that would have ultimately been passed was from props, the validation was failing so never making it to the mutation.

Now, there's a flag to not update the patient's address to the store if address is passed as a prop AND the prop address is set to the store on mount for good measure.

## Test Cases

- [x] user with address, prop address is set => prop address should override
- [x] user with address, prop address is not set => user's address should be used
- [x] user without address, prop address is set => prop address should be used
- [x] user without address, prop address is not set => should fail validation and show error

![image](https://user-images.githubusercontent.com/700617/235279602-8ea4be03-381d-492f-8a5c-54d842613242.png)
