### PR TITLE
Hide Patient Dropdown if Patient ID is passed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29819,7 +29819,7 @@
     },
     "packages/elements": {
       "name": "@photonhealth/elements",
-      "version": "0.0.99",
+      "version": "0.0.101",
       "license": "ISC",
       "dependencies": {
         "@photonhealth/components": "*",
@@ -30135,6 +30135,7 @@
       }
     },
     "packages/settings": {
+      "name": "@client/settings",
       "version": "0.0.1"
     }
   },

--- a/packages/elements/src/photon-multirx-form/components/PatientCard.tsx
+++ b/packages/elements/src/photon-multirx-form/components/PatientCard.tsx
@@ -1,6 +1,6 @@
 import { message } from '../../validators';
 import { string, any, record } from 'superstruct';
-import { createSignal, onMount, Show } from 'solid-js';
+import { createSignal, onMount, Show, createEffect } from 'solid-js';
 import { PatientStore } from '../../stores/patient';
 import { PhotonClientStore } from '../../store';
 import { formatDate } from '../../utils';
@@ -57,13 +57,21 @@ export const PatientCard = (props: {
     }
   });
 
+  createEffect(() => {
+    if (store?.selectedPatient?.data) {
+      if (store?.selectedPatient?.data?.id !== props.store['patient']?.value?.id) {
+        // update patient when selected patient changes
+        updatePatient({ detail: { patient: store?.selectedPatient?.data } });
+      }
+    }
+  });
+
   return (
     <photon-card>
       <div class="flex flex-col gap-3">
         <p class="font-sans text-l font-medium">
           {props?.patientId ? 'Patient' : 'Select Patient'}
         </p>
-
         {/* Show Dropdown when no patientId is passed */}
         <Show when={!props?.patientId}>
           <photon-patient-select
@@ -74,14 +82,13 @@ export const PatientCard = (props: {
             sdk={props.client!.getSDK()}
           ></photon-patient-select>
         </Show>
-
         {/* Show Patient Name when patientId is passed */}
         <Show when={props?.patientId}>
           <Show
             when={store?.selectedPatient?.data?.id}
             fallback={<sl-spinner style="font-size: 1rem;"></sl-spinner>}
           >
-            <p class="font-sans text-sm">
+            <p class="font-sans text-gray-700">
               {store?.selectedPatient?.data?.name?.full},{' '}
               {formatDate(store?.selectedPatient?.data?.dateOfBirth || '')}
             </p>

--- a/packages/elements/src/photon-multirx-form/components/PatientCard.tsx
+++ b/packages/elements/src/photon-multirx-form/components/PatientCard.tsx
@@ -1,8 +1,9 @@
 import { message } from '../../validators';
 import { string, any, record } from 'superstruct';
-import { createSignal, Show } from 'solid-js';
+import { createSignal, onMount, Show } from 'solid-js';
 import { PatientStore } from '../../stores/patient';
 import { PhotonClientStore } from '../../store';
+import { formatDate } from '../../utils';
 
 const patientValidator = message(record(string(), any()), 'Please select a patient...');
 
@@ -20,44 +21,73 @@ export const PatientCard = (props: {
   hideAddress?: boolean;
 }) => {
   const [dialogOpen, setDialogOpen] = createSignal(false);
-  const { actions } = PatientStore;
+  const { actions, store } = PatientStore;
 
   props.actions.registerValidator({
     key: 'patient',
-    validator: patientValidator,
+    validator: patientValidator
   });
 
   if (props.enableOrder) {
     props.actions.registerValidator({
       key: 'address',
-      validator: patientAddressValidator,
+      validator: patientAddressValidator
     });
   }
+
+  const updatePatient = (e: any) => {
+    props.actions.updateFormValue({
+      key: 'patient',
+      value: e.detail.patient
+    });
+    if (props.enableOrder && !props.hideAddress) {
+      // update address when you want to allow send order
+      // but the address hasn't been manually overridden
+      props.actions.updateFormValue({
+        key: 'address',
+        value: e.detail.patient.address
+      });
+    }
+  };
+
+  onMount(() => {
+    if (props?.patientId) {
+      // fetch patient on mount when patientId is passed
+      actions.getSelectedPatient(props.client!.getSDK(), props.patientId);
+    }
+  });
 
   return (
     <photon-card>
       <div class="flex flex-col gap-3">
-        <p class="font-sans text-l font-medium">Select Patient</p>
-        <photon-patient-select
-          invalid={props.store['patient']?.error ?? false}
-          help-text={props.store['patient']?.error}
-          on:photon-patient-selected={(e: any) => {
-            props.actions.updateFormValue({
-              key: 'patient',
-              value: e.detail.patient,
-            });
-            if (props.enableOrder && !props.hideAddress) {
-              // update address in the scenario where you want to allow send order
-              // but the address hasn't been manually overridden
-              props.actions.updateFormValue({
-                key: 'address',
-                value: e.detail.patient.address,
-              });
-            }
-          }}
-          selected={props.store['patient']?.value?.id ?? props.patientId}
-          sdk={props.client!.getSDK()}
-        ></photon-patient-select>
+        <p class="font-sans text-l font-medium">
+          {props?.patientId ? 'Patient' : 'Select Patient'}
+        </p>
+
+        {/* Show Dropdown when no patientId is passed */}
+        <Show when={!props?.patientId}>
+          <photon-patient-select
+            invalid={props.store['patient']?.error ?? false}
+            help-text={props.store['patient']?.error}
+            on:photon-patient-selected={updatePatient}
+            selected={props.store['patient']?.value?.id ?? props.patientId}
+            sdk={props.client!.getSDK()}
+          ></photon-patient-select>
+        </Show>
+
+        {/* Show Patient Name when patientId is passed */}
+        <Show when={props?.patientId}>
+          <Show
+            when={store?.selectedPatient?.data?.id}
+            fallback={<sl-spinner style="font-size: 1rem;"></sl-spinner>}
+          >
+            <p class="font-sans text-sm">
+              {store?.selectedPatient?.data?.name?.full},{' '}
+              {formatDate(store?.selectedPatient?.data?.dateOfBirth || '')}
+            </p>
+          </Show>
+        </Show>
+
         <Show when={props.store['patient']?.value?.id && props.enableOrder && !props.hideAddress}>
           <photon-patient-dialog
             open={dialogOpen()}
@@ -90,7 +120,7 @@ export const PatientCard = (props: {
                   'p-2': props.store['address']!.error,
                   'border-red-500': props.store['address']!.error,
                   'border-2': props.store['address']!.error,
-                  rounded: props.store['address']!.error,
+                  rounded: props.store['address']!.error
                 }}
               >
                 Please edit patient and add address

--- a/packages/elements/src/photon-multirx-form/components/PatientCard.tsx
+++ b/packages/elements/src/photon-multirx-form/components/PatientCard.tsx
@@ -58,11 +58,9 @@ export const PatientCard = (props: {
   });
 
   createEffect(() => {
-    if (store?.selectedPatient?.data) {
-      if (store?.selectedPatient?.data?.id !== props.store['patient']?.value?.id) {
-        // update patient when selected patient changes
-        updatePatient({ detail: { patient: store?.selectedPatient?.data } });
-      }
+    if (store?.selectedPatient?.data && props?.patientId) {
+      // update patient when passed-in patient (patientId) is fetched
+      updatePatient({ detail: { patient: store?.selectedPatient?.data } });
     }
   });
 

--- a/packages/elements/src/photon-patient-select/index.tsx
+++ b/packages/elements/src/photon-patient-select/index.tsx
@@ -60,7 +60,7 @@ customElement(
       if (store.selectedPatient.data) {
         return [
           store.selectedPatient.data,
-          ...store.patients.data.filter((x) => x.id !== store.selectedPatient.data!.id)
+          ...store.patients.data.filter((x) => x?.id !== store.selectedPatient.data!.id)
         ];
       } else {
         return store.patients.data;

--- a/packages/elements/src/utils.ts
+++ b/packages/elements/src/utils.ts
@@ -25,3 +25,10 @@ export const toTitleCase = (str: string) => {
 export const isZip = (zip: string) => {
   return /^\d+$/.test(zip) && zip.length >= 5;
 };
+
+// Takes a date string in the format 'YYYY-MM-DD'
+// and returns it in the format 'MM-DD-YYYY'.
+export const formatDate = (dateString: string) => {
+  const [year, month, day] = dateString.split('-');
+  return `${month}-${day}-${year}`;
+};


### PR DESCRIPTION
``` html
<photon-prescribe-workflow patient-id="pat_01GQ0XFBHSH3YXN936A2D2SD7Y"></photon-prescribe-workflow>
```

<img width="357" alt="Screen Shot 2023-05-01 at 5 36 52 PM" src="https://user-images.githubusercontent.com/700617/235535897-df85db5a-1f54-4e66-b4fc-3c3b2f54ef81.png">

Tests
- [x] only `patient-id` passed, should only show patient name but not address
- [x] `patient-id` and `enable-order`, should show patient name and address
- [x] `patient-id` and `address` passed, should only see patient name but not address
- [x] only `enable-order`, patient dropdown then show ability to edit address. should be able to select different patients and address should update, then editing patient address should update the address
- [x]  `patient-id` and `address` passed to patient that has address. the hard coded address should take precedence



closes #256 