### PR TITLE
Display Template Name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29819,7 +29819,7 @@
     },
     "packages/elements": {
       "name": "@photonhealth/elements",
-      "version": "0.0.99",
+      "version": "0.0.101",
       "license": "ISC",
       "dependencies": {
         "@photonhealth/components": "*",
@@ -30135,6 +30135,7 @@
       }
     },
     "packages/settings": {
+      "name": "@client/settings",
       "version": "0.0.1"
     }
   },

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@photonhealth/elements",
-  "version": "0.0.101",
+  "version": "0.0.102",
   "description": "",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/elements/src/photon-treatment-select/index.tsx
+++ b/packages/elements/src/photon-treatment-select/index.tsx
@@ -57,16 +57,11 @@ customElement(
 
     const getData = (filter: string): (Treatment | PrescriptionTemplate)[] => {
       if (store.catalogs.data.length > 0) {
-        const data = props.offCatalogOption
-          ? [
-              props.offCatalogOption as Treatment,
-              ...store.catalogs.data[0].templates.map((x) => x as PrescriptionTemplate),
-              ...store.catalogs.data[0].treatments.map((x) => x as Treatment)
-            ]
-          : [
-              ...store.catalogs.data[0].templates.map((x) => x as PrescriptionTemplate),
-              ...store.catalogs.data[0].treatments.map((x) => x as Treatment)
-            ];
+        const data = [
+          ...(props.offCatalogOption ? [props.offCatalogOption as Treatment] : []),
+          ...store.catalogs.data[0].templates.map((x) => x as PrescriptionTemplate),
+          ...store.catalogs.data[0].treatments.map((x) => x as Treatment)
+        ];
         if (filter.length === 0) {
           return data;
         }
@@ -94,24 +89,16 @@ customElement(
           groups={[
             {
               label: 'Off Catalog',
-              filter: (x: Treatment | PrescriptionTemplate) => {
-                if (!props.offCatalogOption) {
-                  return false;
-                }
-                return x.id === props.offCatalogOption?.id;
-              }
+              filter: (t: Treatment | PrescriptionTemplate) =>
+                props.offCatalogOption && t.id === props.offCatalogOption.id
             },
             {
               label: 'Templates',
-              filter: (x: Treatment | PrescriptionTemplate) => {
-                return x ? Object.keys(x).includes('treatment') : false;
-              }
+              filter: (t: Treatment | PrescriptionTemplate) => 'treatment' in t
             },
             {
               label: 'Catalog',
-              filter: (x: Treatment | PrescriptionTemplate) => {
-                return x ? Object.keys(x).includes('name') : false;
-              }
+              filter: (t: Treatment | PrescriptionTemplate) => 'name' in t && !('treatment' in t)
             }
           ]}
           label={props.label}
@@ -123,36 +110,31 @@ customElement(
           hasMore={false}
           selectedData={props.selected ?? (props.offCatalogOption as Treatment)}
           displayAccessor={(t: Treatment | PrescriptionTemplate, groupAccess: boolean) => {
-            return 'name' in t ? (
+            return 'name' in t && !('treatment' in t) ? (
               t.name
             ) : groupAccess ? (
               <>
                 <p class="overflow-hidden whitespace-nowrap overflow-ellipsis">
+                  {t?.name ? `${t.name}: ` : ''}
                   {t.treatment.name}
                 </p>
                 <p class="font-normal pl-4 overflow-hidden whitespace-nowrap overflow-ellipsis">
-                  QTY: {t.dispenseQuantity} {t.dispenseUnit}&nbsp;|&nbsp;Days Supply:&nbsp;
-                  {t.daysSupply}
-                  &nbsp;|&nbsp;Refills:{' '}
+                  QTY: {t.dispenseQuantity} {t.dispenseUnit} | Days Supply: {t.daysSupply} |{' '}
                   {/* A "-1" is needed here because in the UI we are displaying the number of refills, not fills. We get this from the templates in the catalog */}
-                  {t.fillsAllowed ? t.fillsAllowed - 1 : 0}&nbsp;|&nbsp;Sig: {t.instructions}
+                  Refills: {t.fillsAllowed ? t.fillsAllowed - 1 : 0} | Sig: {t.instructions}
                 </p>
               </>
             ) : (
               t.treatment.name
             );
           }}
-          onSearchChange={async (s: string) => {
-            setFilter(s);
-          }}
+          onSearchChange={async (s: string) => setFilter(s)}
           onOpen={async () => {
             if (store.catalogs.data.length === 0) {
               await actions.getCatalogs(client!.getSDK());
             }
           }}
-          onHide={async () => {
-            setFilter('');
-          }}
+          onHide={async () => setFilter('')}
           noDataMsg={
             store.catalogs.data.length === 0 && !store.catalogs.isLoading
               ? 'No catalog found'

--- a/packages/elements/src/photon-treatment-select/index.tsx
+++ b/packages/elements/src/photon-treatment-select/index.tsx
@@ -109,8 +109,8 @@ customElement(
           isLoading={client?.clinical.catalog.state.isLoading || false}
           hasMore={false}
           selectedData={props.selected ?? (props.offCatalogOption as Treatment)}
-          displayAccessor={(t: Treatment | PrescriptionTemplate, groupAccess: boolean) => {
-            return 'name' in t && !('treatment' in t) ? (
+          displayAccessor={(t: Treatment | PrescriptionTemplate, groupAccess: boolean) =>
+            t.__typename !== 'PrescriptionTemplate' ? (
               t.name
             ) : groupAccess ? (
               <>
@@ -126,8 +126,8 @@ customElement(
               </>
             ) : (
               t.treatment.name
-            );
-          }}
+            )
+          }
           onSearchChange={async (s: string) => setFilter(s)}
           onOpen={async () => {
             if (store.catalogs.data.length === 0) {

--- a/packages/elements/src/stores/catalog.ts
+++ b/packages/elements/src/stores/catalog.ts
@@ -13,6 +13,7 @@ const CATALOG_TREATMENTS_FIELDS = gql`
     }
     templates {
       id
+      name
       daysSupply
       dispenseAsWritten
       dispenseQuantity


### PR DESCRIPTION
Choosing to display the template name before the treatment name, my thinking is to me to lead with the disambiguation. 

<img width="564" alt="Screen Shot 2023-05-02 at 11 56 31 AM" src="https://user-images.githubusercontent.com/700617/235719955-1acbf262-33e4-4297-a7aa-937d98f9c77a.png">

Caveat:
When selected, we are passing around the treatment data, so when we display it in the selector or in Pending Prescriptions section it doesn't have access to the template data at the moment.
<img width="659" alt="Screen Shot 2023-05-02 at 11 58 34 AM" src="https://user-images.githubusercontent.com/700617/235720512-5c86f777-7806-442c-b75b-6e364a8ffa1c.png">
<img width="664" alt="Screen Shot 2023-05-02 at 11 59 02 AM" src="https://user-images.githubusercontent.com/700617/235720633-246680ad-dc22-4090-95cc-abcf0778b11a.png">
