### PR TITLE
Handle error if medication already added to catalog

### DIFF
--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@photonhealth/elements",
-  "version": "0.0.103",
+  "version": "0.0.104",
   "description": "",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/elements/src/photon-med-search-dialog/index.tsx
+++ b/packages/elements/src/photon-med-search-dialog/index.tsx
@@ -53,13 +53,17 @@ customElement(
             setLoading(true);
             if (addToCatalog()) {
               const addCatalogMutation = client!.getSDK().clinical.catalog.addToCatalog({});
-              await addCatalogMutation({
-                variables: {
-                  catalogId: catalogId(),
-                  treatmentId: medication()?.id
-                },
-                awaitRefetchQueries: false
-              });
+              try {
+                await addCatalogMutation({
+                  variables: {
+                    catalogId: catalogId(),
+                    treatmentId: medication()?.id
+                  },
+                  awaitRefetchQueries: false
+                });
+              } catch {
+                // do nothing, this is expected if medication exists in catalog
+              }
             }
             dispatchMedicationSelected();
             setLoading(false);

--- a/packages/elements/src/photon-med-search-dialog/index.tsx
+++ b/packages/elements/src/photon-med-search-dialog/index.tsx
@@ -61,8 +61,8 @@ customElement(
                   },
                   awaitRefetchQueries: false
                 });
-              } catch {
-                // do nothing, this is expected if medication exists in catalog
+              } catch (e) {
+                console.log('Error adding to catalog: ', e?.message);
               }
             }
             dispatchMedicationSelected();


### PR DESCRIPTION
If you re add a medication to the catalog that already exists it throws an error. This handles it silently.
