### PR TITLE
r.at (🐀) is not a function

### DIFF
--- a/apps/app/src/views/components/NameView.tsx
+++ b/apps/app/src/views/components/NameView.tsx
@@ -12,7 +12,7 @@ const NameView = (props: NameViewProps) => {
   const { name, sub, isPatient, patientId } = props;
   return (
     <HStack spacing="3">
-      <Avatar name={name} src="" boxSize="10" />
+      <Avatar name={typeof name === 'string' ? name : ''} src="" boxSize="10" />
       <Box>
         {isPatient ? (
           <Button

--- a/apps/app/src/views/components/Nav.tsx
+++ b/apps/app/src/views/components/Nav.tsx
@@ -56,7 +56,11 @@ export const Nav = () => {
                 <NavButton label="" icon={FiHelpCircle} link="/support" />
               </ButtonGroup>
               <Tooltip label={user?.name} aria-label={user?.name}>
-                <Avatar name={user?.name} src={user?.image} boxSize="10" />
+                <Avatar
+                  name={typeof user?.name === 'string' ? user.name : ''}
+                  src={typeof user?.image === 'string' ? user.image : ''}
+                  boxSize="10"
+                />
               </Tooltip>
             </HStack>
           ) : (

--- a/apps/app/src/views/components/PharmacyNameView.tsx
+++ b/apps/app/src/views/components/PharmacyNameView.tsx
@@ -19,7 +19,7 @@ const PharmacyNameView = (props: PharmacyNameViewProps) => {
   const { name, phone, address } = props;
   return (
     <HStack spacing="3">
-      <Avatar name={name} src="" boxSize="10" />
+      <Avatar name={typeof name === 'string' ? name : ''} src="" boxSize="10" />
       <Box>
         <Text fontWeight="medium" color="black">
           {name}

--- a/apps/app/src/views/components/UserProfile.tsx
+++ b/apps/app/src/views/components/UserProfile.tsx
@@ -7,7 +7,11 @@ export const UserProfile = () => {
 
   return (
     <HStack spacing="3" ps="2">
-      <Avatar name={user?.name} src={user?.image} boxSize="10" />
+      <Avatar
+        name={typeof user?.name === 'string' ? user.name : ''}
+        src={typeof user?.image === 'string' ? user.image : ''}
+        boxSize="10"
+      />
       <Box>
         <Text fontWeight="medium" fontSize="sm">
           {user?.name}


### PR DESCRIPTION
https://photon-health.sentry.io/issues/4052433134/?project=6641717&query=&referrer=issue-stream&statsPeriod=1h&stream_index=0

from the issue we can see `AvatarName` which is a Chakra component:
<img width="430" alt="Screen Shot 2023-05-03 at 5 11 52 PM" src="https://user-images.githubusercontent.com/700617/236050922-327288f4-45b5-4012-8951-93ed777f4a9d.png">
https://github.com/chakra-ui/chakra-ui/blob/997e3083f282f73c8a85bb1e612e1062f1f6d715/packages/components/avatar/src/avatar-name.tsx


The logging in grabbing the initials is:

```
const names = name.split(" ")
const firstName = names.at(0) ?? ""
```

I'm not sure what would not error on  `.split` but fails on `.at`
