### PR TITLE
Fix Calculator Layout

### DIFF
--- a/packages/elements/index.html
+++ b/packages/elements/index.html
@@ -16,8 +16,6 @@
       audience="https://api.boson.health"
       uri="https://api.boson.health/graphql"
     >
-      <photon-audit></photon-audit>
-      <photon-pharmacy-search></photon-pharmacy-search>
       <!-- <photon-dialog
         id="photon-modal"
         label="Send Prescription"
@@ -37,11 +35,11 @@
       <!-- <photon-multirx-form-wrapper hide-templates="false" /> -->
 
       <!-- To test the prescribe component only run this - idk who uses this but template creation doesnt work here so the add to templates option is hidden by default -->
-      <!-- <photon-prescribe-workflow
+      <div>
+        <photon-prescribe-workflow
           patient-id="pat_01G8VFW0X44YCW8KW7FW3FC0ZT"
-          template-ids="tmp_01GHEYTMGWZZV3TDMYWR2ZW0ZB,tmp_01GHEYV0YCZVJW34253HKMY042"
-        ></photon-prescribe-workflow> -->
-      <pharmacy-search></pharmacy-search>
+        ></photon-prescribe-workflow>
+      </div>
       <!-- <photon-patient-dialog
         open="true"
         patient-id="pat_01G8VFW0X44YCW8KW7FW3FC0ZT"

--- a/packages/elements/src/photon-multirx-form/components/AddPrescriptionCard.tsx
+++ b/packages/elements/src/photon-multirx-form/components/AddPrescriptionCard.tsx
@@ -135,7 +135,7 @@ export const AddPrescriptionCard = (props: {
           ></photon-datepicker>
         </div>
         <div class="mt-2 sm:mt-0 sm:grid sm:grid-cols-2 sm:gap-4">
-          <div class="flex items-end gap-1">
+          <div>
             <photon-number-input
               class="flex-grow flex-1 w-2/5 sm:w-auto"
               label="Quantity"

--- a/packages/elements/src/photon-multirx-form/components/AddPrescriptionCard.tsx
+++ b/packages/elements/src/photon-multirx-form/components/AddPrescriptionCard.tsx
@@ -135,7 +135,7 @@ export const AddPrescriptionCard = (props: {
           ></photon-datepicker>
         </div>
         <div class="mt-2 sm:mt-0 sm:grid sm:grid-cols-2 sm:gap-4">
-          <div>
+          <div class="flex items-end gap-1">
             <photon-number-input
               class="flex-grow flex-1 w-2/5 sm:w-auto"
               label="Quantity"
@@ -150,6 +150,7 @@ export const AddPrescriptionCard = (props: {
                   value: Number(e.detail.input)
                 });
               }}
+              style="width:100px"
             ></photon-number-input>
             <photon-dosage-calculator-dialog
               ref={dosageCalculatorRef}


### PR DESCRIPTION
Layout in a container on desktop breaks:
![image](https://github.com/Photon-Health/client/assets/700617/e5d8a5b1-0664-47f3-bbeb-00a059b638e1)

Unfortunately Shoelace is applying some baffling styles that makes it hard to fix this. Worked on it for over an hour but no luck, so fell back to the previous working (but not ideal) layout for now.

<img width="503" alt="Screen Shot 2023-05-15 at 10 57 22 AM" src="https://github.com/Photon-Health/client/assets/700617/a0a7d2e9-3b05-4ce7-8908-58e49ae3759e">

closes #300 