### PR TITLE
Add state tooltips to prescription page

### DIFF
--- a/apps/app/src/views/routes/Prescription.tsx
+++ b/apps/app/src/views/routes/Prescription.tsx
@@ -17,6 +17,7 @@ import {
   Td,
   Tr,
   Text,
+  Tooltip,
   VStack,
   Skeleton,
   SkeletonCircle,
@@ -32,7 +33,12 @@ import { gql, GraphQLClient } from 'graphql-request';
 
 import { formatDate } from '../../utils';
 
-import { PRESCRIPTION_COLOR_MAP, PRESCRIPTION_STATE_MAP } from './Prescriptions';
+import {
+  PRESCRIPTION_COLOR_MAP,
+  PRESCRIPTION_STATE_MAP,
+  PRESCRIPTION_TIP_MAP,
+  PrescriptionStateRecord
+} from './Prescriptions';
 
 import { Page } from '../components/Page';
 import { confirmWrapper } from '../components/GuardDialog';
@@ -91,8 +97,9 @@ export const Prescription = () => {
     instructions
   } = rx;
 
-  const state = PRESCRIPTION_STATE_MAP[rx.state as keyof object] || '';
-  const stateColor = PRESCRIPTION_COLOR_MAP[rx.state as keyof object] || '';
+  const state = PRESCRIPTION_STATE_MAP[rx.state as keyof PrescriptionStateRecord] || '';
+  const stateColor = PRESCRIPTION_COLOR_MAP[rx.state as keyof PrescriptionStateRecord] || '';
+  const stateTip = PRESCRIPTION_TIP_MAP[rx.state as keyof PrescriptionStateRecord] || '';
 
   const writtenAt = formatDate(rx.writtenAt);
   const effectiveDate = formatDate(rx.effectiveDate);
@@ -244,7 +251,9 @@ export const Prescription = () => {
                       ms={isMobile ? 'auto' : undefined}
                     />
                   ) : (
-                    <Badge colorScheme={stateColor}>{state}</Badge>
+                    <Tooltip label={stateTip}>
+                      <Badge colorScheme={stateColor}>{state}</Badge>
+                    </Tooltip>
                   )}
                 </Td>
               </Tr>

--- a/apps/app/src/views/routes/Prescriptions.tsx
+++ b/apps/app/src/views/routes/Prescriptions.tsx
@@ -73,7 +73,7 @@ type PrescriptionState =
   | 'EXPIRED'
   | 'CANCELED'
   | 'ERROR';
-type PrescriptionStateRecord = Record<PrescriptionState, string>;
+export type PrescriptionStateRecord = Record<PrescriptionState, string>;
 
 export const PRESCRIPTION_STATE_MAP: PrescriptionStateRecord = {
   READY: 'Active',

--- a/apps/app/src/views/routes/Prescriptions.tsx
+++ b/apps/app/src/views/routes/Prescriptions.tsx
@@ -98,9 +98,9 @@ export const PRESCRIPTION_COLOR_MAP: PrescriptionStateRecord = {
 export const PRESCRIPTION_TIP_MAP: PrescriptionStateRecord = {
   READY: 'Prescription has active fills',
   PROCESSING: 'Prescription has active fills',
-  ACTIVE: 'Prescription has active fills',
-  DEPLETED: 'All fills depleted',
-  EXPIRED: 'Prescription has expired',
+  ACTIVE: 'Prescription has unused fills',
+  DEPLETED: 'All fills have been sent to a pharmacy',
+  EXPIRED: 'All fills have passed prescription expiration date',
   CANCELED: 'Prescription has been cancelled',
   ERROR: 'There’s an error with prescription'
 };


### PR DESCRIPTION
Surface the same state description tooltips from prescriptions list on single prescription view

<img width="250" alt="image" src="https://github.com/Photon-Health/client/assets/3934326/bbde6644-072d-4ee7-b341-8860f9834bdf">
