### PR TITLE
NPM publish Github Action, attempt #2

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -12,6 +12,9 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
+        with:
+          ref: boson
+          fetch-depth: 0
 
       - name: Set up Node.js
         uses: actions/setup-node@v3
@@ -25,7 +28,6 @@ jobs:
       - name: Check for version updates
         id: check
         run: |
-          git fetch
           PACKAGES=""
           for file in $(git diff --name-only HEAD~1...HEAD | grep '/package.json' | grep '/packages/'); do
             if git diff HEAD~1...HEAD -- $file | grep '\"version\"'; then

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@photonhealth/react",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "main": "dist/react.cjs.js",
   "scripts": {
     "build": "npx nx run react:build",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@photonhealth/sdk",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "main": "dist/lib.js",
   "scripts": {
     "build": "npx nx run sdk:build",


### PR DESCRIPTION
On the Check for Version Updates step I'm getting this error:

```
fatal: ambiguous argument 'HEAD~1...HEAD': unknown revision or path not in the working tree.
```
https://github.com/Photon-Health/client/actions/runs/5080824016/jobs/9128324098

this attempts to make sure that boson is checked out and setting fetch-depth to 0 makes actions/checkout grab more than just the latest commit.