### PR TITLE
Add Git name and email for NPM Publish action

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -25,6 +25,11 @@ jobs:
       - name: Install Dependencies
         run: npm ci
 
+      - name: Set Git User
+        run: |
+          git config --global user.name "Photon Health"
+          git config --global user.email "hello@photon.health"
+
       - name: Check for version updates
         id: check
         run: |

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -27,8 +27,8 @@ jobs:
 
       - name: Set Git User
         run: |
-          git config --global user.name "Photon Health"
-          git config --global user.email "hello@photon.health"
+          git config --global user.name "${{ github.actor }}"
+          git config --global user.email "${{ github.actor }}@users.noreply.github.com"
 
       - name: Check for version updates
         id: check

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@photonhealth/react",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "main": "dist/react.cjs.js",
   "scripts": {
     "build": "npx nx run react:build",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@photonhealth/sdk",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "main": "dist/lib.js",
   "scripts": {
     "build": "npx nx run sdk:build",


### PR DESCRIPTION
Had some success, npm package got published, but the tag failed:
```
Creating GitHub release for packages/react...
Committer identity unknown

*** Please tell me who you are.

Run

  git config --global user.email "you@example.com"
  git config --global user.name "Your Name"

to set your account's default identity.
Omit --global to set the identity only in this repository.

fatal: empty ident name (for <runner@fv-az1259-722.igmqbu2b14eejbj4jfxtszghqh.cx.internal.cloudapp.net>) not allowed
Error: Process completed with exit code 128.
```
https://github.com/Photon-Health/client/actions/runs/5081929140/jobs/9130973665