### PR TITLE
SDK ground work

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@photonhealth/react",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "main": "dist/react.cjs.js",
   "scripts": {
     "build": "npx nx run react:build",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@photonhealth/sdk",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "main": "dist/lib.js",
   "scripts": {
     "build": "npx nx run sdk:build",

--- a/packages/sdk/src/lib.ts
+++ b/packages/sdk/src/lib.ts
@@ -1,5 +1,5 @@
 import { Auth0Client } from '@auth0/auth0-spa-js';
-import { ApolloClient, InMemoryCache, HttpLink } from '@apollo/client';
+import { ApolloClient, InMemoryCache, HttpLink, NormalizedCacheObject } from '@apollo/client';
 import { setContext } from '@apollo/client/link/context/index.js';
 import { AuthManager } from './auth';
 import { ClinicalQueryManager } from './clinical';
@@ -52,6 +52,11 @@ export class PhotonClient {
   public management: ManagementQueryManager;
 
   /**
+   * Apollo client instance
+   */
+  public apollo: ApolloClient<undefined> | ApolloClient<NormalizedCacheObject>;
+
+  /**
    * Constructs a new PhotonSDK instance
    * @param config - Photon SDK configuration options
    * @remarks - Note, that organization is optional for scenarios in which a provider supports more than themselves.
@@ -83,9 +88,10 @@ export class PhotonClient {
       organization: this.organization,
       audience: this.audience
     });
-    const apollo = this.constructApolloClient();
-    this.clinical = new ClinicalQueryManager(apollo);
-    this.management = new ManagementQueryManager(apollo);
+
+    this.apollo = this.constructApolloClient();
+    this.clinical = new ClinicalQueryManager(this.apollo);
+    this.management = new ManagementQueryManager(this.apollo);
   }
 
   private constructApolloClient() {
@@ -111,7 +117,7 @@ export class PhotonClient {
       ),
       defaultOptions: {
         query: {
-          fetchPolicy: 'network-only',
+          fetchPolicy: 'cache-first',
           errorPolicy: 'all'
         }
       },

--- a/packages/sdk/src/utils.ts
+++ b/packages/sdk/src/utils.ts
@@ -22,7 +22,7 @@ export async function makeQuery<T = any>(
   apollo: ApolloClient<undefined> | ApolloClient<NormalizedCacheObject>,
   query: DocumentNode,
   variables: object = {},
-  fetchPolicy?: FetchPolicy
+  fetchPolicy: FetchPolicy = 'network-only'
 ): Promise<MakeQueryReturn<T>> {
   const result = await apollo.query({
     query,


### PR DESCRIPTION
- change Apollo's global fetch policy to `cache-first`
- `makeQuery`'s fetch policy will now default to `network-only` so that the existing methods fetch & store data as before
- expose apollo client

My thinking is that I'll use Apollo's query and mutations directly when building the pharmacy select feature. 