### PR TITLE
Fix peachy sending to patient

### DIFF
--- a/apps/app/src/views/routes/NewOrder/components/OrderForm.tsx
+++ b/apps/app/src/views/routes/NewOrder/components/OrderForm.tsx
@@ -5,7 +5,7 @@ import { useState } from 'react';
 
 import { Alert, AlertIcon, ModalCloseButton, useColorMode, VStack } from '@chakra-ui/react';
 
-import { types } from '@photonhealth/react';
+import { types } from 'packages/sdk';
 import { getSettings } from '@client/settings';
 
 import { confirmWrapper } from '../../../components/GuardDialog';
@@ -126,17 +126,24 @@ const initOrder = (
   if (!sendToPatientEnabled && (orgSettings.pickUp || orgSettings.mailOrder)) {
     const preferredPharmacy = patient?.preferredPharmacies?.[0];
 
+    const enabledFulfillmentTypes: FulfillmentOrEmpty[] = fulfillmentOptions
+      .filter((option) => option.enabled && option.fulfillmentType)
+      .map((option) => option.fulfillmentType);
+
     if (preferredPharmacy) {
       // If preferred pharmacy has an enabled fulfillment type, make that the initial tab
-      const enabledTypes: FulfillmentOrEmpty[] = fulfillmentOptions
-        .filter((option) => option.enabled && option.fulfillmentType)
-        .map((option) => option.fulfillmentType);
-      const pharmacyTypes = preferredPharmacy?.fulfillmentTypes || [];
-      initialFulfillmentType = pharmacyTypes.find((type) => enabledTypes.includes(type)) || '';
+      const preferedPharmacyFulfillmentTypes = preferredPharmacy?.fulfillmentTypes || [];
+      const preferredTypeIsEnabled = preferedPharmacyFulfillmentTypes.find((type) =>
+        enabledFulfillmentTypes.includes(type)
+      );
 
-      if (initialFulfillmentType) {
+      if (preferredTypeIsEnabled) {
+        initialFulfillmentType = preferedPharmacyFulfillmentTypes[0];
         initialPharmacyId = preferredPharmacy.id;
       }
+    }
+    if (!initialFulfillmentType) {
+      initialFulfillmentType = enabledFulfillmentTypes[0];
     }
   }
 

--- a/apps/app/src/views/routes/NewOrder/components/OrderForm.tsx
+++ b/apps/app/src/views/routes/NewOrder/components/OrderForm.tsx
@@ -5,7 +5,7 @@ import { useState } from 'react';
 
 import { Alert, AlertIcon, ModalCloseButton, useColorMode, VStack } from '@chakra-ui/react';
 
-import { types } from 'packages/sdk';
+import { types } from '@photonhealth/react';
 import { getSettings } from '@client/settings';
 
 import { confirmWrapper } from '../../../components/GuardDialog';

--- a/apps/app/src/views/routes/NewOrder/components/SelectPharmacyCard/components/MailOrder.tsx
+++ b/apps/app/src/views/routes/NewOrder/components/SelectPharmacyCard/components/MailOrder.tsx
@@ -72,7 +72,6 @@ export const MailOrder = ({
   return (
     <FormControl isInvalid={!!errors.pharmacyId && touched.pharmacyId}>
       <Text>Contact support to add additional mail order integrations.</Text>
-      {errors ? <FormErrorMessage>Please select a pharmacy...</FormErrorMessage> : null}
       {pharmOptions.map(({ id }: { id: string }) => (
         <Box
           mt={4}
@@ -97,6 +96,7 @@ export const MailOrder = ({
           </HStack>
         </Box>
       ))}
+      {errors ? <FormErrorMessage>Please select a pharmacy...</FormErrorMessage> : null}
     </FormControl>
   );
 };


### PR DESCRIPTION
Closes #352 

Initial fulfillment type was not getting set when only mail order is enabled, this fixes that.
Tested with all variations of enabled types.