### PR TITLE
Add tracking number to status view

### DIFF
--- a/apps/patient/package.json
+++ b/apps/patient/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@photonhealth/react": "^1.0.13",
+    "@photonhealth/sdk": "*",
     "chakra-react-select": "^4.6.0",
     "dayjs": "^1.11.7",
     "react-helmet": "^6.1.0",

--- a/apps/patient/src/utils/queries.ts
+++ b/apps/patient/src/utils/queries.ts
@@ -20,6 +20,7 @@ export const GET_ORDER = gql`
       fulfillment {
         type
         state
+        trackingNumber
       }
       pharmacy {
         id

--- a/apps/patient/src/utils/text.json
+++ b/apps/patient/src/utils/text.json
@@ -113,6 +113,7 @@
       }
     },
     "MAIL_ORDER": {
+      "trackingNumber": "Tracking #:",
       "states": {
         "SENT": {
           "title": "Sent",

--- a/apps/patient/src/views/Main.tsx
+++ b/apps/patient/src/views/Main.tsx
@@ -8,7 +8,7 @@ import { GET_ORDER } from '../utils/queries';
 import { graphQLClient } from '../configs/graphqlClient';
 
 import theme from '../configs/theme';
-import { types } from '@photonhealth/react';
+import { types } from '@photonhealth/sdk';
 
 const AUTH_HEADER_ERRORS = ['EMPTY_AUTHORIZATION_HEADER', 'INVALID_AUTHORIZATION_HEADER'];
 

--- a/apps/patient/src/views/Status.tsx
+++ b/apps/patient/src/views/Status.tsx
@@ -147,7 +147,7 @@ export const Status = () => {
                 {t.status.MAIL_ORDER.trackingNumber}
               </Text>
               <Text display="inline" ms={2}>
-                asdfasfafdsfafsadfsaf
+                {fulfillment.trackingNumber}
               </Text>
             </Box>
           ) : null}

--- a/apps/patient/src/views/Status.tsx
+++ b/apps/patient/src/views/Status.tsx
@@ -14,7 +14,7 @@ import {
 import { Helmet } from 'react-helmet';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { FiCheck, FiMapPin } from 'react-icons/fi';
-import { types } from '@photonhealth/react';
+import { types } from '@photonhealth/sdk';
 
 import { formatAddress, getFulfillmentType } from '../utils/general';
 import { Order } from '../utils/models';
@@ -141,7 +141,17 @@ export const Status = () => {
               </Alert>
             ) : null}
           </VStack>
-          {fulfillmentType !== ('MAIL_ORDER' || 'COURIER') &&
+          {fulfillmentType === types.FulfillmentType.MailOrder && pharmacy?.name ? (
+            <Box alignSelf="start">
+              <Text display="inline" color="gray.500">
+                {t.status.MAIL_ORDER.trackingNumber}
+              </Text>
+              <Text display="inline" ms={2}>
+                asdfasfafdsfafsadfsaf
+              </Text>
+            </Box>
+          ) : null}
+          {fulfillmentType !== (types.FulfillmentType.MailOrder || 'COURIER') &&
           pharmacy?.name &&
           pharmacy?.address ? (
             <Box alignSelf="start">

--- a/package-lock.json
+++ b/package-lock.json
@@ -146,7 +146,7 @@
     "apps/patient": {
       "version": "0.1.0",
       "dependencies": {
-        "@photonhealth/react": "^1.0.13",
+        "@photonhealth/sdk": "*",
         "chakra-react-select": "^4.6.0",
         "dayjs": "^1.11.7",
         "react-helmet": "^6.1.0",
@@ -31508,7 +31508,7 @@
     },
     "packages/elements": {
       "name": "@photonhealth/elements",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "ISC",
       "dependencies": {
         "@photonhealth/components": "*",
@@ -47062,7 +47062,7 @@
     "patient": {
       "version": "file:apps/patient",
       "requires": {
-        "@photonhealth/react": "^1.0.13",
+        "@photonhealth/sdk": "*",
         "chakra-react-select": "^4.6.0",
         "dayjs": "^1.11.7",
         "react-helmet": "^6.1.0",


### PR DESCRIPTION
Patients are requesting their mail order tracking number for more detail into shipping.
Another callout is that our status view was confusing in the case of a [Peachy customer](https://photonhealth.slack.com/archives/C033T9N949M/p1687178532885219), need to look into what sort of UX improvements can be done here.