### PR TITLE
Fix nav help-link going to email not sms

### DIFF
--- a/apps/patient/src/components/Nav.tsx
+++ b/apps/patient/src/components/Nav.tsx
@@ -21,6 +21,8 @@ import { getSettings } from '@client/settings';
 
 const settings = getSettings(process.env.REACT_APP_ENV_NAME);
 
+const PHOTON_PHONE_NUMBER = '+15138663212';
+
 interface NavProps {
   header: string;
   showRefresh: boolean;
@@ -91,7 +93,7 @@ export const Nav = ({ header, showRefresh, orgId }: NavProps) => {
             />
             <MenuList>
               <MenuItem>
-                <Link href="sms:+15138663212" style={{ textDecoration: 'none' }}>
+                <Link href={`sms:${PHOTON_PHONE_NUMBER}`} style={{ textDecoration: 'none' }}>
                   {t.contactSupport}
                 </Link>
               </MenuItem>

--- a/apps/patient/src/components/Nav.tsx
+++ b/apps/patient/src/components/Nav.tsx
@@ -91,7 +91,7 @@ export const Nav = ({ header, showRefresh, orgId }: NavProps) => {
             />
             <MenuList>
               <MenuItem>
-                <Link href="mailto:support@photon.health" style={{ textDecoration: 'none' }}>
+                <Link href="sms:+15138663212" style={{ textDecoration: 'none' }}>
                   {t.contactSupport}
                 </Link>
               </MenuItem>


### PR DESCRIPTION
Closes [issue](https://www.notion.so/photons/Help-link-opens-email-instead-of-sms-743b6cc1b27041c9b9adf5ec049b7061?pvs=4)