### PR TITLE
Closing Dialog Submits Form

### DIFF
--- a/packages/elements/src/photon-dialog/index.tsx
+++ b/packages/elements/src/photon-dialog/index.tsx
@@ -12,7 +12,8 @@ import shoelaceLightStyles from '@shoelace-style/shoelace/dist/themes/light.css?
 import shoelaceDarkStyles from '@shoelace-style/shoelace/dist/themes/dark.css?inline';
 import styles from './style.css?inline';
 import { Show } from 'solid-js';
-// import styles from "./style.css?inline";
+
+type Proceed = 'photon-dialog-confirmed' | 'photon-dialog-alt' | 'photon-dialog-canceled';
 
 customElement(
   'photon-dialog',
@@ -44,15 +45,12 @@ customElement(
   }) => {
     let ref: any;
 
-    const dispatchDecision = (proceed: boolean) => {
-      const event = new CustomEvent(
-        proceed ? 'photon-dialog-confirmed' : 'photon-dialog-canceled',
-        {
-          composed: true,
-          bubbles: true,
-          detail: {}
-        }
-      );
+    const dispatchDecision = (proceed: Proceed) => {
+      const event = new CustomEvent(proceed, {
+        composed: true,
+        bubbles: true,
+        detail: {}
+      });
       ref?.dispatchEvent(event);
     };
 
@@ -79,7 +77,7 @@ customElement(
             } else if (e.detail.source === 'keyboard') {
               e.preventDefault();
             } else {
-              dispatchDecision(false);
+              dispatchDecision('photon-dialog-canceled');
             }
           }}
         >
@@ -102,7 +100,7 @@ customElement(
               variant="outline"
               disabled={props.disableButtons || props.loading}
               on:photon-clicked={() => {
-                dispatchDecision(false);
+                dispatchDecision('photon-dialog-alt');
               }}
             >
               {props.cancelText}
@@ -111,7 +109,7 @@ customElement(
               disabled={props.disableButtons || props.disableSubmit}
               loading={props.loading}
               on:photon-clicked={() => {
-                dispatchDecision(true);
+                dispatchDecision('photon-dialog-confirmed');
               }}
             >
               {props.confirmText}

--- a/packages/elements/src/photon-form-wrapper/index.tsx
+++ b/packages/elements/src/photon-form-wrapper/index.tsx
@@ -24,6 +24,12 @@ const PhotonFormWrapper = (p: PhotonFormWrapperProps) => {
   let ref: any;
   const [closeDialogOpen, onCloseDialogOpen] = createSignal<boolean>(false);
 
+  const handleConfirm = () => {
+    onCloseDialogOpen(false);
+    props.onClosed();
+  };
+  const handleCancel = () => onCloseDialogOpen(false);
+
   return (
     <div ref={ref} class="fixed top-0 left-0 w-full h-screen z-10 overflow-y-scroll">
       <style>{tailwind}</style>
@@ -34,13 +40,9 @@ const PhotonFormWrapper = (p: PhotonFormWrapperProps) => {
         open={closeDialogOpen()}
         confirm-text="Yes, Close"
         cancel-text="Keep Editing"
-        on:photon-dialog-confirmed={() => {
-          onCloseDialogOpen(false);
-          props.onClosed();
-        }}
-        on:photon-dialog-canceled={() => {
-          onCloseDialogOpen(false);
-        }}
+        on:photon-dialog-confirmed={handleConfirm}
+        on:photon-dialog-canceled={handleCancel}
+        on:photon-dialog-alt={handleCancel}
       >
         <p class="font-sans text-lg xs:text-base">{props.closeBody}</p>
       </photon-dialog>

--- a/packages/elements/src/photon-med-search-dialog/index.tsx
+++ b/packages/elements/src/photon-med-search-dialog/index.tsx
@@ -33,6 +33,30 @@ customElement(
       ref?.dispatchEvent(event);
     };
 
+    const handleConfirm = async () => {
+      setLoading(true);
+      if (addToCatalog()) {
+        const addCatalogMutation = client!.getSDK().clinical.catalog.addToCatalog({});
+        try {
+          await addCatalogMutation({
+            variables: {
+              catalogId: catalogId(),
+              treatmentId: medication()?.id
+            },
+            awaitRefetchQueries: false
+          });
+        } catch (e: any) {
+          console.log('Error adding to catalog: ', e?.message);
+        }
+      }
+      dispatchMedicationSelected();
+      setLoading(false);
+      props.open = false;
+    };
+    const handleCancel = () => {
+      props.open = false;
+    };
+
     return (
       <div
         ref={ref}
@@ -48,29 +72,9 @@ customElement(
           cancel-text="Back"
           confirm-text="Select Medication"
           disable-submit={!medication()}
-          on:photon-dialog-confirmed={async () => {
-            setLoading(true);
-            if (addToCatalog()) {
-              const addCatalogMutation = client!.getSDK().clinical.catalog.addToCatalog({});
-              try {
-                await addCatalogMutation({
-                  variables: {
-                    catalogId: catalogId(),
-                    treatmentId: medication()?.id
-                  },
-                  awaitRefetchQueries: false
-                });
-              } catch (e: any) {
-                console.log('Error adding to catalog: ', e?.message);
-              }
-            }
-            dispatchMedicationSelected();
-            setLoading(false);
-            props.open = false;
-          }}
-          on:photon-dialog-canceled={() => {
-            props.open = false;
-          }}
+          on:photon-dialog-confirmed={handleConfirm}
+          on:photon-dialog-canceled={handleCancel}
+          on:photon-dialog-alt={handleCancel}
         >
           <photon-med-search />
         </photon-dialog>

--- a/packages/elements/src/photon-multirx-form-wrapper/index.tsx
+++ b/packages/elements/src/photon-multirx-form-wrapper/index.tsx
@@ -164,6 +164,12 @@ customElement(
       }
     };
 
+    const handleUnsavedConfirm = () => {
+      setContinueSubmitOpen(false);
+      submitForm(form(), actions(), true);
+    };
+    const handleUnsavedCancel = () => setContinueSubmitOpen(false);
+
     return (
       <div ref={ref}>
         <photon-dialog
@@ -171,13 +177,9 @@ customElement(
           open={continueSubmitOpen()}
           confirm-text="Yes, Continue"
           cancel-text="Keep Editing"
-          on:photon-dialog-confirmed={() => {
-            setContinueSubmitOpen(false);
-            submitForm(form(), actions(), true);
-          }}
-          on:photon-dialog-canceled={() => {
-            setContinueSubmitOpen(false);
-          }}
+          on:photon-dialog-confirmed={handleUnsavedConfirm}
+          on:photon-dialog-canceled={handleUnsavedCancel}
+          on:photon-dialog-alt={handleUnsavedCancel}
           width="500px"
         >
           <p class="font-sans text-lg xs:text-base">
@@ -196,6 +198,9 @@ customElement(
             submitForm(form(), actions(), true);
           }}
           on:photon-dialog-canceled={() => {
+            setContinueSaveOnly(false);
+          }}
+          on:photon-dialog-alt={() => {
             setContinueSaveOnly(false);
             submitForm(form(), actions(), false);
           }}

--- a/packages/elements/src/photon-multirx-form/components/DraftPrescriptionCard.tsx
+++ b/packages/elements/src/photon-multirx-form/components/DraftPrescriptionCard.tsx
@@ -62,6 +62,28 @@ export const DraftPrescriptionCard = (props: {
     }
   };
 
+  const handleEditConfirm = () => {
+    editPrescription();
+    setEditDialogOpen(false);
+    setEditDraft(undefined);
+  };
+  const handleEditCancel = () => {
+    setEditDialogOpen(false);
+    setEditDraft(undefined);
+  };
+  const handleDeleteConfirm = () => {
+    props.actions.updateFormValue({
+      key: 'draftPrescriptions',
+      value: props.store['draftPrescriptions'].value.filter((x: any) => x.id !== deleteDraftId())
+    });
+    setDeleteDialogOpen(false);
+    setDeleteDraftId(undefined);
+  };
+  const handleDeleteCancel = () => {
+    setDeleteDialogOpen(false);
+    setDeleteDraftId(undefined);
+  };
+
   return (
     <photon-card>
       <photon-dialog
@@ -69,15 +91,9 @@ export const DraftPrescriptionCard = (props: {
         label="Overwrite in progress prescription?"
         confirm-text="Yes, Overwrite"
         cancel-text="No, Cancel"
-        on:photon-dialog-confirmed={() => {
-          editPrescription();
-          setEditDialogOpen(false);
-          setEditDraft(undefined);
-        }}
-        on:photon-dialog-canceled={() => {
-          setEditDialogOpen(false);
-          setEditDraft(undefined);
-        }}
+        on:photon-dialog-confirmed={handleEditConfirm}
+        on:photon-dialog-canceled={handleEditCancel}
+        on:photon-dialog-alt={handleEditCancel}
       >
         <p class="font-sans text-lg xs:text-base">
           You are editing a prescription that has not been added. This will be overwritten if you
@@ -89,20 +105,9 @@ export const DraftPrescriptionCard = (props: {
         label="Delete pending prescription?"
         confirm-text="Yes, Delete"
         cancel-text="No, Cancel"
-        on:photon-dialog-confirmed={() => {
-          props.actions.updateFormValue({
-            key: 'draftPrescriptions',
-            value: props.store['draftPrescriptions'].value.filter(
-              (x: any) => x.id !== deleteDraftId()
-            )
-          });
-          setDeleteDialogOpen(false);
-          setDeleteDraftId(undefined);
-        }}
-        on:photon-dialog-canceled={() => {
-          setDeleteDialogOpen(false);
-          setDeleteDraftId(undefined);
-        }}
+        on:photon-dialog-confirmed={handleDeleteConfirm}
+        on:photon-dialog-canceled={handleDeleteCancel}
+        on:photon-dialog-alt={handleDeleteCancel}
       >
         <p class="font-sans text-lg xs:text-base">
           Deleting this prescription will remove it from your pending prescriptions. This action


### PR DESCRIPTION
https://www.notion.so/photons/Closing-Dialog-Submits-Form-0b7f529aacb642e39cc9e77866bddf12?pvs=4

Added a third type of event handler to our existing dialog element:

```
'photon-dialog-confirmed' | 'photon-dialog-alt' | 'photon-dialog-canceled'
```

in most cases `alt` and `canceled` are the same affect, but in the case of the dialog in the ticket above we want the alt button to  only create a subscription  and the X button to close the dialog.