### PR TITLE
Revert Dropdown Grouping

### DIFF
--- a/packages/elements/src/photon-dropdown/index.tsx
+++ b/packages/elements/src/photon-dropdown/index.tsx
@@ -371,7 +371,12 @@ export const PhotonDropdown = <T extends { id: string }>(props: {
                       >
                         {el.label}
                       </sl-menu-item>
-                      <For each={virtualizer().getVirtualItems()} fallback={<div>Loading...</div>}>
+                      <For
+                        each={virtualizer()
+                          .getVirtualItems()
+                          .filter((vr) => el.filter(props.data[vr.index]))}
+                        fallback={<div>Loading...</div>}
+                      >
                         {(vr: any) => {
                           const isLoaderRow = vr.index > props.data.length - 1;
                           const datum = props.data[vr.index];

--- a/packages/elements/src/photon-dropdown/index.tsx
+++ b/packages/elements/src/photon-dropdown/index.tsx
@@ -375,7 +375,6 @@ export const PhotonDropdown = <T extends { id: string }>(props: {
                         each={virtualizer()
                           .getVirtualItems()
                           .filter((vr) => el.filter(props.data[vr.index]))}
-                        fallback={<div>Loading...</div>}
                       >
                         {(vr: any) => {
                           const isLoaderRow = vr.index > props.data.length - 1;


### PR DESCRIPTION
Resulting from this [update](https://github.com/Photon-Health/client/commit/afa79f76441b0123f56fa48ba9d148b174a0f39d) when I was updating lint action for repo, somehow this filter got dropped.

https://www.notion.so/photons/Medication-Dropdown-Grouping-fedfe8903df7468f9dcb8c50ea796598?pvs=4