### PR TITLE
Unset Pharmacy ID for "Send to Patient" Tab

### DIFF
--- a/packages/components/src/systems/PharmacySelect/index.tsx
+++ b/packages/components/src/systems/PharmacySelect/index.tsx
@@ -102,6 +102,9 @@ export default function PharmacySelect(props: PharmacySelectProps) {
                   if (props.setPatientId) {
                     props.setPatientId(patientId);
                   }
+                  if (props.setPharmacyId) {
+                    props.setPharmacyId(undefined);
+                  }
                 }}
               >
                 <For each={props?.patientIds || []}>
@@ -130,6 +133,7 @@ export default function PharmacySelect(props: PharmacySelectProps) {
         {tab() === 'Mail Order' && (
           <RadioGroup
             label="Pharmacies"
+            initSelected={props?.mailOrderPharmacyIds?.[0]}
             setSelected={(pharmacyId) => props.setPharmacyId(pharmacyId)}
           >
             <For each={props?.mailOrderPharmacyIds || []}>

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@photonhealth/elements",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
Switching from send to patient to local pharmacy sets the pharmacy id. Then, when you switch back it was not being unset. 