### PR TITLE
Add and Edit Template Names In App

### DIFF
--- a/apps/app/src/model/fragments.ts
+++ b/apps/app/src/model/fragments.ts
@@ -7,6 +7,7 @@ export const CATALOG_TREATMENTS_FIELDS = gql`
       name
     }
     templates {
+      name
       id
       daysSupply
       dispenseAsWritten

--- a/apps/app/src/views/routes/Settings/components/TemplateForm/index.tsx
+++ b/apps/app/src/views/routes/Settings/components/TemplateForm/index.tsx
@@ -9,10 +9,11 @@ import {
   ModalFooter,
   Textarea,
   Heading,
-  useToast
+  useToast,
+  Input
 } from '@chakra-ui/react';
 
-import { RefObject, useEffect, useState } from 'react';
+import { ChangeEvent, RefObject, useEffect, useState } from 'react';
 import { Field, Formik } from 'formik';
 
 import { OptionalText } from '../../../../components/OptionalText';
@@ -93,6 +94,7 @@ export const TemplateForm = ({
     setSubmitting(true);
 
     const templateVariables: any = {
+      name: values.name || '',
       catalogId: catalogs.catalogs?.[0]?.id,
       daysSupply: values.daysSupply ? parseInt(values.daysSupply, 10) : 0,
       dispenseAsWritten: values.dispenseAsWritten,
@@ -127,6 +129,7 @@ export const TemplateForm = ({
       });
     } else {
       templateVariables.treatmentId = values.treatmentId;
+
       createRxTemplateMutation({
         variables: templateVariables,
         onCompleted: () => {
@@ -190,6 +193,21 @@ export const TemplateForm = ({
                 medicationSelectRef={medicationSelectRef}
                 catalogs={catalogs}
               />
+
+              <FormControl>
+                <FormLabel>
+                  Template Name
+                  <OptionalText />
+                </FormLabel>
+
+                <Input
+                  type="text"
+                  value={values.name}
+                  onChange={(val: ChangeEvent<HTMLInputElement>) =>
+                    setFieldValue('name', val.target.value)
+                  }
+                />
+              </FormControl>
 
               <FormControl>
                 <Field

--- a/apps/app/src/views/routes/Settings/components/TemplateForm/utils.ts
+++ b/apps/app/src/views/routes/Settings/components/TemplateForm/utils.ts
@@ -34,6 +34,7 @@ export const TEMPLATE_INITIAL_VALUES = {
     name: '',
     __typename: ''
   },
+  name: '',
   treatmentId: '',
   dispenseAsWritten: false,
   dispenseQuantity: 1,

--- a/apps/app/src/views/routes/Settings/views/TemplateTab.tsx
+++ b/apps/app/src/views/routes/Settings/views/TemplateTab.tsx
@@ -34,15 +34,22 @@ const renderTemplateRow = (
   setShowModal: any
 ) => {
   const med = rx.treatment;
-
+  const templateName = rx.name ? (
+    <>
+      <Text as="b" fontSize="md">
+        {rx.name}:
+      </Text>{' '}
+      {med.name}
+    </>
+  ) : (
+    med.name
+  );
   return {
     template: (
       <>
-        <Text as="b" fontWeight={500}>
-          {med.name}
-        </Text>
+        <Text fontSize="md">{templateName}</Text>
         <Box ps={4}>
-          <Text fontSize="sm" textOverflow="ellipsis" overflow="hidden">
+          <Text fontSize="sm" textOverflow="ellipsis" overflow="hidden" color="gray.500">
             QTY: {rx.dispenseQuantity} {rx.dispenseUnit}&nbsp;|&nbsp;Days Supply:&nbsp;
             {rx.daysSupply}
             {/* We need a -1 here becuause we are intentionally displaying Refills, not fills in the template UI */}

--- a/packages/sdk/src/clinical/prescriptionTemplate.ts
+++ b/packages/sdk/src/clinical/prescriptionTemplate.ts
@@ -49,7 +49,8 @@ export class PrescriptionTemplateQueryManager {
           $fillsAllowed: Int,
           $daysSupply: Int,
           $instructions: String,
-          $notes: String
+          $notes: String,
+          $name: String
         ) {
           createPrescriptionTemplate(
             catalogId: $catalogId
@@ -61,6 +62,7 @@ export class PrescriptionTemplateQueryManager {
             daysSupply: $daysSupply
             instructions: $instructions
             notes: $notes
+            name: $name
         ) {
             ...${fName}
         }
@@ -93,7 +95,8 @@ export class PrescriptionTemplateQueryManager {
           $fillsAllowed: Int,
           $daysSupply: Int,
           $instructions: String,
-          $notes: String
+          $notes: String,
+          $name: String
         ) {
           updatePrescriptionTemplate(
             catalogId: $catalogId
@@ -105,6 +108,7 @@ export class PrescriptionTemplateQueryManager {
             daysSupply: $daysSupply
             instructions: $instructions
             notes: $notes
+            name: $name
         ) {
             ...${fName}
         }


### PR DESCRIPTION
Cleaned up the template rows, highlight if it has a name.
<img width="791" alt="Screen Shot 2023-07-14 at 3 22 30 PM" src="https://github.com/Photon-Health/client/assets/700617/34166b06-f55d-4418-8c52-3e2fa0ed6f91">

Create and Edit Form now has a template name area:
<img width="341" alt="Screen Shot 2023-07-14 at 3 23 27 PM" src="https://github.com/Photon-Health/client/assets/700617/fe8b1f68-7578-4b9b-97f1-3a05f6066999">

https://www.notion.so/photons/Ability-to-add-and-update-template-names-1923639a26914fed8a7ffab0fa349526?pvs=4