### PR TITLE
Add Order table to page

### DIFF
--- a/apps/app/src/views/components/OrderStatusBadge.tsx
+++ b/apps/app/src/views/components/OrderStatusBadge.tsx
@@ -1,0 +1,109 @@
+import { Tag, TagLabel, TagLeftIcon, Tooltip } from '@chakra-ui/react';
+import { OrderState } from 'packages/sdk/dist/types';
+import {
+  FiAlertTriangle,
+  FiArrowUpRight,
+  FiCheck,
+  FiClock,
+  FiCornerUpRight,
+  FiX
+} from 'react-icons/fi';
+
+export type OrderFulfillmentState =
+  | 'SENT'
+  // Pick Up
+  | 'RECEIVED'
+  | 'READY'
+  | 'PICKED_UP'
+  // Mail Order
+  | 'FILLING'
+  | 'SHIPPED'
+  | 'DELIVERED';
+type OrderFulfillmentRecord = Record<OrderFulfillmentState, string>;
+
+export const ORDER_STATE_MAP: { [key in OrderState]: string } = {
+  PLACED: 'Placed',
+  ROUTING: 'Routing',
+  PENDING: 'Pending',
+  CANCELED: 'Canceled',
+  COMPLETED: 'Completed',
+  ERROR: 'Error'
+};
+
+export const ORDER_STATE_ICON_MAP: any = {
+  PLACED: FiArrowUpRight,
+  ROUTING: FiCornerUpRight,
+  PENDING: FiClock,
+  CANCELED: FiX,
+  COMPLETED: FiCheck,
+  ERROR: FiAlertTriangle
+};
+
+export const ORDER_FULFILLMENT_STATE_MAP: OrderFulfillmentRecord = {
+  SENT: 'Sent',
+  RECEIVED: 'Received',
+  READY: 'Ready',
+  PICKED_UP: 'Picked up',
+  FILLING: 'Filling',
+  SHIPPED: 'Shipped',
+  DELIVERED: 'Delivered'
+};
+
+export const ORDER_FULFILLMENT_COLOR_MAP: OrderFulfillmentRecord = {
+  SENT: 'yellow',
+  RECEIVED: 'orange',
+  READY: 'green',
+  PICKED_UP: 'green',
+  FILLING: 'orange',
+  SHIPPED: 'green',
+  DELIVERED: 'gray'
+};
+
+export const ORDER_FULFILLMENT_TIP_MAP: OrderFulfillmentRecord = {
+  SENT: 'Order sent to pharmacy',
+  RECEIVED: 'Order received by pharmacy',
+  READY: 'Order ready at pharmacy',
+  PICKED_UP: 'Order picked up by patient',
+  FILLING: 'Mail order being filled',
+  SHIPPED: 'Mail order shipped',
+  DELIVERED: 'Mail order delivered'
+};
+
+interface OrderStatusBadgeProps {
+  fulfillmentState?: OrderFulfillmentState;
+  orderState?: OrderState;
+}
+
+function OrderStatusBadge({ fulfillmentState, orderState }: OrderStatusBadgeProps) {
+  let status = '';
+  let statusColor = 'gray';
+  let statusTip = '';
+  let statusIcon;
+
+  if (!fulfillmentState && !orderState) {
+    return null;
+  }
+
+  if (fulfillmentState) {
+    const key = fulfillmentState;
+    status = ORDER_FULFILLMENT_STATE_MAP[key];
+    statusTip = ORDER_FULFILLMENT_TIP_MAP[key] || status;
+    statusColor = ORDER_FULFILLMENT_COLOR_MAP[key] || statusColor;
+  } else {
+    const key = orderState as OrderState;
+    status = ORDER_STATE_MAP[key];
+    statusTip = 'Order waiting on patient pharmacy selection';
+    statusIcon = ORDER_STATE_ICON_MAP[key];
+  }
+
+  return (
+    <Tooltip label={statusTip}>
+      <Tag size="sm" borderRadius="full" colorScheme={statusColor}>
+        {statusIcon ? <TagLeftIcon boxSize="12px" as={statusIcon} /> : null}
+        <TagLabel>{status}</TagLabel>
+      </Tag>
+    </Tooltip>
+  );
+}
+
+export default OrderStatusBadge;

--- a/apps/app/src/views/routes/Order.tsx
+++ b/apps/app/src/views/routes/Order.tsx
@@ -518,15 +518,19 @@ export const Order = () => {
                                 <Text>{fill.treatment.name}</Text>
                               </LinkOverlay>
                             </HStack>
-                            <HStack>
-                              <Text fontSize="sm" color="gray.500">
+                            <Stack direction={['column', 'row']}>
+                              <Text fontSize="xs" color="gray.500">
                                 Fill ID: {fill.id}
                               </Text>
-                              <OrderStatusBadge
-                                fulfillmentState={order.fulfillment?.state as OrderFulfillmentState}
-                                orderState={order.state}
-                              />
-                            </HStack>
+                              <div>
+                                <OrderStatusBadge
+                                  fulfillmentState={
+                                    order.fulfillment?.state as OrderFulfillmentState
+                                  }
+                                  orderState={order.state}
+                                />
+                              </div>
+                            </Stack>
                           </VStack>
 
                           <Box alignItems="end">

--- a/apps/app/src/views/routes/Order.tsx
+++ b/apps/app/src/views/routes/Order.tsx
@@ -5,7 +5,6 @@ import {
   AlertDescription,
   AlertIcon,
   AlertTitle,
-  Badge,
   Box,
   Button,
   Card,
@@ -520,12 +519,13 @@ export const Order = () => {
                               </LinkOverlay>
                             </HStack>
                             <HStack>
-                              <Badge
-                                size="sm"
-                                colorScheme={FILL_COLOR_MAP[fill.state as keyof object] || ''}
-                              >
-                                {FILL_STATE_MAP[fill.state as keyof object] || ''}
-                              </Badge>
+                              <Text fontSize="sm" color="gray.500">
+                                Fill ID: {fill.id}
+                              </Text>
+                              <OrderStatusBadge
+                                fulfillmentState={order.fulfillment?.state as OrderFulfillmentState}
+                                orderState={order.state}
+                              />
                             </HStack>
                           </VStack>
 

--- a/apps/app/src/views/routes/Order.tsx
+++ b/apps/app/src/views/routes/Order.tsx
@@ -1,4 +1,4 @@
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import { useState, useEffect } from 'react';
 import {
   Alert,
@@ -31,7 +31,9 @@ import {
   VStack,
   useBreakpointValue,
   useColorMode,
-  useToast
+  useToast,
+  LinkBox,
+  LinkOverlay
 } from '@chakra-ui/react';
 import { gql, GraphQLClient } from 'graphql-request';
 import { usePhoton, types } from '@photonhealth/react';
@@ -84,13 +86,13 @@ export const ORDER_STATE_ICON_MAP: any = {
   COMPLETED: FiCheck,
   ERROR: FiAlertTriangle
 };
-const FILL_STATE_MAP: object = {
+export const FILL_STATE_MAP: object = {
   CANCELED: 'Canceled',
   NEW: 'New',
   SCHEDULED: 'Scheduled',
   SENT: 'Sent'
 };
-const FILL_COLOR_MAP: object = {
+export const FILL_COLOR_MAP: object = {
   CANCELED: 'gray',
   NEW: 'green',
   SCHEDULED: 'orange',
@@ -100,7 +102,6 @@ export const Order = () => {
   const toast = useToast();
   const params = useParams();
   const id = params.orderId;
-  const navigate = useNavigate();
   const { getOrder, getToken } = usePhoton();
   const { order, loading, error } = getOrder({ id: id! });
   const [accessToken, setAccessToken] = useState('');
@@ -520,43 +521,45 @@ export const Order = () => {
               Fills
             </Text>
             {order?.fills.length > 0 ? (
-              <TableContainer w="full">
-                <Table bg="transparent" size="sm">
-                  <Tbody>
-                    {order.fills.map((fill: any, i: number) => {
-                      return i < 5 ? (
-                        <Tr
-                          key={fill.id}
-                          onClick={() => navigate(`/prescriptions/${fill?.prescription?.id}`)}
-                          _hover={{ backgroundColor: 'gray.100' }}
-                          cursor="pointer"
-                        >
-                          <Td px={0} py={3} whiteSpace="pre-wrap" borderColor="gray.200">
-                            <HStack w="full" justify="space-between">
-                              <VStack alignItems="start">
-                                <HStack>
-                                  <Text>{fill.treatment.name}</Text>
-                                </HStack>
-                                <HStack>
-                                  <Badge
-                                    size="sm"
-                                    colorScheme={FILL_COLOR_MAP[fill.state as keyof object] || ''}
-                                  >
-                                    {FILL_STATE_MAP[fill.state as keyof object] || ''}
-                                  </Badge>
-                                </HStack>
-                              </VStack>
-                              <Box alignItems="end">
-                                <FiChevronRight size="1.3em" />
-                              </Box>
+              <>
+                {order.fills.map((fill: any, i: number) => {
+                  return i < 5 ? (
+                    <LinkBox key={fill.id} w="full" style={{ textDecoration: 'none' }}>
+                      <Card
+                        variant="outline"
+                        p={[2, 3]}
+                        w="full"
+                        shadow="none"
+                        _hover={{
+                          backgroundColor: 'gray.50'
+                        }}
+                      >
+                        <HStack justifyContent="space-between">
+                          <VStack alignItems="start">
+                            <HStack>
+                              <LinkOverlay href={`/prescriptions/${fill?.prescription?.id}`}>
+                                <Text>{fill.treatment.name}</Text>
+                              </LinkOverlay>
                             </HStack>
-                          </Td>
-                        </Tr>
-                      ) : null;
-                    })}
-                  </Tbody>
-                </Table>
-              </TableContainer>
+                            <HStack>
+                              <Badge
+                                size="sm"
+                                colorScheme={FILL_COLOR_MAP[fill.state as keyof object] || ''}
+                              >
+                                {FILL_STATE_MAP[fill.state as keyof object] || ''}
+                              </Badge>
+                            </HStack>
+                          </VStack>
+
+                          <Box alignItems="end">
+                            <FiChevronRight size="1.3em" />
+                          </Box>
+                        </HStack>
+                      </Card>
+                    </LinkBox>
+                  ) : null;
+                })}
+              </>
             ) : (
               <Text as="i">No fills</Text>
             )}

--- a/apps/app/src/views/routes/Orders.tsx
+++ b/apps/app/src/views/routes/Orders.tsx
@@ -11,68 +11,22 @@ import {
   PopoverTrigger,
   SkeletonCircle,
   SkeletonText,
-  Tag,
-  TagLeftIcon,
-  TagLabel,
   Text,
-  Tooltip,
   useBreakpointValue
 } from '@chakra-ui/react';
 
 import { FiInfo } from 'react-icons/fi';
 import { useEffect, useState } from 'react';
 import { useDebounce } from 'use-debounce';
-import { usePhoton, types } from '@photonhealth/react';
+import { usePhoton } from '@photonhealth/react';
 
 import { Page } from '../components/Page';
 import { TablePage } from '../components/TablePage';
 import PatientView from '../components/PatientView';
 import PharmacyNameView from '../components/PharmacyNameView';
 import { formatDate, formatFills } from '../../utils';
-import { ORDER_STATE_MAP, ORDER_STATE_ICON_MAP } from './Order';
 import { Order } from 'packages/sdk/dist/types';
-
-type OrderFulfillmentState =
-  | 'SENT'
-  // Pick Up
-  | 'RECEIVED'
-  | 'READY'
-  | 'PICKED_UP'
-  // Mail Order
-  | 'FILLING'
-  | 'SHIPPED'
-  | 'DELIVERED';
-type OrderFulfillmentRecord = Record<OrderFulfillmentState, string>;
-
-export const ORDER_FULFILLMENT_STATE_MAP: OrderFulfillmentRecord = {
-  SENT: 'Sent',
-  RECEIVED: 'Received',
-  READY: 'Ready',
-  PICKED_UP: 'Picked up',
-  FILLING: 'Filling',
-  SHIPPED: 'Shipped',
-  DELIVERED: 'Delivered'
-};
-
-export const ORDER_FULFILLMENT_COLOR_MAP: OrderFulfillmentRecord = {
-  SENT: 'yellow',
-  RECEIVED: 'orange',
-  READY: 'green',
-  PICKED_UP: 'gray',
-  FILLING: 'orange',
-  SHIPPED: 'green',
-  DELIVERED: 'gray'
-};
-
-export const ORDER_FULFILLMENT_TIP_MAP: OrderFulfillmentRecord = {
-  SENT: 'Order sent to pharmacy',
-  RECEIVED: 'Order received by pharmacy',
-  READY: 'Order ready at pharmacy',
-  PICKED_UP: 'Order picked up by patient',
-  FILLING: 'Mail order being filled',
-  SHIPPED: 'Mail order shipped',
-  DELIVERED: 'Mail order delivered'
-};
+import OrderStatusBadge, { OrderFulfillmentState } from '../components/OrderStatusBadge';
 
 interface ActionsProps {
   id: string;
@@ -129,35 +83,16 @@ const renderRow = (order: Order) => {
     <Text as="i">Pending selection</Text>
   );
 
-  let status = '';
-  let statusColor = 'gray';
-  let statusTip = '';
-  let statusIcon;
-
-  if (order.fulfillment?.state) {
-    const key = order.fulfillment.state as OrderFulfillmentState;
-    status = ORDER_FULFILLMENT_STATE_MAP[key];
-    statusTip = ORDER_FULFILLMENT_TIP_MAP[key] || status;
-    statusColor = ORDER_FULFILLMENT_COLOR_MAP[key] || statusColor;
-  } else {
-    const key = order.state as types.OrderState;
-    status = ORDER_STATE_MAP[key];
-    statusTip = 'Order waiting on patient pharmacy selection';
-    statusIcon = ORDER_STATE_ICON_MAP[key];
-  }
-
   return {
     id,
     externalId: extId,
     createdAt: formatDate(order.createdAt),
     fills: <Text fontWeight="medium">{fills}</Text>,
     status: (
-      <Tooltip label={statusTip}>
-        <Tag size="sm" borderRadius="full" colorScheme={statusColor}>
-          {statusIcon ? <TagLeftIcon boxSize="12px" as={statusIcon} /> : null}
-          <TagLabel>{status}</TagLabel>
-        </Tag>
-      </Tooltip>
+      <OrderStatusBadge
+        fulfillmentState={order.fulfillment?.state as OrderFulfillmentState}
+        orderState={order.state}
+      />
     ),
     patient: <PatientView patient={patient} />,
     pharmacy: pharmacyView,

--- a/apps/app/src/views/routes/Patient.tsx
+++ b/apps/app/src/views/routes/Patient.tsx
@@ -38,7 +38,7 @@ import { formatDateLong, formatPhone, formatDate } from '../../utils';
 import { Page } from '../components/Page';
 
 import { PRESCRIPTION_STATE_MAP, PRESCRIPTION_COLOR_MAP } from './Prescriptions';
-import { ORDER_FULFILLMENT_STATE_MAP, ORDER_FULFILLMENT_COLOR_MAP } from './Orders';
+import OrderStatusBadge, { OrderFulfillmentState } from '../components/OrderStatusBadge';
 
 export const Patient = () => {
   const [loading, setLoading] = useState<boolean>(true);
@@ -421,7 +421,7 @@ export const Patient = () => {
               <TableContainer>
                 <Table bg="transparent" size="sm">
                   <Tbody>
-                    {orders.map(({ id: orderId, fulfillment, fills, createdAt }, i) => {
+                    {orders.map(({ id: orderId, fulfillment, fills, createdAt, state }, i) => {
                       const fillsFormatted = fills.reduce((prev: string, cur: any) => {
                         const fill = cur.treatment.name;
                         return prev ? `${prev}, ${fill}` : fill;
@@ -439,20 +439,10 @@ export const Patient = () => {
                               <VStack alignItems="start">
                                 <Text>{fillsFormatted}</Text>
                                 <HStack>
-                                  {fulfillment?.state ? (
-                                    <Badge
-                                      size="sm"
-                                      colorScheme={
-                                        ORDER_FULFILLMENT_COLOR_MAP[
-                                          fulfillment.state as keyof object
-                                        ] || ''
-                                      }
-                                    >
-                                      {ORDER_FULFILLMENT_STATE_MAP[
-                                        fulfillment.state as keyof object
-                                      ] || ''}
-                                    </Badge>
-                                  ) : null}
+                                  <OrderStatusBadge
+                                    fulfillmentState={fulfillment?.state as OrderFulfillmentState}
+                                    orderState={state}
+                                  />
                                   <Text>{formatDate(createdAt)}</Text>
                                 </HStack>
                               </VStack>

--- a/apps/app/src/views/routes/Prescription.tsx
+++ b/apps/app/src/views/routes/Prescription.tsx
@@ -545,7 +545,7 @@ export const Prescription = () => {
                                   <HStack spacing={2}>
                                     <Text fontSize="md">
                                       {fill?.order?.pharmacy?.name ||
-                                        'Pharmacy not been selected by the patient.'}
+                                        'Pharmacy has not been selected by the patient.'}
                                     </Text>
                                     <OrderStatusBadge
                                       fulfillmentState={
@@ -558,8 +558,8 @@ export const Prescription = () => {
                               </HStack>
                               <Text fontSize="sm" color="gray.500">
                                 {addressString}
-                                <br />
-                                Created At:{' '}
+                                {addressString ? <br /> : null}
+                                Created:{' '}
                                 {dayjs(fill?.order?.createdAt).format('MMM D, YYYY, h:mm A')}
                               </Text>
                             </VStack>

--- a/apps/app/src/views/routes/Prescription.tsx
+++ b/apps/app/src/views/routes/Prescription.tsx
@@ -543,9 +543,11 @@ export const Prescription = () => {
                               <HStack>
                                 <LinkOverlay href={`/orders/${fill?.order?.id}`}>
                                   <HStack spacing={2}>
-                                    <Text fontSize="md">
-                                      {fill?.order?.pharmacy?.name ||
-                                        'Waiting for pharmacy selection'}
+                                    <Text
+                                      fontSize="md"
+                                      as={fill?.order?.pharmacy?.name ? undefined : 'i'}
+                                    >
+                                      {fill?.order?.pharmacy?.name || 'Pending Selection'}
                                     </Text>
                                     <OrderStatusBadge
                                       fulfillmentState={

--- a/apps/app/src/views/routes/Prescription.tsx
+++ b/apps/app/src/views/routes/Prescription.tsx
@@ -545,7 +545,7 @@ export const Prescription = () => {
                                   <HStack spacing={2}>
                                     <Text fontSize="md">
                                       {fill?.order?.pharmacy?.name ||
-                                        'Pharmacy has not been selected by the patient.'}
+                                        'Waiting for pharmacy selection'}
                                     </Text>
                                     <OrderStatusBadge
                                       fulfillmentState={

--- a/apps/app/src/views/routes/Prescription.tsx
+++ b/apps/app/src/views/routes/Prescription.tsx
@@ -31,10 +31,14 @@ import {
   AlertTitle,
   AlertDescription,
   Wrap,
-  WrapItem
+  WrapItem,
+  Box,
+  LinkBox,
+  LinkOverlay
 } from '@chakra-ui/react';
-import { FiCopy } from 'react-icons/fi';
+import { FiChevronRight, FiCopy } from 'react-icons/fi';
 import { gql, GraphQLClient } from 'graphql-request';
+import dayjs from 'dayjs';
 
 import { formatDate } from '../../utils';
 
@@ -49,6 +53,8 @@ import { Page } from '../components/Page';
 import { confirmWrapper } from '../components/GuardDialog';
 import PatientView from '../components/PatientView';
 import NameView from '../components/NameView';
+import { Fill, Maybe } from 'packages/sdk/dist/types';
+import { FILL_COLOR_MAP, FILL_STATE_MAP } from './Order';
 
 export const graphQLClient = new GraphQLClient(process.env.REACT_APP_GRAPHQL_URI as string, {
   jsonSerializer: {
@@ -495,6 +501,67 @@ export const Prescription = () => {
                 </Text>
               )}
             </HStack>
+
+            {prescription?.fills && prescription?.fills?.length === 0 ? null : (
+              <>
+                <Divider />
+
+                <Text color="gray.500" fontWeight="medium" fontSize="sm">
+                  Orders
+                </Text>
+                <VStack spacing={4} w="full">
+                  {prescription?.fills?.map((fill: Maybe<Fill>) => {
+                    if (!fill) return null;
+                    const address = fill?.order?.pharmacy?.address;
+                    const addressString = address
+                      ? `${address?.street1}, ${address?.city}, ${address?.state} ${address?.postalCode}`
+                      : '';
+                    return (
+                      <LinkBox key={fill.id} w="full" style={{ textDecoration: 'none' }}>
+                        <Card
+                          variant="outline"
+                          p={[2, 3]}
+                          w="full"
+                          shadow="none"
+                          _hover={{
+                            backgroundColor: 'gray.50'
+                          }}
+                        >
+                          <HStack justifyContent="space-between">
+                            <VStack alignItems="start">
+                              <HStack>
+                                <LinkOverlay href={`/orders/${fill?.order?.id}`}>
+                                  <HStack spacing={2}>
+                                    <Text fontSize="md">
+                                      {fill?.order?.pharmacy?.name || 'Pharmacy not set'}
+                                    </Text>
+                                    <Badge
+                                      size="sm"
+                                      colorScheme={FILL_COLOR_MAP[fill.state as keyof object] || ''}
+                                    >
+                                      {FILL_STATE_MAP[fill.state as keyof object] || ''}
+                                    </Badge>
+                                  </HStack>
+                                </LinkOverlay>
+                              </HStack>
+                              <Text fontSize="sm" color="gray.500">
+                                {addressString}
+                                <br />
+                                Created At:{' '}
+                                {dayjs(fill?.order?.createdAt).format('MMM D, YYYY, h:mm A')}
+                              </Text>
+                            </VStack>
+                            <Box alignItems="end">
+                              <FiChevronRight size="1.3em" />
+                            </Box>
+                          </HStack>
+                        </Card>
+                      </LinkBox>
+                    );
+                  })}
+                </VStack>
+              </>
+            )}
           </VStack>
         </CardBody>
       </Card>

--- a/packages/sdk/src/fragments.ts
+++ b/packages/sdk/src/fragments.ts
@@ -96,6 +96,7 @@ export const FILL_PRESCRIPTION_FIELDS = gql`
     order {
       id
       createdAt
+      state
       fulfillment {
         state
       }

--- a/packages/sdk/src/fragments.ts
+++ b/packages/sdk/src/fragments.ts
@@ -87,10 +87,41 @@ export const DISPENSE_UNIT_FIELDS = gql`
   }
 `;
 
+export const FILL_PRESCRIPTION_FIELDS = gql`
+  fragment FillFields on Fill {
+    id
+    state
+    requestedAt
+    filledAt
+    order {
+      id
+      createdAt
+      fulfillment {
+        state
+      }
+      pharmacy {
+        id
+        name
+        address {
+          street1
+          street2
+          city
+          state
+          postalCode
+        }
+      }
+    }
+  }
+`;
+
 export const PRESCRIPTION_FIELDS = gql`
+  ${FILL_PRESCRIPTION_FIELDS}
   fragment PrescriptionFields on Prescription {
     id
     externalId
+    fills {
+      ...FillFields
+    }
     prescriber {
       id
       name {


### PR DESCRIPTION
https://www.notion.so/photons/Add-Order-table-to-page-8261841d7c4c4e9abd2e8a28d6a52c36?pvs=4

UPDATE
- now has reusable order status badge
- [flattens duplicate fills](https://www.notion.so/photons/Collapse-fills-on-order-screen-that-go-to-the-same-prescription-7bd48025091242f3a0359f5856632543?pvs=4) on order and rx pages
- Fill Id added on the [Order page Fills](https://www.notion.so/photons/Display-fill-id-on-order-view-58e2e21fd3754c8bb3cf3a1bb3a05a57?pvs=4)


### On Prescription page
when routing
<img width="981" alt="Screen Shot 2023-07-18 at 4 24 28 PM" src="https://github.com/Photon-Health/client/assets/700617/70ae5497-4df2-43ff-9a9d-dbd72709db1e">

when it has order status
<img width="981" alt="Screen Shot 2023-07-18 at 4 23 25 PM" src="https://github.com/Photon-Health/client/assets/700617/63ebfe22-26e3-40b0-b7e9-d19bfc55efff">


### Updated order card to match on Order page
<img width="989" alt="Screen Shot 2023-07-18 at 4 21 00 PM" src="https://github.com/Photon-Health/client/assets/700617/b9b05194-25e0-44fc-92f6-6ce5f2b29293">
