### PR TITLE
Update Rx Hierarchy

### DIFF
--- a/apps/app/src/views/components/CopyText.tsx
+++ b/apps/app/src/views/components/CopyText.tsx
@@ -10,7 +10,6 @@ const CopyText = ({ text }: { text: string }) => {
         whiteSpace={{ base: 'nowrap', sm: 'normal' }}
         overflow={{ base: 'hidden', sm: 'visible' }}
         textOverflow={{ base: 'ellipsis', sm: 'clip' }}
-        maxWidth={{ base: '100px', sm: 'none' }}
       >
         {text}
       </Text>

--- a/apps/app/src/views/components/CopyText.tsx
+++ b/apps/app/src/views/components/CopyText.tsx
@@ -1,0 +1,33 @@
+import { HStack, IconButton, Text } from '@chakra-ui/react';
+import { FiCopy } from 'react-icons/fi';
+
+const CopyText = ({ text }: { text: string }) => {
+  if (!text) return null;
+  return (
+    <HStack spacing={2}>
+      <Text
+        fontSize="md"
+        whiteSpace={{ base: 'nowrap', sm: 'normal' }}
+        overflow={{ base: 'hidden', sm: 'visible' }}
+        textOverflow={{ base: 'ellipsis', sm: 'clip' }}
+        maxWidth={{ base: '100px', sm: 'none' }}
+      >
+        {text}
+      </Text>
+      <IconButton
+        variant="ghost"
+        color="gray.500"
+        aria-label="Copy external id"
+        minW="fit-content"
+        h="fit-content"
+        py={0}
+        my={0}
+        _hover={{ backgroundColor: 'transparent' }}
+        icon={<FiCopy size="1.3em" />}
+        onClick={() => navigator.clipboard.writeText(text || '')}
+      />
+    </HStack>
+  );
+};
+
+export default CopyText;

--- a/apps/app/src/views/components/InfoGrid.tsx
+++ b/apps/app/src/views/components/InfoGrid.tsx
@@ -9,7 +9,7 @@ interface InfoGridProps {
 function InfoGrid({ name, children }: InfoGridProps) {
   return (
     <Grid
-      templateColumns={{ base: 'repeat(1, 1fr)', md: 'repeat(5, 1fr)' }}
+      templateColumns={{ base: 'repeat(1, 1fr)', md: 'repeat(6, 1fr)' }}
       gap={{ base: 0, md: 4 }}
       w="100%"
       mb={{ base: 2, md: 0 }}
@@ -19,7 +19,7 @@ function InfoGrid({ name, children }: InfoGridProps) {
           {name}
         </Text>
       </GridItem>
-      <GridItem colSpan={4}>{children}</GridItem>
+      <GridItem colSpan={5}>{children}</GridItem>
     </Grid>
   );
 }

--- a/apps/app/src/views/components/InfoGrid.tsx
+++ b/apps/app/src/views/components/InfoGrid.tsx
@@ -15,7 +15,7 @@ function InfoGrid({ name, children }: InfoGridProps) {
       mb={{ base: 2, md: 0 }}
     >
       <GridItem colSpan={1}>
-        <Text fontSize="xs" color="gray.500" mt={1}>
+        <Text fontSize="xs" color="gray.500" style={{ lineHeight: '24px' }}>
           {name}
         </Text>
       </GridItem>

--- a/apps/app/src/views/components/InfoGrid.tsx
+++ b/apps/app/src/views/components/InfoGrid.tsx
@@ -1,0 +1,27 @@
+import { Grid, GridItem, Text } from '@chakra-ui/react';
+import React from 'react';
+
+interface InfoGridProps {
+  name: string;
+  children: React.ReactNode;
+}
+
+function InfoGrid({ name, children }: InfoGridProps) {
+  return (
+    <Grid
+      templateColumns={{ base: 'repeat(1, 1fr)', md: 'repeat(5, 1fr)' }}
+      gap={{ base: 0, md: 4 }}
+      w="100%"
+      mb={{ base: 2, md: 0 }}
+    >
+      <GridItem colSpan={1}>
+        <Text fontSize="xs" color="gray.500" mt={1}>
+          {name}
+        </Text>
+      </GridItem>
+      <GridItem colSpan={4}>{children}</GridItem>
+    </Grid>
+  );
+}
+
+export default InfoGrid;

--- a/apps/app/src/views/components/Page.tsx
+++ b/apps/app/src/views/components/Page.tsx
@@ -13,7 +13,12 @@ export interface PageProps {
 export const Page = (props: PageProps) => {
   const { kicker, header, buttons, children, disableScroll } = props;
   return (
-    <Container py="8" flex="1" height={disableScroll ? window.innerHeight - 64 : '100%'}>
+    <Container
+      py="8"
+      flex="1"
+      height={disableScroll ? window.innerHeight - 64 : '100%'}
+      mb={{ base: 20, sm: 0 }}
+    >
       <Stack spacing={{ base: kicker ? '3' : '8', lg: kicker ? '3' : '6' }}>
         <Stack
           spacing="4"

--- a/apps/app/src/views/routes/Order.tsx
+++ b/apps/app/src/views/routes/Order.tsx
@@ -12,18 +12,12 @@ import {
   CardHeader,
   Divider,
   HStack,
-  IconButton,
   Link,
   Skeleton,
   SkeletonCircle,
   SkeletonText,
   Stack,
-  Table,
-  TableContainer,
-  Tbody,
-  Td,
   Text,
-  Tr,
   VStack,
   useBreakpointValue,
   useColorMode,
@@ -37,7 +31,7 @@ import {
 } from '@chakra-ui/react';
 import { gql, GraphQLClient } from 'graphql-request';
 import { usePhoton, types } from '@photonhealth/react';
-import { FiCopy, FiChevronRight } from 'react-icons/fi';
+import { FiChevronRight } from 'react-icons/fi';
 import { Page } from '../components/Page';
 import PatientView from '../components/PatientView';
 import { confirmWrapper } from '../components/GuardDialog';
@@ -48,6 +42,8 @@ import {
   ORDER_STATE_ICON_MAP,
   ORDER_STATE_MAP
 } from '../components/OrderStatusBadge';
+import InfoGrid from '../components/InfoGrid';
+import CopyText from '../components/CopyText';
 export const graphQLClient = new GraphQLClient(process.env.REACT_APP_GRAPHQL_URI as string, {
   jsonSerializer: {
     parse: JSON.parse,
@@ -100,36 +96,8 @@ export const Order = () => {
     }
   }, [accessToken]);
   const isMobile = useBreakpointValue({ base: true, sm: false });
-  const rightColWidth = '75%';
   const { colorMode } = useColorMode();
-  const CopyText = ({ text }: { text: string }) => {
-    if (!text) return null;
-    return (
-      <HStack spacing={2} justifyContent={isMobile ? 'end' : 'start'}>
-        <Text
-          fontSize="md"
-          whiteSpace={isMobile ? 'nowrap' : undefined}
-          overflow={isMobile ? 'hidden' : undefined}
-          textOverflow={isMobile ? 'ellipsis' : undefined}
-          maxWidth={isMobile ? '100px' : undefined}
-        >
-          {text}
-        </Text>
-        <IconButton
-          variant="ghost"
-          color="gray.500"
-          aria-label="Copy external id"
-          minW="fit-content"
-          h="fit-content"
-          py={0}
-          my={0}
-          _hover={{ backgroundColor: 'transparent' }}
-          icon={<FiCopy size="1.3em" />}
-          onClick={() => navigator.clipboard.writeText(text || '')}
-        />
-      </HStack>
-    );
-  };
+
   if (error || (!loading && !order)) {
     return (
       <Alert
@@ -160,9 +128,9 @@ export const Order = () => {
     <Button
       aria-label="Cancel Order"
       variant="outline"
-      borderColor="blue.500"
-      textColor="blue.500"
-      colorScheme="blue"
+      borderColor="red.500"
+      textColor="red.500"
+      colorScheme="red"
       isDisabled={
         order.fulfillment?.type !== types.FulfillmentType.MailOrder ||
         order.state === types.OrderState.Canceled
@@ -242,88 +210,48 @@ export const Order = () => {
               Details
             </Text>
 
-            <TableContainer w="full">
-              <Table bg="transparent">
-                <Tbody>
-                  <Tr>
-                    <Td px={0} py={2} border="none">
-                      <Text fontSize="md">Order Status</Text>
-                    </Td>
-                    <Td pe={0} py={2} isNumeric={isMobile} border="none" w={rightColWidth}>
-                      {loading ? (
-                        <Skeleton
-                          width="70px"
-                          height="24px"
-                          borderRadius="xl"
-                          ms={isMobile ? 'auto' : undefined}
-                        />
-                      ) : (
-                        <Tag size="sm" borderRadius="full">
-                          <TagLeftIcon boxSize="12px" as={ORDER_STATE_ICON_MAP[order.state]} />
-                          <TagLabel>{ORDER_STATE_MAP[order.state as keyof object] || ''}</TagLabel>
-                        </Tag>
-                      )}
-                    </Td>
-                  </Tr>
-                  <Tr>
-                    <Td px={0} py={2} border="none">
-                      <Text fontSize="md">Id</Text>
-                    </Td>
-                    <Td pe={0} py={2} isNumeric={isMobile} border="none" w={rightColWidth}>
-                      {loading ? (
-                        <SkeletonText
-                          noOfLines={1}
-                          width="150px"
-                          ms={isMobile ? 'auto' : undefined}
-                        />
-                      ) : order.id ? (
-                        <CopyText text={order.id} />
-                      ) : (
-                        <Text fontSize="md" as="i">
-                          None
-                        </Text>
-                      )}
-                    </Td>
-                  </Tr>
-                  <Tr>
-                    <Td px={0} py={2} border="none">
-                      <Text fontSize="md">External Id</Text>
-                    </Td>
-                    <Td pe={0} py={2} isNumeric={isMobile} border="none" w={rightColWidth}>
-                      {loading ? (
-                        <SkeletonText
-                          noOfLines={1}
-                          width="150px"
-                          ms={isMobile ? 'auto' : undefined}
-                        />
-                      ) : order.externalId ? (
-                        <CopyText text={order.externalId} />
-                      ) : (
-                        <Text fontSize="md" as="i">
-                          None
-                        </Text>
-                      )}
-                    </Td>
-                  </Tr>
-                  <Tr>
-                    <Td px={0} py={2} border="none">
-                      <Text fontSize="md">Created At</Text>
-                    </Td>
-                    <Td pe={0} py={2} isNumeric={isMobile} border="none" w={rightColWidth}>
-                      {loading ? (
-                        <SkeletonText
-                          noOfLines={1}
-                          width="125px"
-                          ms={isMobile ? 'auto' : undefined}
-                        />
-                      ) : (
-                        <Text fontSize="md">{formatDate(order.createdAt)}</Text>
-                      )}
-                    </Td>
-                  </Tr>
-                </Tbody>
-              </Table>
-            </TableContainer>
+            <InfoGrid name="Order Status">
+              {loading ? (
+                <Skeleton width="70px" height="24px" borderRadius="xl" />
+              ) : (
+                <Tag size="sm" borderRadius="full">
+                  <TagLeftIcon boxSize="12px" as={ORDER_STATE_ICON_MAP[order.state]} />
+                  <TagLabel>{ORDER_STATE_MAP[order.state as keyof object] || ''}</TagLabel>
+                </Tag>
+              )}
+            </InfoGrid>
+
+            <InfoGrid name="Id">
+              {loading ? (
+                <SkeletonText noOfLines={1} width="150px" />
+              ) : order.id ? (
+                <CopyText text={order.id} />
+              ) : (
+                <Text fontSize="md" as="i">
+                  None
+                </Text>
+              )}
+            </InfoGrid>
+
+            <InfoGrid name="External Id">
+              {loading ? (
+                <SkeletonText noOfLines={1} width="150px" />
+              ) : order.externalId ? (
+                <CopyText text={order.externalId} />
+              ) : (
+                <Text fontSize="md" as="i">
+                  None
+                </Text>
+              )}
+            </InfoGrid>
+
+            <InfoGrid name="Created At">
+              {loading ? (
+                <SkeletonText noOfLines={1} width="125px" />
+              ) : (
+                <Text fontSize="md">{formatDate(order.createdAt)}</Text>
+              )}
+            </InfoGrid>
 
             <Divider />
 
@@ -331,181 +259,105 @@ export const Order = () => {
               Fulfillment
             </Text>
 
-            <TableContainer w="full">
-              <Table bg="transparent">
-                <Tbody>
-                  <Tr>
-                    <Td px={0} py={2} border="none">
-                      <Text fontSize="md">Type</Text>
-                    </Td>
-                    <Td pe={0} py={2} isNumeric={isMobile} border="none" w={rightColWidth}>
-                      {loading ? (
-                        <SkeletonText
-                          noOfLines={1}
-                          width="100px"
-                          ms={isMobile ? 'auto' : undefined}
-                        />
-                      ) : order.fulfillment ? (
-                        <Text fontSize="md">
-                          {ORDER_FULFILLMENT_TYPE_MAP[order.fulfillment.type]}
-                        </Text>
-                      ) : (
-                        <Text fontSize="md" as="i">
-                          None
-                        </Text>
-                      )}
-                    </Td>
-                  </Tr>
-                  <Tr>
-                    <Td px={0} py={2} border="none">
-                      <Text fontSize="md">Fulfillment Status</Text>
-                    </Td>
-                    <Td pe={0} py={2} isNumeric={isMobile} border="none" w={rightColWidth}>
-                      {loading ? (
-                        <Skeleton
-                          width="70px"
-                          height="24px"
-                          borderRadius="xl"
-                          ms={isMobile ? 'auto' : undefined}
-                        />
-                      ) : order.fulfillment?.state ? (
-                        <Badge
-                          size="sm"
-                          colorScheme={
-                            ORDER_FULFILLMENT_COLOR_MAP[order.fulfillment.state as keyof object] ||
-                            ''
-                          }
-                        >
-                          {ORDER_FULFILLMENT_STATE_MAP[order.fulfillment.state as keyof object] ||
-                            ''}
-                        </Badge>
-                      ) : null}
-                    </Td>
-                  </Tr>
-                  {!loading && order.fulfillment?.type === 'MAIL_ORDER' ? (
-                    <>
-                      <Tr>
-                        <Td px={0} py={2} border="none">
-                          <Text fontSize="md">Carrier</Text>
-                        </Td>
-                        <Td pe={0} py={2} isNumeric={isMobile} border="none" w={rightColWidth}>
-                          {order.fulfillment?.carrier ? (
-                            <Text fontSize="md">{order.fulfillment.carrier}</Text>
-                          ) : (
-                            <Text fontSize="md" as="i">
-                              None
-                            </Text>
-                          )}
-                        </Td>
-                      </Tr>
-                      <Tr>
-                        <Td px={0} py={2} border="none">
-                          <Text fontSize="md">Tracking Number</Text>
-                        </Td>
-                        <Td pe={0} py={2} isNumeric={isMobile} border="none" w={rightColWidth}>
-                          {order.fulfillment?.trackingNumber ? (
-                            <Text fontSize="md">{order.fulfillment.trackingNumber}</Text>
-                          ) : (
-                            <Text fontSize="md" as="i">
-                              None
-                            </Text>
-                          )}
-                        </Td>
-                      </Tr>
-                    </>
-                  ) : null}
-                  <Tr>
-                    <Td px={0} py={2} border="none">
-                      <Text fontSize="md">Pharmacy Id</Text>
-                    </Td>
-                    <Td pe={0} py={2} isNumeric={isMobile} border="none" w={rightColWidth}>
-                      {loading ? (
-                        <SkeletonText
-                          noOfLines={1}
-                          width="100px"
-                          ms={isMobile ? 'auto' : undefined}
-                        />
-                      ) : order?.pharmacy?.id ? (
-                        <CopyText text={order.pharmacy.id} />
-                      ) : (
-                        <Text fontSize="md" as="i">
-                          None
-                        </Text>
-                      )}
-                    </Td>
-                  </Tr>
-                  <Tr>
-                    <Td px={0} py={2} border="none">
-                      <Text fontSize="md">Pharmacy Name</Text>
-                    </Td>
-                    <Td pe={0} py={2} isNumeric={isMobile} border="none" w={rightColWidth}>
-                      {loading ? (
-                        <SkeletonText
-                          noOfLines={1}
-                          width="100px"
-                          ms={isMobile ? 'auto' : undefined}
-                        />
-                      ) : order?.pharmacy?.name ? (
-                        <Text fontSize="md">{order.pharmacy.name}</Text>
-                      ) : (
-                        <Text fontSize="md" as="i">
-                          None
-                        </Text>
-                      )}
-                    </Td>
-                  </Tr>
-                  <Tr>
-                    <Td px={0} py={2} border="none" verticalAlign="top">
-                      <Text fontSize="md">Pharmacy Address</Text>
-                    </Td>
-                    <Td
-                      pe={0}
-                      py={2}
-                      isNumeric={isMobile}
-                      border="none"
-                      whiteSpace="normal"
-                      w={rightColWidth}
-                    >
-                      {loading ? (
-                        <SkeletonText
-                          noOfLines={1}
-                          width="100px"
-                          ms={isMobile ? 'auto' : undefined}
-                        />
-                      ) : order?.pharmacy?.address ? (
-                        <Text fontSize="md">{formatAddress(order.pharmacy.address)}</Text>
-                      ) : (
-                        <Text fontSize="md" as="i">
-                          None
-                        </Text>
-                      )}
-                    </Td>
-                  </Tr>
-                  <Tr>
-                    <Td px={0} py={2} border="none">
-                      <Text fontSize="md">Pharmacy Phone</Text>
-                    </Td>
-                    <Td pe={0} py={2} isNumeric={isMobile} border="none" w={rightColWidth}>
-                      {loading ? (
-                        <SkeletonText
-                          noOfLines={1}
-                          width="100px"
-                          ms={isMobile ? 'auto' : undefined}
-                        />
-                      ) : order?.pharmacy?.phone ? (
-                        <Link fontSize="md" href={`tel:${order.pharmacy.phone}`} isExternal>
-                          {formatPhone(order.pharmacy.phone)}
-                        </Link>
-                      ) : (
-                        <Text fontSize="md" as="i">
-                          None
-                        </Text>
-                      )}
-                    </Td>
-                  </Tr>
-                </Tbody>
-              </Table>
-            </TableContainer>
+            <InfoGrid name="Type">
+              {loading ? (
+                <SkeletonText noOfLines={1} width="100px" />
+              ) : order.fulfillment ? (
+                <Text fontSize="md">{ORDER_FULFILLMENT_TYPE_MAP[order.fulfillment.type]}</Text>
+              ) : (
+                <Text fontSize="md" as="i">
+                  None
+                </Text>
+              )}
+            </InfoGrid>
+
+            <InfoGrid name="Fulfillment Status">
+              {loading ? (
+                <Skeleton width="70px" height="24px" borderRadius="xl" />
+              ) : order.fulfillment?.state ? (
+                <Badge
+                  size="sm"
+                  colorScheme={
+                    ORDER_FULFILLMENT_COLOR_MAP[order.fulfillment.state as keyof object] || ''
+                  }
+                >
+                  {ORDER_FULFILLMENT_STATE_MAP[order.fulfillment.state as keyof object] || ''}
+                </Badge>
+              ) : null}
+            </InfoGrid>
+
+            {!loading && order.fulfillment?.type === 'MAIL_ORDER' ? (
+              <>
+                <InfoGrid name="Carrier">
+                  {order.fulfillment?.carrier ? (
+                    <Text fontSize="md">{order.fulfillment.carrier}</Text>
+                  ) : (
+                    <Text fontSize="md" as="i">
+                      None
+                    </Text>
+                  )}
+                </InfoGrid>
+                <InfoGrid name="Tracking Number">
+                  {order.fulfillment?.trackingNumber ? (
+                    <Text fontSize="md">{order.fulfillment.trackingNumber}</Text>
+                  ) : (
+                    <Text fontSize="md" as="i">
+                      None
+                    </Text>
+                  )}
+                </InfoGrid>
+              </>
+            ) : null}
+
+            <InfoGrid name="Pharmacy Id">
+              {loading ? (
+                <SkeletonText noOfLines={1} width="100px" />
+              ) : order?.pharmacy?.id ? (
+                <CopyText text={order.pharmacy.id} />
+              ) : (
+                <Text fontSize="md" as="i">
+                  None
+                </Text>
+              )}
+            </InfoGrid>
+
+            <InfoGrid name="Pharmacy Name">
+              {loading ? (
+                <SkeletonText noOfLines={1} width="100px" />
+              ) : order?.pharmacy?.name ? (
+                <Text fontSize="md">{order.pharmacy.name}</Text>
+              ) : (
+                <Text fontSize="md" as="i">
+                  None
+                </Text>
+              )}
+            </InfoGrid>
+
+            <InfoGrid name="Pharmacy Address">
+              {loading ? (
+                <SkeletonText noOfLines={1} width="100px" />
+              ) : order?.pharmacy?.address ? (
+                <Text fontSize="md">{formatAddress(order.pharmacy.address)}</Text>
+              ) : (
+                <Text fontSize="md" as="i">
+                  None
+                </Text>
+              )}
+            </InfoGrid>
+
+            <InfoGrid name="Pharmacy Phone">
+              {loading ? (
+                <SkeletonText noOfLines={1} width="100px" />
+              ) : order?.pharmacy?.phone ? (
+                <Link fontSize="md" href={`tel:${order.pharmacy.phone}`} isExternal>
+                  {formatPhone(order.pharmacy.phone)}
+                </Link>
+              ) : (
+                <Text fontSize="md" as="i">
+                  None
+                </Text>
+              )}
+            </InfoGrid>
 
             <Divider />
 

--- a/apps/app/src/views/routes/Order.tsx
+++ b/apps/app/src/views/routes/Order.tsx
@@ -196,7 +196,7 @@ export const Order = () => {
                 {loading ? (
                   <HStack alignContent="center" w="150px" display="flex">
                     <SkeletonCircle size="10" />
-                    <SkeletonText noOfLines={2} flexGrow={1} />
+                    <SkeletonText skeletonHeight={5} noOfLines={2} flexGrow={1} />
                   </HStack>
                 ) : (
                   <PatientView patient={order.patient} />
@@ -223,7 +223,7 @@ export const Order = () => {
 
             <InfoGrid name="Id">
               {loading ? (
-                <SkeletonText noOfLines={1} width="150px" />
+                <SkeletonText skeletonHeight={5} noOfLines={1} width="150px" />
               ) : order.id ? (
                 <CopyText text={order.id} />
               ) : (
@@ -235,7 +235,7 @@ export const Order = () => {
 
             <InfoGrid name="External Id">
               {loading ? (
-                <SkeletonText noOfLines={1} width="150px" />
+                <SkeletonText skeletonHeight={5} noOfLines={1} width="150px" />
               ) : order.externalId ? (
                 <CopyText text={order.externalId} />
               ) : (
@@ -247,7 +247,7 @@ export const Order = () => {
 
             <InfoGrid name="Created At">
               {loading ? (
-                <SkeletonText noOfLines={1} width="125px" />
+                <SkeletonText skeletonHeight={5} noOfLines={1} width="125px" />
               ) : (
                 <Text fontSize="md">{formatDate(order.createdAt)}</Text>
               )}
@@ -261,7 +261,7 @@ export const Order = () => {
 
             <InfoGrid name="Type">
               {loading ? (
-                <SkeletonText noOfLines={1} width="100px" />
+                <SkeletonText skeletonHeight={5} noOfLines={1} width="100px" />
               ) : order.fulfillment ? (
                 <Text fontSize="md">{ORDER_FULFILLMENT_TYPE_MAP[order.fulfillment.type]}</Text>
               ) : (
@@ -311,7 +311,7 @@ export const Order = () => {
 
             <InfoGrid name="Pharmacy Id">
               {loading ? (
-                <SkeletonText noOfLines={1} width="100px" />
+                <SkeletonText skeletonHeight={5} noOfLines={1} width="100px" />
               ) : order?.pharmacy?.id ? (
                 <CopyText text={order.pharmacy.id} />
               ) : (
@@ -323,7 +323,7 @@ export const Order = () => {
 
             <InfoGrid name="Pharmacy Name">
               {loading ? (
-                <SkeletonText noOfLines={1} width="100px" />
+                <SkeletonText skeletonHeight={5} noOfLines={1} width="100px" />
               ) : order?.pharmacy?.name ? (
                 <Text fontSize="md">{order.pharmacy.name}</Text>
               ) : (
@@ -335,7 +335,7 @@ export const Order = () => {
 
             <InfoGrid name="Pharmacy Address">
               {loading ? (
-                <SkeletonText noOfLines={1} width="100px" />
+                <SkeletonText skeletonHeight={5} noOfLines={1} width="100px" />
               ) : order?.pharmacy?.address ? (
                 <Text fontSize="md">{formatAddress(order.pharmacy.address)}</Text>
               ) : (
@@ -347,7 +347,7 @@ export const Order = () => {
 
             <InfoGrid name="Pharmacy Phone">
               {loading ? (
-                <SkeletonText noOfLines={1} width="100px" />
+                <SkeletonText skeletonHeight={5} noOfLines={1} width="100px" />
               ) : order?.pharmacy?.phone ? (
                 <Link fontSize="md" href={`tel:${order.pharmacy.phone}`} isExternal>
                   {formatPhone(order.pharmacy.phone)}

--- a/apps/app/src/views/routes/Patient.tsx
+++ b/apps/app/src/views/routes/Patient.tsx
@@ -25,8 +25,7 @@ import {
   Text,
   VStack,
   Wrap,
-  WrapItem,
-  useBreakpointValue
+  WrapItem
 } from '@chakra-ui/react';
 
 import { FiEdit, FiPhone, FiMail, FiChevronRight, FiPlus } from 'react-icons/fi';
@@ -71,8 +70,6 @@ export const Patient = () => {
     FEMALE: 'Female',
     UNKNOWN: 'Unknown'
   };
-
-  const isMobile = useBreakpointValue({ base: true, sm: false });
 
   useEffect(() => {
     const refetchData = async () => {
@@ -208,7 +205,7 @@ export const Patient = () => {
               <>
                 <InfoGrid name="Date of Birth">
                   {loading ? (
-                    <SkeletonText noOfLines={1} width="130px" ms={isMobile ? 'auto' : undefined} />
+                    <SkeletonText noOfLines={1} width="130px" />
                   ) : (
                     <Text fontSize="md">{formatDateLong(patient.dateOfBirth)}</Text>
                   )}
@@ -216,7 +213,7 @@ export const Patient = () => {
 
                 <InfoGrid name="Sex">
                   {loading ? (
-                    <SkeletonText noOfLines={1} width="50px" ms={isMobile ? 'auto' : undefined} />
+                    <SkeletonText noOfLines={1} width="50px" />
                   ) : (
                     <Text fontSize="md">{sexMap[patient.sex as keyof object]} </Text>
                   )}
@@ -224,7 +221,7 @@ export const Patient = () => {
 
                 <InfoGrid name="Gender">
                   {loading ? (
-                    <SkeletonText noOfLines={1} width="50px" ms={isMobile ? 'auto' : undefined} />
+                    <SkeletonText noOfLines={1} width="50px" />
                   ) : (
                     <Text fontSize="md">{patient.gender}</Text>
                   )}
@@ -233,7 +230,7 @@ export const Patient = () => {
                 <InfoGrid name="Cell Phone Number">
                   {' '}
                   {loading ? (
-                    <SkeletonText noOfLines={1} width="120px" ms={isMobile ? 'auto' : undefined} />
+                    <SkeletonText noOfLines={1} width="120px" />
                   ) : (
                     <Link
                       fontSize="md"
@@ -248,7 +245,7 @@ export const Patient = () => {
 
                 <InfoGrid name="Email">
                   {loading ? (
-                    <SkeletonText noOfLines={1} width="150px" ms={isMobile ? 'auto' : undefined} />
+                    <SkeletonText noOfLines={1} width="150px" />
                   ) : (
                     <Link
                       fontSize="md"
@@ -263,7 +260,7 @@ export const Patient = () => {
 
                 <InfoGrid name="Id">
                   {loading ? (
-                    <SkeletonText noOfLines={1} width="150px" ms={isMobile ? 'auto' : undefined} />
+                    <SkeletonText noOfLines={1} width="150px" />
                   ) : (
                     <CopyText text={id || ''} />
                   )}

--- a/apps/app/src/views/routes/Patient.tsx
+++ b/apps/app/src/views/routes/Patient.tsx
@@ -29,7 +29,7 @@ import {
   useBreakpointValue
 } from '@chakra-ui/react';
 
-import { FiCopy, FiEdit, FiPhone, FiMail, FiChevronRight, FiPlus } from 'react-icons/fi';
+import { FiEdit, FiPhone, FiMail, FiChevronRight, FiPlus } from 'react-icons/fi';
 
 import { usePhoton } from '@photonhealth/react';
 import { useEffect, useState } from 'react';
@@ -39,6 +39,8 @@ import { Page } from '../components/Page';
 
 import { PRESCRIPTION_STATE_MAP, PRESCRIPTION_COLOR_MAP } from './Prescriptions';
 import OrderStatusBadge, { OrderFulfillmentState } from '../components/OrderStatusBadge';
+import InfoGrid from '../components/InfoGrid';
+import CopyText from '../components/CopyText';
 
 export const Patient = () => {
   const [loading, setLoading] = useState<boolean>(true);
@@ -71,7 +73,6 @@ export const Patient = () => {
   };
 
   const isMobile = useBreakpointValue({ base: true, sm: false });
-  const tableWidth = useBreakpointValue({ base: 'full', sm: '100%', md: '75%' });
 
   useEffect(() => {
     const refetchData = async () => {
@@ -204,142 +205,70 @@ export const Patient = () => {
               </Button>
             </HStack>
             {!loading && patient ? (
-              <TableContainer w={tableWidth}>
-                <Table bg="transparent">
-                  <Tbody>
-                    <Tr>
-                      <Td px={0} py={2} border="none">
-                        <Text fontSize="md">Date of Birth</Text>
-                      </Td>
-                      <Td pe={0} py={2} isNumeric={isMobile} border="none">
-                        {loading ? (
-                          <SkeletonText
-                            noOfLines={1}
-                            width="130px"
-                            ms={isMobile ? 'auto' : undefined}
-                          />
-                        ) : (
-                          <Text fontSize="md">{formatDateLong(patient.dateOfBirth)}</Text>
-                        )}
-                      </Td>
-                    </Tr>
-                    <Tr>
-                      <Td px={0} py={2} border="none">
-                        <Text fontSize="md">Sex</Text>
-                      </Td>
-                      <Td pe={0} py={2} isNumeric={isMobile} border="none">
-                        {loading ? (
-                          <SkeletonText
-                            noOfLines={1}
-                            width="50px"
-                            ms={isMobile ? 'auto' : undefined}
-                          />
-                        ) : (
-                          <Text fontSize="md">{sexMap[patient.sex as keyof object]} </Text>
-                        )}
-                      </Td>
-                    </Tr>
-                    <Tr>
-                      <Td px={0} py={2} border="none">
-                        <Text fontSize="md">Gender</Text>
-                      </Td>
-                      <Td pe={0} py={2} isNumeric={isMobile} border="none">
-                        {loading ? (
-                          <SkeletonText
-                            noOfLines={1}
-                            width="50px"
-                            ms={isMobile ? 'auto' : undefined}
-                          />
-                        ) : (
-                          <Text fontSize="md">{patient.gender}</Text>
-                        )}
-                      </Td>
-                    </Tr>
-                    <Tr>
-                      <Td px={0} py={2} border="none">
-                        <Text fontSize="md">Phone number</Text>
-                      </Td>
-                      <Td pe={0} py={2} isNumeric={isMobile} border="none">
-                        {loading ? (
-                          <SkeletonText
-                            noOfLines={1}
-                            width="120px"
-                            ms={isMobile ? 'auto' : undefined}
-                          />
-                        ) : (
-                          <Link
-                            fontSize="md"
-                            href={`tel:${patient.phone}`}
-                            isExternal
-                            textDecoration="underline"
-                          >
-                            {formatPhone(patient.phone)}
-                          </Link>
-                        )}
-                      </Td>
-                    </Tr>
-                    <Tr>
-                      <Td px={0} py={2} border="none">
-                        <Text fontSize="md">Email</Text>
-                      </Td>
-                      <Td pe={0} py={2} isNumeric={isMobile} border="none">
-                        {loading ? (
-                          <SkeletonText
-                            noOfLines={1}
-                            width="150px"
-                            ms={isMobile ? 'auto' : undefined}
-                          />
-                        ) : (
-                          <Link
-                            fontSize="md"
-                            href={`mailto:${patient.email}`}
-                            isExternal
-                            textDecoration="underline"
-                          >
-                            {patient.email}
-                          </Link>
-                        )}
-                      </Td>
-                    </Tr>
-                    <Tr>
-                      <Td px={0} py={2} border="none">
-                        <Text fontSize="md">Id</Text>
-                      </Td>
-                      <Td pe={0} py={2} isNumeric={isMobile} border="none">
-                        {loading ? (
-                          <SkeletonText
-                            noOfLines={1}
-                            width="150px"
-                            ms={isMobile ? 'auto' : undefined}
-                          />
-                        ) : (
-                          <HStack spacing={2} justifyContent={isMobile ? 'end' : 'start'}>
-                            <Text
-                              fontSize="md"
-                              whiteSpace={isMobile ? 'nowrap' : undefined}
-                              overflow={isMobile ? 'hidden' : undefined}
-                              textOverflow={isMobile ? 'ellipsis' : undefined}
-                              maxWidth={isMobile ? '130px' : undefined}
-                            >
-                              {id}
-                            </Text>
-                            <IconButton
-                              variant="ghost"
-                              color="gray.500"
-                              aria-label="Copy external id"
-                              minW="fit-content"
-                              py={0}
-                              _hover={{ backgroundColor: 'transparent' }}
-                              icon={<FiCopy size="1.3em" />}
-                              onClick={() => navigator.clipboard.writeText(id || '')}
-                            />
-                          </HStack>
-                        )}
-                      </Td>
-                    </Tr>
-                  </Tbody>
-                </Table>
-              </TableContainer>
+              <>
+                <InfoGrid name="Date of Birth">
+                  {loading ? (
+                    <SkeletonText noOfLines={1} width="130px" ms={isMobile ? 'auto' : undefined} />
+                  ) : (
+                    <Text fontSize="md">{formatDateLong(patient.dateOfBirth)}</Text>
+                  )}
+                </InfoGrid>
+
+                <InfoGrid name="Sex">
+                  {loading ? (
+                    <SkeletonText noOfLines={1} width="50px" ms={isMobile ? 'auto' : undefined} />
+                  ) : (
+                    <Text fontSize="md">{sexMap[patient.sex as keyof object]} </Text>
+                  )}
+                </InfoGrid>
+
+                <InfoGrid name="Gender">
+                  {loading ? (
+                    <SkeletonText noOfLines={1} width="50px" ms={isMobile ? 'auto' : undefined} />
+                  ) : (
+                    <Text fontSize="md">{patient.gender}</Text>
+                  )}
+                </InfoGrid>
+
+                <InfoGrid name="Cell Phone Number">
+                  {' '}
+                  {loading ? (
+                    <SkeletonText noOfLines={1} width="120px" ms={isMobile ? 'auto' : undefined} />
+                  ) : (
+                    <Link
+                      fontSize="md"
+                      href={`tel:${patient.phone}`}
+                      isExternal
+                      textDecoration="underline"
+                    >
+                      {formatPhone(patient.phone)}
+                    </Link>
+                  )}
+                </InfoGrid>
+
+                <InfoGrid name="Email">
+                  {loading ? (
+                    <SkeletonText noOfLines={1} width="150px" ms={isMobile ? 'auto' : undefined} />
+                  ) : (
+                    <Link
+                      fontSize="md"
+                      href={`mailto:${patient.email}`}
+                      isExternal
+                      textDecoration="underline"
+                    >
+                      {patient.email}
+                    </Link>
+                  )}
+                </InfoGrid>
+
+                <InfoGrid name="Id">
+                  {loading ? (
+                    <SkeletonText noOfLines={1} width="150px" ms={isMobile ? 'auto' : undefined} />
+                  ) : (
+                    <CopyText text={id || ''} />
+                  )}
+                </InfoGrid>
+              </>
             ) : null}
 
             <Divider />

--- a/apps/app/src/views/routes/Patient.tsx
+++ b/apps/app/src/views/routes/Patient.tsx
@@ -32,7 +32,7 @@ import { FiEdit, FiPhone, FiMail, FiChevronRight, FiPlus } from 'react-icons/fi'
 
 import { usePhoton } from '@photonhealth/react';
 import { useEffect, useState } from 'react';
-import { formatDateLong, formatPhone, formatDate } from '../../utils';
+import { formatDateLong, formatPhone, formatDate, formatFills } from '../../utils';
 
 import { Page } from '../components/Page';
 
@@ -205,7 +205,7 @@ export const Patient = () => {
               <>
                 <InfoGrid name="Date of Birth">
                   {loading ? (
-                    <SkeletonText noOfLines={1} width="130px" />
+                    <SkeletonText skeletonHeight={5} noOfLines={1} width="130px" />
                   ) : (
                     <Text fontSize="md">{formatDateLong(patient.dateOfBirth)}</Text>
                   )}
@@ -213,7 +213,7 @@ export const Patient = () => {
 
                 <InfoGrid name="Sex">
                   {loading ? (
-                    <SkeletonText noOfLines={1} width="50px" />
+                    <SkeletonText skeletonHeight={5} noOfLines={1} width="50px" />
                   ) : (
                     <Text fontSize="md">{sexMap[patient.sex as keyof object]} </Text>
                   )}
@@ -221,7 +221,7 @@ export const Patient = () => {
 
                 <InfoGrid name="Gender">
                   {loading ? (
-                    <SkeletonText noOfLines={1} width="50px" />
+                    <SkeletonText skeletonHeight={5} noOfLines={1} width="50px" />
                   ) : (
                     <Text fontSize="md">{patient.gender}</Text>
                   )}
@@ -230,7 +230,7 @@ export const Patient = () => {
                 <InfoGrid name="Cell Phone Number">
                   {' '}
                   {loading ? (
-                    <SkeletonText noOfLines={1} width="120px" />
+                    <SkeletonText skeletonHeight={5} noOfLines={1} width="120px" />
                   ) : (
                     <Link
                       fontSize="md"
@@ -245,7 +245,7 @@ export const Patient = () => {
 
                 <InfoGrid name="Email">
                   {loading ? (
-                    <SkeletonText noOfLines={1} width="150px" />
+                    <SkeletonText skeletonHeight={5} noOfLines={1} width="150px" />
                   ) : (
                     <Link
                       fontSize="md"
@@ -260,7 +260,7 @@ export const Patient = () => {
 
                 <InfoGrid name="Id">
                   {loading ? (
-                    <SkeletonText noOfLines={1} width="150px" />
+                    <SkeletonText skeletonHeight={5} noOfLines={1} width="150px" />
                   ) : (
                     <CopyText text={id || ''} />
                   )}
@@ -348,10 +348,7 @@ export const Patient = () => {
                 <Table bg="transparent" size="sm">
                   <Tbody>
                     {orders.map(({ id: orderId, fulfillment, fills, createdAt, state }, i) => {
-                      const fillsFormatted = fills.reduce((prev: string, cur: any) => {
-                        const fill = cur.treatment.name;
-                        return prev ? `${prev}, ${fill}` : fill;
-                      }, '');
+                      const fillsFormatted = formatFills(fills);
 
                       return i < 5 ? (
                         <Tr

--- a/apps/app/src/views/routes/Prescription.tsx
+++ b/apps/app/src/views/routes/Prescription.tsx
@@ -28,7 +28,8 @@ import {
   WrapItem,
   Box,
   LinkBox,
-  LinkOverlay
+  LinkOverlay,
+  Show
 } from '@chakra-ui/react';
 import { FiChevronRight } from 'react-icons/fi';
 import { gql, GraphQLClient } from 'graphql-request';
@@ -237,8 +238,9 @@ export const Prescription = () => {
                   <PatientView patient={patient} />
                 )}
               </VStack>
-
-              <Divider orientation="vertical" height="auto" />
+              <Show above="sm">
+                <Divider orientation="vertical" height="auto" />
+              </Show>
 
               <VStack align="start" borderRadius={6} w={isMobile ? '50%' : undefined}>
                 <Text color="gray.500" fontWeight="medium" fontSize="sm">

--- a/apps/app/src/views/routes/Prescription.tsx
+++ b/apps/app/src/views/routes/Prescription.tsx
@@ -256,7 +256,9 @@ export const Prescription = () => {
             </Stack>
 
             <Divider />
-
+            <Text color="gray.500" fontWeight="medium" fontSize="sm">
+              Prescription Details
+            </Text>
             <InfoGrid name="Instructions">
               {loading ? (
                 <SkeletonText noOfLines={1} width="100px" />

--- a/apps/app/src/views/routes/Prescription.tsx
+++ b/apps/app/src/views/routes/Prescription.tsx
@@ -10,7 +10,6 @@ import {
   CardBody,
   CardHeader,
   Divider,
-  IconButton,
   Stack,
   HStack,
   Link,
@@ -31,7 +30,7 @@ import {
   LinkBox,
   LinkOverlay
 } from '@chakra-ui/react';
-import { FiChevronRight, FiCopy } from 'react-icons/fi';
+import { FiChevronRight } from 'react-icons/fi';
 import { gql, GraphQLClient } from 'graphql-request';
 import dayjs from 'dayjs';
 

--- a/apps/app/src/views/routes/Prescription.tsx
+++ b/apps/app/src/views/routes/Prescription.tsx
@@ -51,6 +51,7 @@ import NameView from '../components/NameView';
 import { Fill, Maybe } from 'packages/sdk/dist/types';
 import OrderStatusBadge, { OrderFulfillmentState } from '../components/OrderStatusBadge';
 import InfoGrid from '../components/InfoGrid';
+import CopyText from '../components/CopyText';
 
 export const graphQLClient = new GraphQLClient(process.env.REACT_APP_GRAPHQL_URI as string, {
   jsonSerializer: {
@@ -422,19 +423,7 @@ export const Prescription = () => {
               {loading ? (
                 <SkeletonText noOfLines={1} width="150px" />
               ) : (
-                <HStack spacing={2}>
-                  <Text fontSize="md">{id}</Text>
-                  <IconButton
-                    variant="ghost"
-                    color="gray.500"
-                    aria-label="Copy external id"
-                    minW="fit-content"
-                    py={0}
-                    _hover={{ backgroundColor: 'transparent' }}
-                    icon={<FiCopy size="1.3em" />}
-                    onClick={() => navigator.clipboard.writeText(id || '')}
-                  />
-                </HStack>
+                <CopyText text={id || ''} />
               )}
             </InfoGrid>
 
@@ -442,20 +431,7 @@ export const Prescription = () => {
               {loading ? (
                 <SkeletonText noOfLines={1} width="65px" />
               ) : rx.externalId ? (
-                <HStack spacing={2}>
-                  <Text fontSize="md">{rx.externalId}</Text>
-                  <IconButton
-                    variant="ghost"
-                    color="gray.500"
-                    aria-label="Copy external id"
-                    minW="fit-content"
-                    py={0}
-                    size="sm"
-                    _hover={{ backgroundColor: 'transparent' }}
-                    icon={<FiCopy size="1.3em" />}
-                    onClick={() => navigator.clipboard.writeText(rx.externalId || '')}
-                  />
-                </HStack>
+                <CopyText text={rx.externalId || ''} />
               ) : (
                 <Text fontSize="md" as="i">
                   None

--- a/apps/app/src/views/routes/Prescription.tsx
+++ b/apps/app/src/views/routes/Prescription.tsx
@@ -14,11 +14,6 @@ import {
   Stack,
   HStack,
   Link,
-  Table,
-  TableContainer,
-  Tbody,
-  Td,
-  Tr,
   Text,
   Tooltip,
   VStack,
@@ -55,6 +50,7 @@ import PatientView from '../components/PatientView';
 import NameView from '../components/NameView';
 import { Fill, Maybe } from 'packages/sdk/dist/types';
 import OrderStatusBadge, { OrderFulfillmentState } from '../components/OrderStatusBadge';
+import InfoGrid from '../components/InfoGrid';
 
 export const graphQLClient = new GraphQLClient(process.env.REACT_APP_GRAPHQL_URI as string, {
   jsonSerializer: {
@@ -117,7 +113,6 @@ export const Prescription = () => {
   const expirationDate = formatDate(rx.expirationDate);
 
   const isMobile = useBreakpointValue({ base: true, sm: false });
-  const tableWidth = useBreakpointValue({ base: 'full', sm: '100%', md: '75%' });
   const { colorMode } = useColorMode();
 
   if (error || (!loading && !prescription)) {
@@ -181,9 +176,8 @@ export const Prescription = () => {
               }
             }}
             variant="outline"
-            borderColor="blue.500"
-            textColor="blue.500"
-            colorScheme="blue"
+            textColor="red.500"
+            colorScheme="red"
           >
             Cancel Prescription
           </Button>
@@ -229,7 +223,7 @@ export const Prescription = () => {
             w="100%"
             mt={0}
           >
-            <Stack direction="row" gap={3} w="full">
+            <Stack direction={{ base: 'column', sm: 'row' }} gap={3} w="full">
               <VStack align="start" borderRadius={6} w={isMobile ? '50%' : undefined}>
                 <Text color="gray.500" fontWeight="medium" fontSize="sm">
                   Patient
@@ -263,255 +257,95 @@ export const Prescription = () => {
 
             <Divider />
 
-            <Text color="gray.500" fontWeight="medium" fontSize="sm">
-              Instructions
-            </Text>
-            <HStack>
+            <InfoGrid name="Instructions">
               {loading ? (
-                <SkeletonText noOfLines={1} width="200px" pt={2} />
+                <SkeletonText noOfLines={1} width="100px" />
               ) : (
                 <Text fontSize="md">{instructions}</Text>
               )}
-            </HStack>
+            </InfoGrid>
 
-            <Divider />
-
-            <Text color="gray.500" fontWeight="medium" fontSize="sm">
-              Prescription Details
-            </Text>
-
-            <TableContainer w={tableWidth}>
-              <Table bg="transparent">
-                <Tbody>
-                  <Tr>
-                    <Td ps={0} py={2} border="none">
-                      <Text fontSize="md">Status</Text>
-                    </Td>
-                    <Td pe={0} py={2} isNumeric={isMobile} border="none">
-                      {loading ? (
-                        <Skeleton
-                          width="70px"
-                          height="24px"
-                          borderRadius="xl"
-                          ms={isMobile ? 'auto' : undefined}
-                        />
-                      ) : (
-                        <Tooltip label={stateTip}>
-                          <Badge colorScheme={stateColor}>{state}</Badge>
-                        </Tooltip>
-                      )}
-                    </Td>
-                  </Tr>
-                  <Tr>
-                    <Td ps={0} py={2} border="none">
-                      <Text fontSize="md">Quantity</Text>
-                    </Td>
-                    <Td pe={0} py={2} isNumeric={isMobile} border="none">
-                      {loading ? (
-                        <SkeletonText
-                          noOfLines={1}
-                          width="100px"
-                          ms={isMobile ? 'auto' : undefined}
-                        />
-                      ) : (
-                        <Text fontSize="md">
-                          {dispenseQuantity} ct / {daysSupply} day
-                        </Text>
-                      )}
-                    </Td>
-                  </Tr>
-                  <Tr>
-                    <Td ps={0} py={2} border="none">
-                      <Text fontSize="md">Fills Remaining</Text>
-                    </Td>
-                    <Td pe={0} py={2} isNumeric={isMobile} border="none">
-                      {loading ? (
-                        <SkeletonText
-                          noOfLines={1}
-                          width="30px"
-                          ms={isMobile ? 'auto' : undefined}
-                        />
-                      ) : (
-                        <Text fontSize="md">{fillsRemaining}</Text>
-                      )}
-                    </Td>
-                  </Tr>
-                  <Tr>
-                    <Td ps={0} py={2} border="none">
-                      <Text fontSize="md">Fills Allowed</Text>
-                    </Td>
-                    <Td pe={0} py={2} isNumeric={isMobile} border="none">
-                      {loading ? (
-                        <SkeletonText
-                          noOfLines={1}
-                          width="30px"
-                          ms={isMobile ? 'auto' : undefined}
-                        />
-                      ) : (
-                        <Text fontSize="md">{fillsAllowed}</Text>
-                      )}
-                    </Td>
-                  </Tr>
-                  <Tr>
-                    <Td ps={0} py={2} border="none">
-                      <Text fontSize="md">Effective Date</Text>
-                    </Td>
-                    <Td pe={0} py={2} isNumeric={isMobile} border="none">
-                      {loading ? (
-                        <SkeletonText
-                          noOfLines={1}
-                          width="100px"
-                          ms={isMobile ? 'auto' : undefined}
-                        />
-                      ) : (
-                        <Text fontSize="md">{effectiveDate}</Text>
-                      )}
-                    </Td>
-                  </Tr>
-                  <Tr>
-                    <Td ps={0} py={2} border="none">
-                      <Text fontSize="md">Expiration</Text>
-                    </Td>
-                    <Td pe={0} py={2} isNumeric={isMobile} border="none">
-                      {loading ? (
-                        <SkeletonText
-                          noOfLines={1}
-                          width="100px"
-                          ms={isMobile ? 'auto' : undefined}
-                        />
-                      ) : (
-                        <Text fontSize="md">{expirationDate}</Text>
-                      )}
-                    </Td>
-                  </Tr>
-                  <Tr>
-                    <Td ps={0} py={2} border="none">
-                      <Text fontSize="md">Written</Text>
-                    </Td>
-                    <Td pe={0} py={2} isNumeric={isMobile} border="none">
-                      {loading ? (
-                        <SkeletonText
-                          noOfLines={1}
-                          width="100px"
-                          ms={isMobile ? 'auto' : undefined}
-                        />
-                      ) : (
-                        <Text fontSize="md">{writtenAt}</Text>
-                      )}
-                    </Td>
-                  </Tr>
-                  <Tr>
-                    <Td ps={0} py={2} border="none">
-                      <Text fontSize="md">Dispense As Written</Text>
-                    </Td>
-                    <Td pe={0} py={2} isNumeric={isMobile} border="none">
-                      {loading ? (
-                        <SkeletonText
-                          noOfLines={1}
-                          width="50px"
-                          ms={isMobile ? 'auto' : undefined}
-                        />
-                      ) : (
-                        <Text fontSize="md">{dispenseAsWritten ? 'Yes' : 'No'}</Text>
-                      )}
-                    </Td>
-                  </Tr>
-                  <Tr>
-                    <Td px={0} py={2} border="none">
-                      <Text fontSize="md">Id</Text>
-                    </Td>
-                    <Td pe={0} py={2} isNumeric={isMobile} border="none">
-                      {loading ? (
-                        <SkeletonText
-                          noOfLines={1}
-                          width="150px"
-                          ms={isMobile ? 'auto' : undefined}
-                        />
-                      ) : (
-                        <HStack spacing={2} justifyContent={isMobile ? 'end' : 'start'}>
-                          <Text
-                            fontSize="md"
-                            whiteSpace={isMobile ? 'nowrap' : undefined}
-                            overflow={isMobile ? 'hidden' : undefined}
-                            textOverflow={isMobile ? 'ellipsis' : undefined}
-                            maxWidth={isMobile ? '130px' : undefined}
-                          >
-                            {id}
-                          </Text>
-                          <IconButton
-                            variant="ghost"
-                            color="gray.500"
-                            aria-label="Copy external id"
-                            minW="fit-content"
-                            py={0}
-                            _hover={{ backgroundColor: 'transparent' }}
-                            icon={<FiCopy size="1.3em" />}
-                            onClick={() => navigator.clipboard.writeText(id || '')}
-                          />
-                        </HStack>
-                      )}
-                    </Td>
-                  </Tr>
-                  <Tr>
-                    <Td ps={0} py={2} border="none">
-                      <Text fontSize="md">External ID</Text>
-                    </Td>
-                    <Td pe={0} py={2} isNumeric={isMobile} border="none">
-                      {loading ? (
-                        <SkeletonText
-                          noOfLines={1}
-                          width="65px"
-                          ms={isMobile ? 'auto' : undefined}
-                        />
-                      ) : rx.externalId ? (
-                        <HStack spacing={2} justifyContent={isMobile ? 'end' : 'start'}>
-                          <Text
-                            fontSize="md"
-                            whiteSpace={isMobile ? 'nowrap' : undefined}
-                            overflow={isMobile ? 'hidden' : undefined}
-                            textOverflow={isMobile ? 'ellipsis' : undefined}
-                            maxWidth={isMobile ? '130px' : undefined}
-                          >
-                            {rx.externalId}
-                          </Text>
-                          <IconButton
-                            variant="ghost"
-                            color="gray.500"
-                            aria-label="Copy external id"
-                            minW="fit-content"
-                            py={0}
-                            _hover={{ backgroundColor: 'transparent' }}
-                            icon={<FiCopy size="1.3em" />}
-                            onClick={() => navigator.clipboard.writeText(rx.externalId || '')}
-                          />
-                        </HStack>
-                      ) : (
-                        <Text fontSize="md" as="i">
-                          None
-                        </Text>
-                      )}
-                    </Td>
-                  </Tr>
-                </Tbody>
-              </Table>
-            </TableContainer>
-
-            <Divider />
-
-            <Text color="gray.500" fontWeight="medium" fontSize="sm">
-              Notes
-            </Text>
-            <HStack>
+            <InfoGrid name="Pharmacy Notes">
               {loading ? (
-                <SkeletonText noOfLines={1} width="200px" pt={2} />
-              ) : rx.notes ? (
-                <Text fontSize="md">{rx.notes}</Text>
+                <SkeletonText noOfLines={1} width="100px" />
               ) : (
-                <Text fontSize="md" as="i">
-                  None
+                <Text
+                  fontSize="md"
+                  as={!rx?.notes ? 'i' : undefined}
+                  color={!rx?.notes ? 'gray.500' : undefined}
+                >
+                  {rx?.notes ? rx.notes : 'None'}
                 </Text>
               )}
-            </HStack>
+            </InfoGrid>
+
+            <InfoGrid name="Status">
+              {loading ? (
+                <SkeletonText noOfLines={1} width="100px" />
+              ) : (
+                <Tooltip label={stateTip}>
+                  <Badge colorScheme={stateColor}>{state}</Badge>
+                </Tooltip>
+              )}
+            </InfoGrid>
+
+            <InfoGrid name="Quantity">
+              {loading ? (
+                <SkeletonText noOfLines={1} width="100px" />
+              ) : (
+                <Text fontSize="md">
+                  {dispenseQuantity} ct / {daysSupply} day
+                </Text>
+              )}
+            </InfoGrid>
+
+            <InfoGrid name="Fills Remaining">
+              {loading ? (
+                <SkeletonText noOfLines={1} width="100px" />
+              ) : (
+                <Text fontSize="md">{fillsRemaining}</Text>
+              )}
+            </InfoGrid>
+
+            <InfoGrid name="Fills Allowed">
+              {loading ? (
+                <SkeletonText noOfLines={1} width="100px" />
+              ) : (
+                <Text fontSize="md">{fillsAllowed}</Text>
+              )}
+            </InfoGrid>
+
+            <InfoGrid name="Effective Date">
+              {loading ? (
+                <SkeletonText noOfLines={1} width="100px" />
+              ) : (
+                <Text fontSize="md">{effectiveDate}</Text>
+              )}
+            </InfoGrid>
+
+            <InfoGrid name="Expiration">
+              {loading ? (
+                <SkeletonText noOfLines={1} width="100px" />
+              ) : (
+                <Text fontSize="md">{expirationDate}</Text>
+              )}
+            </InfoGrid>
+
+            <InfoGrid name="Written">
+              {loading ? (
+                <SkeletonText noOfLines={1} width="100px" />
+              ) : (
+                <Text fontSize="md">{writtenAt}</Text>
+              )}
+            </InfoGrid>
+
+            <InfoGrid name="Dispense As Written">
+              {loading ? (
+                <SkeletonText noOfLines={1} width="100px" />
+              ) : (
+                <Text fontSize="md">{dispenseAsWritten ? 'Yes' : 'No'}</Text>
+              )}
+            </InfoGrid>
 
             {orders.length === 0 ? null : (
               <>
@@ -576,6 +410,56 @@ export const Prescription = () => {
                 </VStack>
               </>
             )}
+
+            <Divider />
+            <Text color="gray.500" fontWeight="medium" fontSize="sm">
+              Advanced
+            </Text>
+
+            <InfoGrid name="Id">
+              {loading ? (
+                <SkeletonText noOfLines={1} width="150px" />
+              ) : (
+                <HStack spacing={2}>
+                  <Text fontSize="md">{id}</Text>
+                  <IconButton
+                    variant="ghost"
+                    color="gray.500"
+                    aria-label="Copy external id"
+                    minW="fit-content"
+                    py={0}
+                    _hover={{ backgroundColor: 'transparent' }}
+                    icon={<FiCopy size="1.3em" />}
+                    onClick={() => navigator.clipboard.writeText(id || '')}
+                  />
+                </HStack>
+              )}
+            </InfoGrid>
+
+            <InfoGrid name="External Id">
+              {loading ? (
+                <SkeletonText noOfLines={1} width="65px" />
+              ) : rx.externalId ? (
+                <HStack spacing={2}>
+                  <Text fontSize="md">{rx.externalId}</Text>
+                  <IconButton
+                    variant="ghost"
+                    color="gray.500"
+                    aria-label="Copy external id"
+                    minW="fit-content"
+                    py={0}
+                    size="sm"
+                    _hover={{ backgroundColor: 'transparent' }}
+                    icon={<FiCopy size="1.3em" />}
+                    onClick={() => navigator.clipboard.writeText(rx.externalId || '')}
+                  />
+                </HStack>
+              ) : (
+                <Text fontSize="md" as="i">
+                  None
+                </Text>
+              )}
+            </InfoGrid>
           </VStack>
         </CardBody>
       </Card>

--- a/apps/app/src/views/routes/Prescription.tsx
+++ b/apps/app/src/views/routes/Prescription.tsx
@@ -232,7 +232,7 @@ export const Prescription = () => {
                 {loading ? (
                   <HStack alignContent="center" w="150px" display="flex">
                     <SkeletonCircle size="10" />
-                    <SkeletonText noOfLines={1} flexGrow={1} />
+                    <SkeletonText skeletonHeight={5} noOfLines={1} flexGrow={1} />
                   </HStack>
                 ) : (
                   <PatientView patient={patient} />
@@ -249,7 +249,7 @@ export const Prescription = () => {
                 {loading ? (
                   <HStack alignContent="center" w="150px" display="flex">
                     <SkeletonCircle size="10" />
-                    <SkeletonText noOfLines={1} flexGrow={1} />
+                    <SkeletonText skeletonHeight={5} noOfLines={1} flexGrow={1} />
                   </HStack>
                 ) : (
                   <NameView name={prescriber?.name?.full} />
@@ -263,7 +263,7 @@ export const Prescription = () => {
             </Text>
             <InfoGrid name="Instructions">
               {loading ? (
-                <SkeletonText noOfLines={1} width="100px" />
+                <SkeletonText skeletonHeight={5} noOfLines={1} width="150px" />
               ) : (
                 <Text fontSize="md">{instructions}</Text>
               )}
@@ -271,7 +271,7 @@ export const Prescription = () => {
 
             <InfoGrid name="Pharmacy Notes">
               {loading ? (
-                <SkeletonText noOfLines={1} width="100px" />
+                <SkeletonText skeletonHeight={5} noOfLines={1} width="150px" />
               ) : (
                 <Text
                   fontSize="md"
@@ -285,7 +285,7 @@ export const Prescription = () => {
 
             <InfoGrid name="Status">
               {loading ? (
-                <SkeletonText noOfLines={1} width="100px" />
+                <SkeletonText skeletonHeight={5} noOfLines={1} width="100px" />
               ) : (
                 <Tooltip label={stateTip}>
                   <Badge colorScheme={stateColor}>{state}</Badge>
@@ -295,7 +295,7 @@ export const Prescription = () => {
 
             <InfoGrid name="Quantity">
               {loading ? (
-                <SkeletonText noOfLines={1} width="100px" />
+                <SkeletonText skeletonHeight={5} noOfLines={1} width="100px" />
               ) : (
                 <Text fontSize="md">
                   {dispenseQuantity} ct / {daysSupply} day
@@ -305,7 +305,7 @@ export const Prescription = () => {
 
             <InfoGrid name="Fills Remaining">
               {loading ? (
-                <SkeletonText noOfLines={1} width="100px" />
+                <SkeletonText skeletonHeight={5} noOfLines={1} width="20px" />
               ) : (
                 <Text fontSize="md">{fillsRemaining}</Text>
               )}
@@ -313,7 +313,7 @@ export const Prescription = () => {
 
             <InfoGrid name="Fills Allowed">
               {loading ? (
-                <SkeletonText noOfLines={1} width="100px" />
+                <SkeletonText skeletonHeight={5} noOfLines={1} width="20px" />
               ) : (
                 <Text fontSize="md">{fillsAllowed}</Text>
               )}
@@ -321,7 +321,7 @@ export const Prescription = () => {
 
             <InfoGrid name="Effective Date">
               {loading ? (
-                <SkeletonText noOfLines={1} width="100px" />
+                <SkeletonText skeletonHeight={5} noOfLines={1} width="100px" />
               ) : (
                 <Text fontSize="md">{effectiveDate}</Text>
               )}
@@ -329,7 +329,7 @@ export const Prescription = () => {
 
             <InfoGrid name="Expiration">
               {loading ? (
-                <SkeletonText noOfLines={1} width="100px" />
+                <SkeletonText skeletonHeight={5} noOfLines={1} width="100px" />
               ) : (
                 <Text fontSize="md">{expirationDate}</Text>
               )}
@@ -337,7 +337,7 @@ export const Prescription = () => {
 
             <InfoGrid name="Written">
               {loading ? (
-                <SkeletonText noOfLines={1} width="100px" />
+                <SkeletonText skeletonHeight={5} noOfLines={1} width="100px" />
               ) : (
                 <Text fontSize="md">{writtenAt}</Text>
               )}
@@ -345,7 +345,7 @@ export const Prescription = () => {
 
             <InfoGrid name="Dispense As Written">
               {loading ? (
-                <SkeletonText noOfLines={1} width="100px" />
+                <SkeletonText skeletonHeight={5} noOfLines={1} width="50px" />
               ) : (
                 <Text fontSize="md">{dispenseAsWritten ? 'Yes' : 'No'}</Text>
               )}
@@ -422,7 +422,7 @@ export const Prescription = () => {
 
             <InfoGrid name="Id">
               {loading ? (
-                <SkeletonText noOfLines={1} width="150px" />
+                <SkeletonText skeletonHeight={5} noOfLines={1} width="150px" />
               ) : (
                 <CopyText text={id || ''} />
               )}
@@ -430,7 +430,7 @@ export const Prescription = () => {
 
             <InfoGrid name="External Id">
               {loading ? (
-                <SkeletonText noOfLines={1} width="65px" />
+                <SkeletonText skeletonHeight={5} noOfLines={1} width="65px" />
               ) : rx.externalId ? (
                 <CopyText text={rx.externalId || ''} />
               ) : (


### PR DESCRIPTION
https://www.notion.so/photons/Rx-Page-Info-Hierarchy-e155b8dba73046d390a26dc1e977d9ef?pvs=4

- [x] Could we move instructions and notes into the existing “prescription details” section? They are a part of the prescription details, not separate pieces
- [x] can we call “notes” -> “pharmacy notes”
- [x] could we move id and external id somewhere else? They are not a part of the prescription details so should be moved to a different part

(bonus New)
- [x] changed cancel button to red so it feels more dangerous ⚠️
- [x] get rid of table in favor of grid items so that they collapse to vertical stacked mobile, right now I have to scroll off the right side of the page to see the text
  - <img src="https://github.com/Photon-Health/client/assets/700617/c2101418-9197-4fd1-b012-45361b1b9f30" width="200" />
- [x] Lightened and shrunk the description/name column

# Rx Page 
### Desktop
![Frame 21](https://github.com/Photon-Health/client/assets/700617/16c492f2-8279-4b32-89d8-b190434671c2)
### Mobile
<img width="771" alt="Screen Shot 2023-07-21 at 3 12 59 PM" src="https://github.com/Photon-Health/client/assets/700617/80133f7c-b965-4f69-b231-e50c01f687b3">


# Order Page (Bonus)
### Desktop
![Frame 20 (1)](https://github.com/Photon-Health/client/assets/700617/463e5ca3-72bf-4e88-8c3f-97feafca3768)

### Mobile
![Screen Shot 2023-07-21 at 2 47 41 PM](https://github.com/Photon-Health/client/assets/700617/796a2dd1-7163-4345-9f80-5843f552dd67)
