### PR TITLE
Add Providers with Typeform

### DIFF
--- a/apps/app/src/views/components/Auth.tsx
+++ b/apps/app/src/views/components/Auth.tsx
@@ -1,5 +1,4 @@
 import { Button, Stack } from '@chakra-ui/react';
-import { CopyIcon } from '@chakra-ui/icons';
 
 import { usePhoton } from '@photonhealth/react';
 import { getSettings } from '@client/settings';
@@ -13,33 +12,14 @@ interface AuthProps {
 
 export const Auth = (props: AuthProps) => {
   const { returnTo } = props;
-  const { user, isLoading, isAuthenticated, getToken, login, logout } = usePhoton();
+  const { user, isLoading, isAuthenticated, login, logout } = usePhoton();
   const orgSettings = user?.org_id in settings ? settings[user?.org_id] : settings.default;
-
-  const getAccessToken = async () => {
-    try {
-      const token = await getToken();
-      navigator.clipboard.writeText(token);
-    } catch (e) {
-      console.error(e);
-    }
-  };
 
   if (isLoading) return <Button isLoading loadingText="Loading" colorScheme="gray" />;
 
   if (isAuthenticated)
     return (
       <Stack direction="row" spacing={4}>
-        <Button
-          borderColor="blue.500"
-          textColor="blue.500"
-          colorScheme="blue"
-          rightIcon={<CopyIcon />}
-          variant="outline"
-          onClick={getAccessToken}
-        >
-          Auth Token
-        </Button>
         <Button
           colorScheme="brand"
           onClick={() => {

--- a/apps/app/src/views/routes/Settings/components/Credentials.tsx
+++ b/apps/app/src/views/routes/Settings/components/Credentials.tsx
@@ -1,3 +1,4 @@
+import { CopyIcon } from '@chakra-ui/icons';
 import {
   Box,
   CircularProgress,
@@ -8,7 +9,9 @@ import {
   Alert,
   AlertIcon,
   Container,
-  Divider
+  Divider,
+  Button,
+  HStack
 } from '@chakra-ui/react';
 
 import { usePhoton } from '@photonhealth/react';
@@ -16,9 +19,16 @@ import { usePhoton } from '@photonhealth/react';
 import { ClientInfoCard } from './ClientInfoCard';
 
 export const Credentials = () => {
-  const { getClients } = usePhoton();
+  const { getClients, getToken } = usePhoton();
   const { loading, error, clients } = getClients();
-
+  const getAccessToken = async () => {
+    try {
+      const token = await getToken();
+      navigator.clipboard.writeText(token);
+    } catch (e) {
+      console.error(e);
+    }
+  };
   return (
     <Box
       py={{ base: '4', md: '8' }}
@@ -31,9 +41,22 @@ export const Credentials = () => {
       <Container padding={{ base: '0', md: '0' }}>
         <Box>
           <Stack paddingBottom={5}>
-            <Text fontSize="xl" fontWeight="medium">
-              API Credentials
-            </Text>
+            <HStack justify="space-between">
+              <Text fontSize="xl" fontWeight="medium">
+                API Credentials
+              </Text>
+
+              <Button
+                borderColor="blue.500"
+                textColor="blue.500"
+                colorScheme="blue"
+                rightIcon={<CopyIcon />}
+                variant="outline"
+                onClick={getAccessToken}
+              >
+                Auth Token
+              </Button>
+            </HStack>
             <Divider />
             <Text color="muted" fontSize="md">
               You can execute a client credentials exchange to obtain auth tokens for your

--- a/apps/app/src/views/routes/Settings/index.tsx
+++ b/apps/app/src/views/routes/Settings/index.tsx
@@ -24,7 +24,7 @@ const Buttons = ({ orgId, orgName }: { orgId: string; orgName: string }) => (
         rightIcon={<AddIcon />}
         variant="outline"
       >
-        Add a New Provider
+        Add a Provider
       </Button>
     </Link>
     <Auth />

--- a/apps/app/src/views/routes/Settings/index.tsx
+++ b/apps/app/src/views/routes/Settings/index.tsx
@@ -1,4 +1,4 @@
-import { HStack, TabPanel, TabPanels, Tab, TabList, Tabs } from '@chakra-ui/react';
+import { HStack, TabPanel, TabPanels, Tab, TabList, Tabs, Button, Link } from '@chakra-ui/react';
 import { useEffect, useState } from 'react';
 import { usePhoton } from '@photonhealth/react';
 import { useLocation, useNavigate } from 'react-router-dom';
@@ -9,9 +9,24 @@ import { Auth } from '../../components/Auth';
 import { TemplateTab } from './views/TemplateTab';
 import { TreatmentTab } from './views/TreatmentTab';
 import { UserTab } from './views/UserTab';
+import { AddIcon } from '@chakra-ui/icons';
 
-const buttons = (
+const Buttons = ({ orgId, orgName }: { orgId: string; orgName: string }) => (
   <HStack>
+    <Link
+      href={`https://fxr8djfdbq8.typeform.com/to/awCi4YTp#org_id=${orgId}&org_name=${orgName}`}
+      isExternal
+    >
+      <Button
+        borderColor="blue.500"
+        textColor="blue.500"
+        colorScheme="blue"
+        rightIcon={<AddIcon />}
+        variant="outline"
+      >
+        Add a New Provider
+      </Button>
+    </Link>
     <Auth />
     <ColorModeSwitcher />
   </HStack>
@@ -58,9 +73,17 @@ export const Settings = () => {
         break;
     }
   };
-
+  console.log('organization', organization);
   return (
-    <Page header="Settings" buttons={buttons}>
+    <Page
+      header="Settings"
+      buttons={
+        <Buttons
+          orgId={organization?.organization?.id}
+          orgName={organization?.organization?.name}
+        />
+      }
+    >
       <Tabs index={tabIndex} onChange={handleTabsChange}>
         <TabList>
           <Tab>User</Tab>

--- a/apps/app/src/views/routes/Settings/index.tsx
+++ b/apps/app/src/views/routes/Settings/index.tsx
@@ -73,7 +73,7 @@ export const Settings = () => {
         break;
     }
   };
-  console.log('organization', organization);
+
   return (
     <Page
       header="Settings"


### PR DESCRIPTION
Placement of Auth Token got swapped with Add Provider

<img width="500" alt="Screen Shot 2023-07-24 at 10 49 29 AM" src="https://github.com/Photon-Health/client/assets/700617/9e39df55-a8d7-480b-bdaa-363c0e882b94" />

This opens up a form into a new tab with Org name and id as hidden fields on the form. When you're done submitting, you'll see in the `#new-provider` slack channel:

<img width="500" alt="Screen Shot 2023-07-24 at 10 51 32 AM" src="https://github.com/Photon-Health/client/assets/700617/fe9f5f75-546e-4f7e-9195-c5436244c829">

### Outside of this PR
- [x] pay for typeform so we can add branding and logic tree
- [ ] update form with relevant questions 
