### PR TITLE
Disable create order when rx depleted

### DIFF
--- a/apps/app/src/views/routes/Prescription.tsx
+++ b/apps/app/src/views/routes/Prescription.tsx
@@ -45,7 +45,7 @@ import { Page } from '../components/Page';
 import { confirmWrapper } from '../components/GuardDialog';
 import PatientView from '../components/PatientView';
 import NameView from '../components/NameView';
-import { Fill, Maybe } from 'packages/sdk/dist/types';
+import { types } from '@photonhealth/sdk';
 import OrderStatusBadge, { OrderFulfillmentState } from '../components/OrderStatusBadge';
 import InfoGrid from '../components/InfoGrid';
 import CopyText from '../components/CopyText';
@@ -303,6 +303,7 @@ export const Prescription = () => {
                   to={`/orders/new?prescriptionId=${id}${
                     patient?.id ? `&patientId=${patient?.id}` : ''
                   }`}
+                  isDisabled={rx.state === types.PrescriptionState.Depleted}
                   colorScheme="blue"
                   size="sm"
                 >
@@ -319,7 +320,7 @@ export const Prescription = () => {
                 ) : (
                   <>
                     <VStack spacing={4} w="full">
-                      {orders.map((fill: Maybe<Fill>) => {
+                      {orders.map((fill: types.Maybe<types.Fill>) => {
                         if (!fill) return null;
                         const address = fill?.order?.pharmacy?.address;
                         const addressString = formatAddress(address as FormatAddressProps);

--- a/apps/app/src/views/routes/Prescriptions.tsx
+++ b/apps/app/src/views/routes/Prescriptions.tsx
@@ -41,25 +41,29 @@ const MedView = (props: MedViewProps) => {
 interface ActionsViewProps {
   prescriptionId: string;
   patientId: string;
+  disableCreateOrder: boolean;
 }
 
 const ActionsView = (props: ActionsViewProps) => {
-  const { prescriptionId, patientId } = props;
+  const { prescriptionId, patientId, disableCreateOrder = false } = props;
   return (
     <HStack spacing="0">
       <IconButton
         icon={<FiInfo fontSize="1.25rem" />}
         variant="ghost"
         aria-label="View prescription details"
+        title="View prescription details"
         as={RouterLink}
         to={`/prescriptions/${prescriptionId}`}
       />
       <IconButton
         icon={<FiShoppingCart fontSize="1.25rem" />}
         variant="ghost"
-        aria-label="New Order"
+        aria-label="Create Order"
+        title="Create Order"
         as={RouterLink}
         to={`/orders/new?patientId=${patientId}&prescriptionIds=${prescriptionId}`}
+        isDisabled={disableCreateOrder}
       />
     </HStack>
   );
@@ -140,7 +144,13 @@ const renderRow = (rx: any) => {
     ),
     prescriber: <NameView name={prescriber} />,
     writtenAt: <Text>{writtenAt}</Text>,
-    actions: <ActionsView prescriptionId={id} patientId={rx.patient.id} />
+    actions: (
+      <ActionsView
+        prescriptionId={id}
+        patientId={rx.patient.id}
+        disableCreateOrder={rx.state === types.PrescriptionState.Depleted}
+      />
+    )
   };
 };
 


### PR DESCRIPTION
Fixes: [Remove ability to create an order for a depleted prescription](https://www.notion.so/photons/Remove-ability-to-create-an-order-for-a-depleted-prescription-c039f447647541d8875ede200610a1fd) 

In depleted, create order
- disabled on prescriptions table
- disabled on prescription view