### PR TITLE
Pass in Patient data to Prescribe Workflow

### DIFF
--- a/packages/elements/index.html
+++ b/packages/elements/index.html
@@ -16,7 +16,6 @@
     >
       <div style="padding: 15px">
         <photon-prescribe-workflow
-          patient='{"externalId":"123abc","firstName":"paul","lastName":"thomas","dateOfBirth":"2000-01-01","sex":"MALE","phone":"+17135609948","email":"paul@aoeu.com"}'
           enable-order="true"
           enable-send-to-patient="true"
           enable-local-pickup="true"

--- a/packages/elements/index.html
+++ b/packages/elements/index.html
@@ -16,7 +16,7 @@
     >
       <div style="padding: 15px">
         <photon-prescribe-workflow
-          patient-id="pat_01GQ0XFBHSH3YXN936A2D2SD7Y"
+          patient='{"externalId":"123abc","firstName":"paul","lastName":"thomas","dateOfBirth":"2000-01-01","sex":"MALE","phone":"+17135609948","email":"paul@aoeu.com"}'
           enable-order="true"
           enable-send-to-patient="true"
           enable-local-pickup="true"

--- a/packages/elements/src/photon-multirx-form/index.tsx
+++ b/packages/elements/src/photon-multirx-form/index.tsx
@@ -464,6 +464,7 @@ customElement(
                 patientId={props?.patientId}
                 patient={props?.patient}
                 client={client!}
+                address={props?.address}
                 enableOrder={props.enableOrder}
                 hideAddress={!!props.address}
               />

--- a/packages/elements/src/photon-multirx-form/index.tsx
+++ b/packages/elements/src/photon-multirx-form/index.tsx
@@ -18,7 +18,7 @@ import { createEffect, onMount, createSignal, Show, For } from 'solid-js';
 import type { FormError } from '../stores/form';
 import { createFormStore } from '../stores/form';
 import { usePhoton } from '../context';
-import { Order, Prescription, PrescriptionTemplate } from '@photonhealth/sdk/dist/types';
+import { Order, Prescription, PrescriptionTemplate, SexType } from '@photonhealth/sdk/dist/types';
 import { AddPrescriptionCard } from './components/AddPrescriptionCard';
 import { PatientCard } from './components/PatientCard';
 import { DraftPrescriptionCard } from './components/DraftPrescriptionCard';
@@ -71,6 +71,15 @@ customElement(
   (
     props: {
       patientId?: string;
+      patient?: {
+        externalId: string;
+        firstName: string;
+        lastName: string;
+        dateOfBirth: string;
+        sex: SexType;
+        phone: string;
+        email?: string;
+      };
       templateIds?: string;
       hideSubmit: boolean;
       hideTemplates: boolean;

--- a/packages/elements/src/photon-multirx-form/index.tsx
+++ b/packages/elements/src/photon-multirx-form/index.tsx
@@ -18,13 +18,7 @@ import { createEffect, onMount, createSignal, Show, For } from 'solid-js';
 import type { FormError } from '../stores/form';
 import { createFormStore } from '../stores/form';
 import { usePhoton } from '../context';
-import {
-  Order,
-  Patient,
-  Prescription,
-  PrescriptionTemplate,
-  SexType
-} from '@photonhealth/sdk/dist/types';
+import { Order, Prescription, PrescriptionTemplate, SexType } from '@photonhealth/sdk/dist/types';
 import { AddPrescriptionCard } from './components/AddPrescriptionCard';
 import { PatientCard } from './components/PatientCard';
 import { DraftPrescriptionCard } from './components/DraftPrescriptionCard';

--- a/packages/elements/src/stores/patient.ts
+++ b/packages/elements/src/stores/patient.ts
@@ -93,6 +93,14 @@ const createPatientStore = () => {
     });
   };
 
+  const setSelectedPatient = (patient: Patient) => {
+    setStore('selectedPatient', {
+      ...store.selectedPatient,
+      isLoading: false,
+      data: patient
+    });
+  };
+
   const getPatients = async (
     client: PhotonClient,
     args?: {
@@ -185,6 +193,7 @@ const createPatientStore = () => {
     actions: {
       getPatients,
       getSelectedPatient,
+      setSelectedPatient,
       clearSelectedPatient,
       reset
     }


### PR DESCRIPTION
Instead of relying on syncing our customer's data ahead of time, we can make patients on the fly by passing in their information like this:

``` html
<photon-prescribe-workflow
  patient='{"externalId":"123abc","firstName":"paul","lastName":"thomas","dateOfBirth":"2000-01-01","sex":"MALE","phone":"+17135609948","email":"paul@aoeu.com"}'
  address='{"city":"brooklyn","postalCode":"11221","state":"NY","street1":"372 Jefferson Ave"}'
></photon-prescribe-workflow>
```