### PR TITLE
Fix Mail order pharmacy selection persisting in local pickup tab

### DIFF
--- a/apps/app/src/views/routes/NewOrder/components/SelectPharmacyCard/components/MailOrder.tsx
+++ b/apps/app/src/views/routes/NewOrder/components/SelectPharmacyCard/components/MailOrder.tsx
@@ -66,7 +66,7 @@ export const MailOrder = ({
     if (isVisible && pharmOptions?.length === 1 && !pharmacyId) {
       setFieldValue('pharmacyId', pharmOptions[0].id);
     }
-  }, [isVisible, pharmOptions, pharmacyId]);
+  }, [isVisible]);
 
   const borderColor = useColorModeValue('gray.200', 'gray.700');
 


### PR DESCRIPTION
If there's one mail order option it should auto select the only option. The problem is it had a weird race condition unselecting while still being visible when you switch tabs.

https://www.notion.so/photons/Mail-order-pharmacy-selection-persisting-in-local-pickup-tab-ebd3e8a4279a4b94a06c388daef5cec4?pvs=4