### PR TITLE
Remove patient instructions on rx review

### DIFF
--- a/apps/patient/src/graphql/queries.ts
+++ b/apps/patient/src/graphql/queries.ts
@@ -57,7 +57,6 @@ export const GET_ORDER = gql`
           dispenseQuantity
           expirationDate
           fillsAllowed
-          instructions
         }
       }
       patient {

--- a/apps/patient/src/utils/text.ts
+++ b/apps/patient/src/utils/text.ts
@@ -12,7 +12,6 @@ export const text = {
     refills: 'Refills',
     substitutions: 'Substitutions',
     expires: 'Expires',
-    instructions: 'Instructions',
     cta: 'Search for a pharmacy'
   },
   readyBy: {

--- a/apps/patient/src/views/Review.tsx
+++ b/apps/patient/src/views/Review.tsx
@@ -116,10 +116,6 @@ export const Review = () => {
                             </Text>
                           </HStack>
                         </HStack>
-                        <HStack w="full" align="start">
-                          <Text color="gray.500">{t.review.instructions}</Text>
-                          <Text data-dd-privacy="mask">{prescription.instructions}</Text>
-                        </HStack>
                       </VStack>
                     </AccordionPanel>
                   </CardBody>


### PR DESCRIPTION
Instructions on prescriptions can be confusing for people (like myself) that aren’t familiar with medical terminology. For example, not everyone knows that “Take 1 BID PO” means “Take one tablet twice a day, with meals.” It's the pharmacists job to make this sort of translation. So we're removing to not confuse people.

[See ticket](https://www.notion.so/photons/Remove-instructions-on-patient-rx-review-00d4ba992f4e4e73b03a886785a2415e)