### PR TITLE
Draft Prescription Refactor

### DIFF
--- a/packages/components/dev/App.tsx
+++ b/packages/components/dev/App.tsx
@@ -8,6 +8,44 @@ import { randomNames } from '../src/sampleData/randomNames';
 import ComboBox from '../src/particles/ComboBox';
 import PharmacySelect from '../src/systems/PharmacySelect';
 import Card from '../src/particles/Card';
+import DraftPrescriptions, { DraftPrescription } from '../src/systems/DraftPrescriptios';
+
+const draftPrescriptions: DraftPrescription[] = [
+  {
+    id: '1',
+    effectiveDate: '2021-01-01',
+    treatment: {
+      name: 'Metroprolol 50mg'
+    },
+    dispenseAsWritten: false,
+    dispenseQuantity: 1,
+    dispenseUnit: 'dispenseUnit',
+    daysSupply: 1,
+    refillsInput: 1,
+    instructions: 'instructions',
+    notes: 'notes',
+    fillsAllowed: 1,
+    addToTemplates: false,
+    catalogId: 'catalogId'
+  },
+  {
+    id: '2',
+    effectiveDate: '2021-01-01',
+    treatment: {
+      name: 'lisinopril 20 MG / hydroCHLOROthiazide 12.5 MG Oral Tablet'
+    },
+    dispenseAsWritten: false,
+    dispenseQuantity: 1,
+    dispenseUnit: 'dispenseUnit',
+    daysSupply: 1,
+    refillsInput: 1,
+    instructions: 'Here are some much longer instructions that will wrap around the card.',
+    notes: 'notes',
+    fillsAllowed: 1,
+    addToTemplates: false,
+    catalogId: 'catalogId'
+  }
+];
 
 const App = () => {
   const [setPharmacy] = createSignal<any>();
@@ -37,6 +75,7 @@ const App = () => {
       <div>
         <h1>Photon Component Systems</h1>
       </div>
+
       <Client
         id="7N9QZujlNJHL8EIPqXpu1wq8OuXqoxKb"
         org="org_KzSVZBQixLRkqj5d"
@@ -45,8 +84,16 @@ const App = () => {
         uri="https://api.boson.health/graphql"
       >
         <div class="mb-10">
+          <h2>Draft Presciptions</h2>
+          <DraftPrescriptions draftPrescriptions={draftPrescriptions} />
+          <h2>Loading Draft Presciptions</h2>
+          <DraftPrescriptions draftPrescriptions={[]} loading />
+        </div>
+
+        <div class="mb-10">
           <div>
             <h2>ComboBox</h2>
+
             <ComboBox>
               <ComboBox.Input
                 onInput={(e) => setQuery(e.currentTarget.value)}

--- a/packages/components/dev/App.tsx
+++ b/packages/components/dev/App.tsx
@@ -117,6 +117,7 @@ const App = () => {
               'tmp_01H5JB37PPK9F64RE3QQ52WD7M',
               'tmp_01GQJDV39GPEJ03BATZV1X0SRJ'
             ]}
+            prescriptionIds={['rx_01H82MN6S6FN9PN0K7FTKGWC60', 'rx_01H82RKH4K1RA4RS2VG4H8J8XG']}
           />
         </div>
 

--- a/packages/components/dev/App.tsx
+++ b/packages/components/dev/App.tsx
@@ -8,14 +8,22 @@ import { randomNames } from '../src/sampleData/randomNames';
 import ComboBox from '../src/particles/ComboBox';
 import PharmacySelect from '../src/systems/PharmacySelect';
 import Card from '../src/particles/Card';
-import DraftPrescriptions, { DraftPrescription } from '../src/systems/DraftPrescriptios';
+import DraftPrescriptions, { DraftPrescription } from '../src/systems/DraftPrescriptions';
 
 const draftPrescriptions: DraftPrescription[] = [
   {
     id: '1',
     effectiveDate: '2021-01-01',
     treatment: {
-      name: 'Metroprolol 50mg'
+      name: 'Metroprolol 50mg',
+      id: 'treatmentId',
+      codes: {
+        rxcui: 'String',
+        productNDC: 'String',
+        packageNDC: 'String',
+        SKU: 'String',
+        HCPCS: 'String'
+      }
     },
     dispenseAsWritten: false,
     dispenseQuantity: 1,
@@ -32,7 +40,15 @@ const draftPrescriptions: DraftPrescription[] = [
     id: '2',
     effectiveDate: '2021-01-01',
     treatment: {
-      name: 'lisinopril 20 MG / hydroCHLOROthiazide 12.5 MG Oral Tablet'
+      name: 'Metroprolol 50mg',
+      id: 'treatmentId',
+      codes: {
+        rxcui: 'String',
+        productNDC: 'String',
+        packageNDC: 'String',
+        SKU: 'String',
+        HCPCS: 'String'
+      }
     },
     dispenseAsWritten: false,
     dispenseQuantity: 1,
@@ -53,6 +69,9 @@ const App = () => {
   const [query, setQuery] = createSignal('');
   const [patientIds, setPatientIds] = createSignal<string[]>([]);
   const [timedAddress, setTimedAddress] = createSignal<string>('');
+  const [draftPrescriptionsFromTemplates, setDraftPrescriptions] = createSignal<
+    DraftPrescription[]
+  >([]);
 
   const rando = randomNames.slice(0, 3);
   const filteredPeople = createMemo(() => {
@@ -85,9 +104,20 @@ const App = () => {
       >
         <div class="mb-10">
           <h2>Draft Presciptions</h2>
-          <DraftPrescriptions draftPrescriptions={draftPrescriptions} />
-          <h2>Loading Draft Presciptions</h2>
-          <DraftPrescriptions draftPrescriptions={[]} loading />
+          <DraftPrescriptions
+            draftPrescriptions={draftPrescriptions}
+            setDraftPrescriptions={setDraftPrescriptions}
+          />
+          <h2>Fetching Draft Presciptions</h2>
+          <DraftPrescriptions
+            draftPrescriptions={draftPrescriptionsFromTemplates()}
+            setDraftPrescriptions={setDraftPrescriptions}
+            templateIds={[
+              'tmp_01H5JXWKYFMYT70RND1CGQCFKZ',
+              'tmp_01H5JB37PPK9F64RE3QQ52WD7M',
+              'tmp_01GQJDV39GPEJ03BATZV1X0SRJ'
+            ]}
+          />
         </div>
 
         <div class="mb-10">

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -2,6 +2,15 @@ import RadioGroup from './particles/RadioGroup';
 import Text from './particles/Text';
 import DoseCalculator from './systems/DoseCalculator';
 import PharmacySelect from './systems/PharmacySelect';
+import DraftPrescriptions from './systems/DraftPrescriptions';
 import SDKProvider, { usePhotonClient } from './systems/SDKProvider';
 
-export { Text, RadioGroup, DoseCalculator, PharmacySelect, SDKProvider, usePhotonClient };
+export {
+  Text,
+  RadioGroup,
+  DoseCalculator,
+  PharmacySelect,
+  SDKProvider,
+  DraftPrescriptions,
+  usePhotonClient
+};

--- a/packages/components/src/particles/Text/index.tsx
+++ b/packages/components/src/particles/Text/index.tsx
@@ -3,7 +3,7 @@ import { JSXElement, Show } from 'solid-js';
 import { createMemo, mergeProps } from 'solid-js';
 
 export type TextSize = 'lg' | 'md' | 'sm';
-export type TextColor = 'black' | 'gray';
+export type TextColor = 'black' | 'gray' | 'red';
 
 export interface TextProps {
   size?: TextSize;
@@ -25,6 +25,7 @@ export default function Text(props: TextProps) {
       'text-lg leading-snug	': merged.size === 'lg',
       'text-black': !props.loading && merged.color === 'black',
       'text-slate-500': !props.loading && merged.color === 'gray',
+      'text-red-500': !props.loading && merged.color === 'red',
       'text-transparent box-border rounded-md': props.loading,
       'bg-gray-100': !props.selected && props.loading,
       'bg-blue-100': props.selected && props.loading

--- a/packages/components/src/systems/DraftPrescriptions/index.tsx
+++ b/packages/components/src/systems/DraftPrescriptions/index.tsx
@@ -1,4 +1,4 @@
-import { PrescriptionTemplate } from '@photonhealth/sdk/dist/types';
+import { Catalog, PrescriptionTemplate } from '@photonhealth/sdk/dist/types';
 import gql from 'graphql-tag';
 import { createSignal, For, JSXElement, mergeProps, onMount, Show } from 'solid-js';
 import Card from '../../particles/Card';
@@ -30,6 +30,26 @@ const GetTemplatesFromCatalogs = gql`
   }
 `;
 
+// Can't use a fragment because of the type difference between Prescription and PrescriptionTemplate
+const GetPrescription = gql`
+  query GetPrescription($id: ID!) {
+    prescription(id: $id) {
+      id
+      daysSupply
+      dispenseAsWritten
+      dispenseQuantity
+      dispenseUnit
+      instructions
+      notes
+      fillsAllowed
+      treatment {
+        id
+        name
+      }
+    }
+  }
+`;
+
 export type DraftPrescription = PrescriptionTemplate & {
   refillsInput?: number;
   addToTemplates?: boolean;
@@ -51,50 +71,87 @@ const DraftPrescription = (props: { LeftChildren: JSXElement; RightChildren?: JS
 interface DraftPrescriptionsProps {
   draftPrescriptions: DraftPrescription[];
   templateIds?: string[];
+  prescriptionIds?: string[];
   setDraftPrescriptions: (draftPrescriptions: DraftPrescription[]) => void;
   handleEdit?: (draftId: string) => void;
   handleDelete?: (draftId: string) => void;
+  error?: string;
 }
 
 export default function DraftPrescriptions(props: DraftPrescriptionsProps) {
-  const merged = mergeProps({ draftPrescriptions: [], templateIds: [] }, props);
+  const merged = mergeProps(
+    {
+      draftPrescriptions: [] as string[],
+      templateIds: [] as string[],
+      prescriptionIds: [] as string[]
+    },
+    props
+  );
   const [isLoading, setIsLoading] = createSignal<boolean>(true);
   const client = usePhotonClient();
 
-  async function fetchTemplates() {
+  async function fetchDrafts() {
     setIsLoading(true);
-    const { data } = await client!.apollo.query({ query: GetTemplatesFromCatalogs });
     const draftPrescriptions: DraftPrescription[] = [];
 
-    if (data?.catalogs) {
-      // get all templates, most likely only one catalog
-      const templates = data.catalogs.reduce(
-        (acc: PrescriptionTemplate[], catalog: any) => [...acc, ...catalog.templates],
-        []
-      );
-      // for each templateId, find the template by id and set the draft prescription
-      merged.templateIds.forEach((templateId: string) => {
-        const template = templates.find(
-          (template: PrescriptionTemplate) => template.id === templateId
+    // fetch templates
+    if (merged.templateIds.length > 0) {
+      const { data } = await client!.apollo.query({ query: GetTemplatesFromCatalogs });
+
+      if (data?.catalogs) {
+        // get all templates, most likely only one catalog
+        const templates = data.catalogs.reduce(
+          (acc: PrescriptionTemplate[], catalog: Catalog) => [...acc, ...catalog.templates],
+          []
         );
 
-        if (!template) {
-          return console.error(`Invalid template id ${templateId}`);
-        }
+        // for each templateId, find the template by id and set the draft prescription
+        merged.templateIds.forEach((templateId: string) => {
+          const template = templates.find(
+            (template: PrescriptionTemplate) => template.id === templateId
+          );
 
-        if (
-          // minimum template fields required to create a prescription
-          !template?.treatment ||
-          !template?.dispenseQuantity ||
-          !template?.dispenseUnit ||
-          !template?.fillsAllowed ||
-          !template?.instructions
-        ) {
-          console.error(`Template is missing required prescription details ${templateId}`);
-        } else {
-          draftPrescriptions.push(generateDraftPrescription(template));
-        }
-      });
+          if (!template) {
+            return console.error(`Invalid template id ${templateId}`);
+          }
+
+          if (
+            // minimum template fields required to create a prescription
+            !template?.treatment ||
+            !template?.dispenseQuantity ||
+            !template?.dispenseUnit ||
+            !template?.fillsAllowed ||
+            !template?.instructions
+          ) {
+            console.error(`Template is missing required prescription details ${templateId}`);
+          } else {
+            draftPrescriptions.push(generateDraftPrescription(template));
+          }
+        });
+      }
+    }
+
+    // fetch prescriptions
+    if (merged.prescriptionIds.length > 0) {
+      // for each prescriptionId, find the prescription by id and set the draft prescription
+      await Promise.allSettled(
+        merged.prescriptionIds.map(async (prescriptionId: string) => {
+          const { data } = await client!.apollo.query({
+            query: GetPrescription,
+            variables: {
+              id: prescriptionId
+            }
+          });
+
+          const prescription = data?.prescription;
+
+          if (!prescription) {
+            return console.error(`Invalid prescription id ${prescriptionId}`);
+          }
+
+          draftPrescriptions.push(generateDraftPrescription(prescription));
+        })
+      );
     }
     if (draftPrescriptions.length > 0) {
       props.setDraftPrescriptions(draftPrescriptions);
@@ -103,9 +160,8 @@ export default function DraftPrescriptions(props: DraftPrescriptionsProps) {
   }
 
   onMount(() => {
-    console.log(merged.templateIds.length);
-    if (merged.templateIds.length > 0) {
-      fetchTemplates();
+    if (merged.templateIds.length > 0 || merged.prescriptionIds.length > 0) {
+      fetchDrafts();
     } else {
       setIsLoading(false);
     }
@@ -115,7 +171,7 @@ export default function DraftPrescriptions(props: DraftPrescriptionsProps) {
     <div class="space-y-3">
       {/* Show when Loading */}
       <Show when={isLoading()}>
-        <For each={merged.templateIds}>
+        <For each={[...merged.templateIds, ...merged.prescriptionIds]}>
           {() => (
             <DraftPrescription
               LeftChildren={
@@ -131,7 +187,7 @@ export default function DraftPrescriptions(props: DraftPrescriptionsProps) {
 
       {/* Show when No Drafts */}
       <Show when={!isLoading() && merged.draftPrescriptions.length === 0}>
-        <Text color="gray" class="italic">
+        <Text color={merged.error ? 'red' : 'gray'} class="italic">
           No prescriptions pending
         </Text>
       </Show>

--- a/packages/components/src/systems/DraftPrescriptions/index.tsx
+++ b/packages/components/src/systems/DraftPrescriptions/index.tsx
@@ -1,0 +1,102 @@
+import { For, JSXElement, mergeProps, Show } from 'solid-js';
+import Card from '../../particles/Card';
+import Icon from '../../particles/Icon';
+import Text from '../../particles/Text';
+
+export interface DraftPrescription {
+  id: string;
+  effectiveDate: string;
+  treatment: {
+    name: string;
+  };
+  dispenseAsWritten: boolean;
+  dispenseQuantity: number;
+  dispenseUnit: string;
+  daysSupply: number;
+  refillsInput: number;
+  instructions: string;
+  notes: string;
+  fillsAllowed: number;
+  addToTemplates: boolean;
+  catalogId: string;
+}
+
+interface DraftPrescriptionsProps {
+  loading?: boolean;
+  draftPrescriptions: DraftPrescription[];
+  handleEdit?: (draftId: string) => void;
+  handleDelete?: (draftId: string) => void;
+}
+
+const CardLayout = (props: { LeftChildren: JSXElement; RightChildren?: JSXElement }) => (
+  <Card>
+    <div class="flex justify-between items-center gap-4">
+      <div class="flex flex-col items-start">{props.LeftChildren}</div>
+      <Show when={props?.RightChildren}>
+        <div class="flex flex-col items-start gap-3">{props.RightChildren}</div>
+      </Show>
+    </div>
+  </Card>
+);
+
+export default function DraftPrescriptions(props: DraftPrescriptionsProps) {
+  const merged = mergeProps({ draftPrescriptions: [], loading: false }, props);
+
+  return (
+    <div class="space-y-3">
+      {/* Show when Loading */}
+      <Show when={merged.loading}>
+        <CardLayout
+          LeftChildren={
+            <>
+              <Text size="lg" sampleLoadingText="Medication 100mg" loading />
+              <Text size="sm" sampleLoadingText="Loading notes about the medication" loading />
+            </>
+          }
+        />
+      </Show>
+
+      {/* Show when No Drafts */}
+      <Show when={!merged.loading && merged.draftPrescriptions.length === 0}>
+        <Text color="gray" class="italic">
+          No prescriptions pending
+        </Text>
+      </Show>
+
+      {/* Show when Drafts */}
+      <Show when={!merged.loading && merged.draftPrescriptions.length > 0}>
+        <For each={merged.draftPrescriptions}>
+          {(draft: DraftPrescription) => {
+            return (
+              <CardLayout
+                LeftChildren={
+                  <>
+                    <Text>{draft.treatment.name}</Text>
+                    <Text color="gray" size="sm">
+                      {draft.dispenseQuantity} {draft.dispenseUnit}, {draft.refillsInput} refills -{' '}
+                      {draft.instructions}
+                    </Text>
+                  </>
+                }
+                RightChildren={
+                  <>
+                    <button onClick={() => merged.handleEdit && merged.handleEdit(draft.id)}>
+                      <Icon
+                        name="pencilSquare"
+                        size="sm"
+                        class="text-gray-500 hover:text-amber-500"
+                      />
+                    </button>
+                    <button onClick={() => merged.handleDelete && merged.handleDelete(draft.id)}>
+                      <Icon name="trash" size="sm" class="text-gray-500 hover:text-red-500" />
+                    </button>
+                  </>
+                }
+              />
+            );
+          }}
+        </For>
+      </Show>
+    </div>
+  );
+}

--- a/packages/components/src/systems/DraftPrescriptions/index.tsx
+++ b/packages/components/src/systems/DraftPrescriptions/index.tsx
@@ -62,7 +62,7 @@ const DraftPrescription = (props: { LeftChildren: JSXElement; RightChildren?: JS
     <div class="flex justify-between items-center gap-4">
       <div class="flex flex-col items-start">{props.LeftChildren}</div>
       <Show when={props?.RightChildren}>
-        <div class="flex flex-col items-start gap-3">{props.RightChildren}</div>
+        <div class="flex items-start gap-3">{props.RightChildren}</div>
       </Show>
     </div>
   </Card>

--- a/packages/components/src/systems/DraftPrescriptions/utils/generateDraftPrescription.ts
+++ b/packages/components/src/systems/DraftPrescriptions/utils/generateDraftPrescription.ts
@@ -1,0 +1,21 @@
+import { format } from 'date-fns';
+import { Prescription, PrescriptionTemplate } from '@photonhealth/sdk/dist/types';
+
+const generateDraftPrescription = (prescription: Prescription | PrescriptionTemplate) => ({
+  id: String(Math.random()),
+  effectiveDate: format(new Date(), 'yyyy-MM-dd').toString(),
+  treatment: prescription.treatment,
+  dispenseAsWritten: prescription.dispenseAsWritten,
+  dispenseQuantity: prescription.dispenseQuantity,
+  dispenseUnit: prescription.dispenseUnit,
+  daysSupply: prescription.daysSupply,
+  // when we pre-populate draft prescriptions using template ID's, we need need to update the value for refills here
+  refillsInput: prescription.fillsAllowed ? prescription.fillsAllowed - 1 : 0,
+  fillsAllowed: prescription.fillsAllowed,
+  instructions: prescription.instructions,
+  notes: prescription.notes,
+  addToTemplates: false,
+  catalogId: undefined
+});
+
+export default generateDraftPrescription;

--- a/packages/elements/index.html
+++ b/packages/elements/index.html
@@ -21,6 +21,7 @@
           enable-send-to-patient="true"
           enable-local-pickup="true"
           mail-order-ids="phr_01GA9HPVBVJ0E65P819FD881N0,phr_01GCA54GVKA06C905DETQ9SY98"
+          template-ids="tmp_01H5JB37PPK9F64RE3QQ52WD7M,tmp_01GQJDV39GPEJ03BATZV1X0SRJ"
           prescription-ids="rx_01H6VN3YM5K60PZ8FMM24MD4DX"
         ></photon-prescribe-workflow>
       </div>

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@photonhealth/elements",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/elements/src/photon-multirx-form/components/AddPrescriptionCard.tsx
+++ b/packages/elements/src/photon-multirx-form/components/AddPrescriptionCard.tsx
@@ -66,7 +66,6 @@ export const AddPrescriptionCard = (props: {
           help-text={props.store['treatment']?.error}
           off-catalog-option={offCatalog()}
           on:photon-treatment-selected={(e: any) => {
-            clearForm(props.actions);
             if (e.detail.data.__typename === 'PrescriptionTemplate') {
               repopulateForm(props.actions, e.detail.data);
             } else {

--- a/packages/elements/src/photon-multirx-form/components/DraftPrescriptionCard.tsx
+++ b/packages/elements/src/photon-multirx-form/components/DraftPrescriptionCard.tsx
@@ -134,7 +134,7 @@ export const DraftPrescriptionCard = (props: {
           }}
           templateIds={props.templateIds}
           prescriptionIds={props.prescriptionIds}
-          setDraftPrescriptions={(draftPrescriptions: any) => {
+          setDraftPrescriptions={(draftPrescriptions) => {
             props.actions.updateFormValue({
               key: 'draftPrescriptions',
               value: draftPrescriptions

--- a/packages/elements/src/photon-multirx-form/components/DraftPrescriptionCard.tsx
+++ b/packages/elements/src/photon-multirx-form/components/DraftPrescriptionCard.tsx
@@ -10,10 +10,11 @@ const draftPrescriptionsValidator = message(
 );
 
 export const DraftPrescriptionCard = (props: {
+  templateIds: string[];
+  prescriptionIds: string[];
   prescriptionRef: HTMLDivElement | undefined;
   actions: Record<string, (...args: any) => any>;
   store: Record<string, any>;
-  isLoading: boolean;
   setIsEditing: (isEditing: boolean) => void;
 }) => {
   const [deleteDialogOpen, setDeleteDialogOpen] = createSignal<boolean>(false);
@@ -79,6 +80,11 @@ export const DraftPrescriptionCard = (props: {
     });
     setDeleteDialogOpen(false);
     setDeleteDraftId(undefined);
+
+    if (props.store['draftPrescriptions']?.value?.length === 0) {
+      // reopen form if all drafts are deleted
+      props.setIsEditing(true);
+    }
   };
   const handleDeleteCancel = () => {
     setDeleteDialogOpen(false);
@@ -126,7 +132,15 @@ export const DraftPrescriptionCard = (props: {
           handleEdit={(draftId: string) => {
             checkEditPrescription(draftId);
           }}
-          loading={props.isLoading}
+          templateIds={props.templateIds}
+          prescriptionIds={props.prescriptionIds}
+          setDraftPrescriptions={(draftPrescriptions: any) => {
+            props.actions.updateFormValue({
+              key: 'draftPrescriptions',
+              value: draftPrescriptions
+            });
+          }}
+          error={props.store['draftPrescriptions']?.error}
         />
       </div>
     </photon-card>

--- a/packages/elements/src/photon-multirx-form/components/DraftPrescriptionCard.tsx
+++ b/packages/elements/src/photon-multirx-form/components/DraftPrescriptionCard.tsx
@@ -1,6 +1,7 @@
-import { createSignal, For, Show } from 'solid-js';
-import { message } from '../../validators';
+import { createSignal } from 'solid-js';
+import { DraftPrescriptions } from '@photonhealth/components';
 import { size, array, any } from 'superstruct';
+import { message } from '../../validators';
 import repopulateForm from '../util/repopulateForm';
 
 const draftPrescriptionsValidator = message(
@@ -116,66 +117,17 @@ export const DraftPrescriptionCard = (props: {
       </photon-dialog>
       <div class="flex flex-col gap-3">
         <p class="font-sans text-l font-medium">Pending Prescriptions</p>
-        <Show
-          when={(props.store['draftPrescriptions']?.value ?? []).length === 0 && !props.isLoading}
-        >
-          <div>
-            <photon-card invalid={props.store['draftPrescriptions']?.error}>
-              <p class="italic font-sans text-gray-500">No prescriptions pending</p>
-            </photon-card>
-            <Show when={props.store['draftPrescriptions']?.error}>
-              <p class="font-sans text-red-500 text-sm pt-1.5">
-                {props.store['draftPrescriptions']?.error}
-              </p>
-            </Show>
-          </div>
-        </Show>
-        <Show when={props.isLoading}>
-          <div>
-            <photon-card>
-              <div class="w-full flex justify-between">
-                <p class="italic font-sans text-gray-500">Loading Prescriptions...</p>
-                <sl-spinner style={{ 'font-size': '1rem' }} />
-              </div>
-            </photon-card>
-          </div>
-        </Show>
-        <For each={props.store['draftPrescriptions']?.value ?? []}>
-          {(draft: any) => {
-            return (
-              <photon-card>
-                <div class="flex flex-row items-center">
-                  <div class="flex flex-col flex-grow">
-                    <p class="font-medium font-sans">{draft.treatment.name}</p>
-                    <p class="font-normal text-gray-700 overflow-hidden overflow-ellipsis font-sans">
-                      {/* draft.refillsInput exists here because we are displaying the number of refills, not fills, the user entered into the form as part of the drafted prescription.
-                       We have this stored under refillsInput. This should not have a "+1" unless we update this to show fills*/}
-                      {draft.dispenseQuantity} {draft.dispenseUnit}, {draft.refillsInput} refills -{' '}
-                      {draft.instructions}
-                    </p>
-                  </div>
-                  <div class="flex flex-row">
-                    <sl-icon-button
-                      class="self-end text-xl edit-icon-button"
-                      name="pencil-square"
-                      onClick={() => {
-                        checkEditPrescription(draft.id);
-                      }}
-                    />
-                    <sl-icon-button
-                      class="self-end text-xl remove-icon-button"
-                      name="trash3"
-                      onClick={() => {
-                        setDeleteDialogOpen(true);
-                        setDeleteDraftId(draft.id);
-                      }}
-                    />
-                  </div>
-                </div>
-              </photon-card>
-            );
+        <DraftPrescriptions
+          draftPrescriptions={props.store['draftPrescriptions']?.value ?? []}
+          handleDelete={(draftId: string) => {
+            setDeleteDialogOpen(true);
+            setDeleteDraftId(draftId);
           }}
-        </For>
+          handleEdit={(draftId: string) => {
+            checkEditPrescription(draftId);
+          }}
+          loading={props.isLoading}
+        />
       </div>
     </photon-card>
   );

--- a/packages/elements/src/photon-multirx-form/components/DraftPrescriptionCard.tsx
+++ b/packages/elements/src/photon-multirx-form/components/DraftPrescriptionCard.tsx
@@ -3,6 +3,7 @@ import { DraftPrescriptions } from '@photonhealth/components';
 import { size, array, any } from 'superstruct';
 import { message } from '../../validators';
 import repopulateForm from '../util/repopulateForm';
+import photonStyles from '@photonhealth/components/dist/style.css?inline';
 
 const draftPrescriptionsValidator = message(
   size(array(any()), 1, Infinity),
@@ -93,6 +94,7 @@ export const DraftPrescriptionCard = (props: {
 
   return (
     <photon-card>
+      <style>{photonStyles}</style>
       <photon-dialog
         open={editDialogOpen()}
         label="Overwrite in progress prescription?"


### PR DESCRIPTION
I'm starting to chip away at moving functionality and styling out of `packages/elements` and into `packages/components`... thought this would be a nice small visual change.

The `DraftPrescriptions` component handles its own querying and moves away from using the SDK methods.

![Frame 186](https://github.com/Photon-Health/client/assets/700617/1793eb4d-1585-4ad3-8e1f-2e3f0d8f77ce)

I want to test this in a few different scenarios to make sure I didn't rollback any functionality. Caught a few minor bugs on the way.