### PR TITLE
Scroll to top on status

### DIFF
--- a/apps/patient/src/views/Status.tsx
+++ b/apps/patient/src/views/Status.tsx
@@ -108,6 +108,11 @@ export const Status = () => {
     }
   }, [pharmacy]);
 
+  // People that select a pharmacy low in the list might start at bottom of status page
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, []);
+
   // Only show "Text us now" prompt if pickup and RECEIVED or READY
   const showChatAlert = fulfillment?.state === 'RECEIVED' || fulfillment?.state === 'READY';
 

--- a/apps/patient/src/views/Status.tsx
+++ b/apps/patient/src/views/Status.tsx
@@ -92,14 +92,6 @@ export const Status = () => {
     window.open(url, '_blank').focus();
   };
 
-  useEffect(() => {
-    if (!order?.fulfillment) {
-      setTimeout(() => {
-        window.location.reload();
-      }, 60000);
-    }
-  }, [order?.fulfillment]);
-
   const initializePharmacy = async (p: types.Pharmacy) => {
     const enrichedPharmacy = await enrichPharmacy(p, false);
     setEnrichedPharmacy(enrichedPharmacy);


### PR DESCRIPTION
- scroll to top on status view, helps when a low pharmacy in the list was selected (always thought this was a weird datadog thing)
- remove unnecessary reload for pharmacy details