### PR TITLE
Preferred Pharmacy in Send to Patient Card

### DIFF
--- a/apps/app/src/views/routes/NewOrder/components/SelectPharmacyCard/components/LocalPickup.tsx
+++ b/apps/app/src/views/routes/NewOrder/components/SelectPharmacyCard/components/LocalPickup.tsx
@@ -37,7 +37,7 @@ const formatPharmacyOptions = (p: types.Pharmacy[], preferredIds: string[], prev
           {org.name}, {titleCase(org.address?.street1)}, {titleCase(org.address?.city)},{' '}
           {org.address?.state}{' '}
           {preferredIds.some((id) => id === org.id) ? (
-            <Tag size="sm" colorScheme="yellow" verticalAlign="text-center" me={1}>
+            <Tag size="sm" colorScheme="blue" verticalAlign="text-center" me={1}>
               <TagLeftIcon boxSize="12px" as={StarIcon} />
               <TagLabel>Preferred</TagLabel>
             </Tag>

--- a/apps/app/src/views/routes/NewOrder/components/SelectPharmacyCard/components/Pharmacy.tsx
+++ b/apps/app/src/views/routes/NewOrder/components/SelectPharmacyCard/components/Pharmacy.tsx
@@ -67,7 +67,7 @@ export const Pharmacy = ({
       {showTags ? (
         <Box>
           {isPreferred ? (
-            <Tag size="sm" colorScheme="yellow" mb={1} me={1}>
+            <Tag size="sm" colorScheme="blue" mb={1} me={1}>
               <TagLeftIcon boxSize="12px" as={StarIcon} />
               <TagLabel>Preferred</TagLabel>
             </Tag>

--- a/apps/app/src/views/routes/NewOrder/components/SelectPharmacyCard/components/SendToPatient.tsx
+++ b/apps/app/src/views/routes/NewOrder/components/SelectPharmacyCard/components/SendToPatient.tsx
@@ -1,5 +1,16 @@
-import { Card, HStack, Link, Radio, Text, VStack } from '@chakra-ui/react';
-import { formatPhone } from '../../../../../../utils';
+import { StarIcon } from '@chakra-ui/icons';
+import {
+  Card,
+  HStack,
+  Link,
+  Radio,
+  Tag,
+  TagLabel,
+  TagLeftIcon,
+  Text,
+  VStack
+} from '@chakra-ui/react';
+import { formatAddress, formatPhone } from '../../../../../../utils';
 
 export const SendToPatient = ({ patient }: any) => {
   return patient ? (
@@ -13,16 +24,33 @@ export const SendToPatient = ({ patient }: any) => {
           <Radio isChecked />
           <VStack align="start" spacing={0} wordBreak="break-all">
             {patient.name ? <Text fontWeight="medium">{patient.name.full}</Text> : null}
-            {patient.phone ? (
-              <Link color="gray.500" href={`tel:${patient.phone}`} isExternal>
-                {formatPhone(patient.phone)}
-              </Link>
-            ) : null}
-            {patient.email ? (
-              <Link color="gray.500" href={`mailto:${patient.email}`} isExternal>
-                {patient.email}
-              </Link>
-            ) : null}
+            {patient?.preferredPharmacies?.length || 0 > 0 ? (
+              <>
+                <Text fontSize="sm" color="gray.500">
+                  {patient?.preferredPharmacies?.[0]?.name}{' '}
+                  <Tag size="sm" colorScheme="blue" mb={1} me={1}>
+                    <TagLeftIcon boxSize="12px" as={StarIcon} />
+                    <TagLabel>Preferred</TagLabel>
+                  </Tag>
+                </Text>
+                <Text fontSize="sm" color="gray.500">
+                  {formatAddress(patient?.preferredPharmacies?.[0]?.address)}
+                </Text>
+              </>
+            ) : (
+              <>
+                {patient.phone ? (
+                  <Link fontSize="sm" color="gray.500" href={`tel:${patient.phone}`} isExternal>
+                    {formatPhone(patient.phone)}
+                  </Link>
+                ) : null}
+                {patient.email ? (
+                  <Link fontSize="sm" color="gray.500" href={`mailto:${patient.email}`} isExternal>
+                    {patient.email}
+                  </Link>
+                ) : null}
+              </>
+            )}
           </VStack>
         </HStack>
       </Card>

--- a/apps/app/src/views/routes/NewOrder/components/SelectPharmacyCard/components/SendToPatient.tsx
+++ b/apps/app/src/views/routes/NewOrder/components/SelectPharmacyCard/components/SendToPatient.tsx
@@ -24,7 +24,7 @@ export const SendToPatient = ({ patient }: any) => {
           <Radio isChecked />
           <VStack align="start" spacing={0} wordBreak="break-all">
             {patient.name ? <Text fontWeight="medium">{patient.name.full}</Text> : null}
-            {patient?.preferredPharmacies?.length || 0 > 0 ? (
+            {(patient?.preferredPharmacies?.length ?? 0) > 0 ? (
               <>
                 <Text fontSize="sm" color="gray.500">
                   {patient?.preferredPharmacies?.[0]?.name}{' '}

--- a/apps/patient/src/components/PharmacyCard.tsx
+++ b/apps/patient/src/components/PharmacyCard.tsx
@@ -145,13 +145,13 @@ export const PharmacyCard = memo(function PharmacyCard({
         <VStack align="start" w="full" spacing={1}>
           <HStack spacing={2}>
             {preferred ? (
-              <Tag size="sm" colorScheme="yellow">
+              <Tag size="sm" colorScheme="blue">
                 <TagLeftIcon boxSize="12px" as={FiStar} />
                 <TagLabel> Preferred</TagLabel>
               </Tag>
             ) : null}
             {previous && !preferred ? (
-              <Tag size="sm" colorScheme="blue">
+              <Tag size="sm" colorScheme="green">
                 <TagLeftIcon boxSize="12px" as={FiRotateCcw} />
                 <TagLabel> Previous</TagLabel>
               </Tag>

--- a/packages/components/src/systems/PharmacySelect/PatientDetails.tsx
+++ b/packages/components/src/systems/PharmacySelect/PatientDetails.tsx
@@ -25,6 +25,7 @@ const GetPatientQuery = gql`
         name
         address {
           street1
+          street2
           city
           state
           postalCode
@@ -74,13 +75,12 @@ export function PatientDetails(props: PatientDetailsProps) {
         size="sm"
         sampleLoadingText="111 222 3333"
       >
-        <Show when={preferredPharmacy()}>
+        <Show when={preferredPharmacy()} fallback={<Text>{patient()?.phone}</Text>}>
           {preferredPharmacy()?.name}{' '}
           <Badge size="sm" color="blue" class="ml-1">
             Preferred
           </Badge>
         </Show>
-        <Show when={!preferredPharmacy()}>{patient()?.phone}</Show>
       </Text>
       <Text
         loading={!patient()}
@@ -89,8 +89,9 @@ export function PatientDetails(props: PatientDetailsProps) {
         size="sm"
         sampleLoadingText="loading@gmail.com"
       >
-        <Show when={preferredPharmacy()}>{formatAddress(preferredPharmacy()?.address)}</Show>
-        <Show when={!preferredPharmacy()}>{patient()?.email}</Show>
+        <Show when={preferredPharmacy()} fallback={patient()?.email}>
+          {formatAddress(preferredPharmacy()?.address)}
+        </Show>
       </Text>
     </div>
   );

--- a/packages/components/src/systems/PharmacySelect/PatientDetails.tsx
+++ b/packages/components/src/systems/PharmacySelect/PatientDetails.tsx
@@ -1,9 +1,11 @@
 import { Patient } from '@photonhealth/sdk/dist/types';
 import gql from 'graphql-tag';
+import { format } from 'path';
 import { createMemo, createSignal, onMount, Show } from 'solid-js';
 import Badge from '../../particles/Badge';
 import { useRadioGroup } from '../../particles/RadioGroup';
 import Text from '../../particles/Text';
+import formatAddress from '../../utils/formatAddress';
 import { usePhotonClient } from '../SDKProvider';
 
 interface PatientDetailsProps {
@@ -26,6 +28,7 @@ const GetPatientQuery = gql`
           street1
           city
           state
+          postalCode
         }
       }
     }
@@ -87,11 +90,7 @@ export function PatientDetails(props: PatientDetailsProps) {
         size="sm"
         sampleLoadingText="loading@gmail.com"
       >
-        <Show when={preferredPharmacy()}>
-          {preferredPharmacy()?.address?.street1} {preferredPharmacy()?.address?.city}
-          {', '}
-          {preferredPharmacy()?.address?.state}
-        </Show>
+        <Show when={preferredPharmacy()}>{formatAddress(preferredPharmacy()?.address)}</Show>
         <Show when={!preferredPharmacy()}>{patient()?.email}</Show>
       </Text>
     </div>

--- a/packages/components/src/systems/PharmacySelect/PatientDetails.tsx
+++ b/packages/components/src/systems/PharmacySelect/PatientDetails.tsx
@@ -1,6 +1,5 @@
 import { Patient } from '@photonhealth/sdk/dist/types';
 import gql from 'graphql-tag';
-import { format } from 'path';
 import { createMemo, createSignal, onMount, Show } from 'solid-js';
 import Badge from '../../particles/Badge';
 import { useRadioGroup } from '../../particles/RadioGroup';

--- a/packages/components/src/systems/PharmacySelect/PatientDetails.tsx
+++ b/packages/components/src/systems/PharmacySelect/PatientDetails.tsx
@@ -1,6 +1,7 @@
 import { Patient } from '@photonhealth/sdk/dist/types';
 import gql from 'graphql-tag';
-import { createMemo, createSignal, onMount } from 'solid-js';
+import { createMemo, createSignal, onMount, Show } from 'solid-js';
+import Badge from '../../particles/Badge';
 import { useRadioGroup } from '../../particles/RadioGroup';
 import Text from '../../particles/Text';
 import { usePhotonClient } from '../SDKProvider';
@@ -19,6 +20,14 @@ const GetPatientQuery = gql`
       }
       email
       phone
+      preferredPharmacies {
+        name
+        address {
+          street1
+          city
+          state
+        }
+      }
     }
   }
 `;
@@ -47,6 +56,10 @@ export function PatientDetails(props: PatientDetailsProps) {
     return state.selected === props.patientId;
   });
 
+  const preferredPharmacy = createMemo(() => {
+    return patient()?.preferredPharmacies?.[0];
+  });
+
   return (
     <div class="flex flex-col items-start	">
       <Text loading={!patient()} selected={selected()} sampleLoadingText="Loading Name">
@@ -59,7 +72,13 @@ export function PatientDetails(props: PatientDetailsProps) {
         size="sm"
         sampleLoadingText="111 222 3333"
       >
-        {patient()?.phone}
+        <Show when={preferredPharmacy()}>
+          {preferredPharmacy()?.name}{' '}
+          <Badge size="sm" color="blue" class="ml-1">
+            Preferred
+          </Badge>
+        </Show>
+        <Show when={!preferredPharmacy()}>{patient()?.phone}</Show>
       </Text>
       <Text
         loading={!patient()}
@@ -68,7 +87,12 @@ export function PatientDetails(props: PatientDetailsProps) {
         size="sm"
         sampleLoadingText="loading@gmail.com"
       >
-        {patient()?.email}
+        <Show when={preferredPharmacy()}>
+          {preferredPharmacy()?.address?.street1} {preferredPharmacy()?.address?.city}
+          {', '}
+          {preferredPharmacy()?.address?.state}
+        </Show>
+        <Show when={!preferredPharmacy()}>{patient()?.email}</Show>
       </Text>
     </div>
   );

--- a/packages/components/src/utils/formatAddress.ts
+++ b/packages/components/src/utils/formatAddress.ts
@@ -1,0 +1,12 @@
+import { Address } from '@photonhealth/sdk/dist/types';
+import { toTitleCase } from './toTitleCase';
+
+function formatAddress(address?: Address | null) {
+  if (!address) return '';
+  const { city, postalCode, state, street1, street2 } = address;
+  return `${toTitleCase(street1)}${street2 ? `, ${toTitleCase(street2)}` : ''}, ${toTitleCase(
+    city
+  )}, ${state} ${postalCode || ''}`;
+}
+
+export default formatAddress;

--- a/packages/components/src/utils/toTitleCase.ts
+++ b/packages/components/src/utils/toTitleCase.ts
@@ -1,5 +1,9 @@
 export const toTitleCase = (str: string) => {
-  return str.replace(/\w\S*/g, function (txt) {
-    return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();
-  });
+  return str
+    .toLowerCase()
+    .split(' ')
+    .map((word) => {
+      return word.charAt(0).toUpperCase() + word.slice(1);
+    })
+    .join(' ');
 };

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@photonhealth/elements",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
https://www.notion.so/photons/Preferred-Pharm-on-Send-To-Patient-Card-7eac7940022a4f7fbeb898f26cb296aa?pvs=4

In Elements, top is a patient without preferred, bottom is a patient with preferred set:

<img width="343" alt="Screen Shot 2023-08-23 at 5 12 35 PM" src="https://github.com/Photon-Health/client/assets/700617/ea8681ab-4e67-430e-a635-4185404fc287">


In the Clinical App (Chakra):

<img width="337" alt="Screen Shot 2023-08-23 at 4 52 09 PM" src="https://github.com/Photon-Health/client/assets/700617/551b9bde-abb3-4e06-bf72-a6df8ac71012">

