### PR TITLE
Improved fetch times on list pages (rxs, orders, patients)

### DIFF
--- a/apps/app/declarations/dob-to-age.d.ts
+++ b/apps/app/declarations/dob-to-age.d.ts
@@ -1,0 +1,4 @@
+declare module 'dob-to-age' {
+  function dobToAge(dob: string): string;
+  export = dobToAge;
+}

--- a/apps/app/src/views/routes/Orders.tsx
+++ b/apps/app/src/views/routes/Orders.tsx
@@ -210,10 +210,11 @@ export const Orders = () => {
   const [filterTextDebounce] = useDebounce(filterText, 250);
 
   const isMobile = useBreakpointValue({ base: true, md: false });
-  // TODO when we have code generation, we can use the generated types here
-  const getOrdersData: { first: number; patientId?: string; patientName?: string } = {
+
+  const getOrdersData = {
     first: 25,
-    patientId: patientId || undefined
+    patientId: patientId || undefined,
+    patientName: filterTextDebounce.length > 0 ? filterTextDebounce : undefined
   };
 
   const { data, loading, error, fetchMore, refetch } = useQuery(GET_ORDERS, {
@@ -261,7 +262,6 @@ export const Orders = () => {
                 after: rows?.at(-1)?.id
               },
               updateQuery: (prev, { fetchMoreResult }) => {
-                console.log('fetch more result', fetchMoreResult, prev);
                 if (!fetchMoreResult) return prev;
                 if (fetchMoreResult.orders.length === 0) {
                   setFinished(true);

--- a/apps/app/src/views/routes/Orders.tsx
+++ b/apps/app/src/views/routes/Orders.tsx
@@ -213,7 +213,7 @@ export const Orders = () => {
 
   const getOrdersData = {
     first: 25,
-    patientId: patientId || undefined,
+    patientId: patientId ?? undefined,
     patientName: filterTextDebounce.length > 0 ? filterTextDebounce : undefined
   };
 
@@ -232,7 +232,7 @@ export const Orders = () => {
   useEffect(() => {
     if (filterTextDebounce) {
       refetch({
-        patientName: filterTextDebounce || ''
+        patientName: filterTextDebounce
       });
     }
   }, [filterTextDebounce, refetch]);

--- a/apps/app/src/views/routes/Patients.tsx
+++ b/apps/app/src/views/routes/Patients.tsx
@@ -154,8 +154,9 @@ export const Patients = () => {
   const [disableScroll, setDisableScroll] = useState<boolean>(false);
   const [filterTextDebounce] = useDebounce(filterText, 250);
 
-  const getPatientsData: { first: number; name?: string } = {
-    first: 25
+  const getPatientsData = {
+    first: 25,
+    name: filterTextDebounce.length > 0 ? filterTextDebounce : undefined
   };
   const { data, loading, error, fetchMore, refetch } = useQuery(GET_PATIENTS, {
     variables: getPatientsData

--- a/apps/app/src/views/routes/Patients.tsx
+++ b/apps/app/src/views/routes/Patients.tsx
@@ -19,6 +19,7 @@ import { TbPrescription } from 'react-icons/tb';
 import { Dispatch, SetStateAction, useEffect, useState } from 'react';
 import { gql, useQuery } from '@apollo/client';
 import { useDebounce } from 'use-debounce';
+import dobToAge from 'dob-to-age';
 import { Page } from '../components/Page';
 import { TablePage } from '../components/TablePage';
 import PatientView from '../components/PatientView';
@@ -26,7 +27,7 @@ import ContactView from '../components/ContactView';
 import { Patient } from 'packages/sdk/dist/types';
 
 const GET_PATIENTS = gql`
-  query GetPatients($after: ID, $name: String, $first: Int) {
+  query GetPatients($name: String, $after: ID, $first: Int) {
     patients(after: $after, first: $first, filter: { name: $name }) {
       id
       externalId
@@ -40,8 +41,6 @@ const GET_PATIENTS = gql`
     }
   }
 `;
-
-const dobToAge = require('dob-to-age');
 
 interface EditViewProps {
   id: string;
@@ -166,7 +165,7 @@ export const Patients = () => {
   useEffect(() => {
     if (filterTextDebounce) {
       refetch({
-        name: filterTextDebounce || ''
+        name: filterTextDebounce
       });
     }
   }, [filterTextDebounce, refetch]);

--- a/apps/app/src/views/routes/Patients.tsx
+++ b/apps/app/src/views/routes/Patients.tsx
@@ -166,7 +166,6 @@ export const Patients = () => {
 
   useEffect(() => {
     if (!loading && patients) {
-      console.log('loading', loading, patients);
       setRows(
         patients
           .filter((patient) => !!patient)

--- a/apps/app/src/views/routes/Prescriptions.tsx
+++ b/apps/app/src/views/routes/Prescriptions.tsx
@@ -51,6 +51,8 @@ const GET_PRESCRIPTIONS = gql`
       dispenseQuantity
       daysSupply
       writtenAt
+      fillsRemaining
+      fillsAllowed
       treatment {
         name
       }
@@ -334,7 +336,7 @@ export const Prescriptions = () => {
   useEffect(() => {
     if (filterTextDebounce) {
       refetch({
-        patientName: filterTextDebounce || ''
+        patientName: filterTextDebounce
       });
     }
   }, [filterTextDebounce, refetch]);

--- a/apps/app/src/views/routes/Prescriptions.tsx
+++ b/apps/app/src/views/routes/Prescriptions.tsx
@@ -296,7 +296,7 @@ export const Prescriptions = () => {
     state: status,
     patientName: filterTextDebounce.length > 0 ? filterTextDebounce : undefined
   };
-  console.log('getPrescriptionsData', getPrescriptionsData);
+
   const { data, loading, error, fetchMore } = useQuery(GET_PRESCRIPTIONS, {
     variables: getPrescriptionsData
   });

--- a/apps/app/src/views/routes/Prescriptions.tsx
+++ b/apps/app/src/views/routes/Prescriptions.tsx
@@ -297,7 +297,7 @@ export const Prescriptions = () => {
     patientName: filterTextDebounce.length > 0 ? filterTextDebounce : undefined
   };
 
-  const { data, loading, error, fetchMore } = useQuery(GET_PRESCRIPTIONS, {
+  const { data, loading, error, fetchMore, refetch } = useQuery(GET_PRESCRIPTIONS, {
     variables: getPrescriptionsData
   });
 
@@ -330,6 +330,14 @@ export const Prescriptions = () => {
       setFinished(prescriptions.length === 0);
     }
   }, [loading, prescriptions]);
+
+  useEffect(() => {
+    if (filterTextDebounce) {
+      refetch({
+        patientName: filterTextDebounce || ''
+      });
+    }
+  }, [filterTextDebounce, refetch]);
 
   const firstUpdate = useRef(true);
   useEffect(() => {

--- a/apps/app/tsconfig.json
+++ b/apps/app/tsconfig.json
@@ -17,5 +17,5 @@
     "jsx": "react-jsx"
   },
   "extends": "../../tsconfig.base.json",
-  "include": ["src", "types.d.ts"]
+  "include": ["src", "types.d.ts", "declarations/*.d.ts"]
 }


### PR DESCRIPTION
Caveat this doesn't solve repetitive auth issue on page load. 

### Prescriptions Page
**~57%** improvement on fetch time, from ~1400ms to ~600ms

### Orders Page
**~82%** improvement on fetch time, from ~1294ms to ~225ms

### Orders Page
no improvement, about the same