### PR TITLE
Hide option to set picked up til order received

### DIFF
--- a/apps/patient/src/views/Status.tsx
+++ b/apps/patient/src/views/Status.tsx
@@ -41,7 +41,7 @@ export const Status = () => {
   const type = searchParams.get('type');
 
   const [showFooter, setShowFooter] = useState<boolean>(
-    order?.state === types.OrderState.Placed &&
+    order?.fulfillment?.state === 'RECEIVED' &&
       order?.fulfillment?.type !== types.FulfillmentType.MailOrder
   );
 


### PR DESCRIPTION
Hide the set picked up footer on the status view til the order has been set received.

[More details](https://www.notion.so/photons/Patient-s-accidentally-setting-picked-up-e5a0103d90324c98ba17dc45fe274b4f?pvs=4)