### PR TITLE
Add User Id to Intercom to segment app v website

### DIFF
--- a/apps/app/src/views/components/Intercom.tsx
+++ b/apps/app/src/views/components/Intercom.tsx
@@ -11,7 +11,8 @@ export const Intercom = () => {
         app_id: 'uqg0xvmw',
         name: user.name,
         email: user.email,
-        org_id: user.org_id
+        org_id: user.org_id,
+        user_id: user.id
       });
     }
   }, [user]);


### PR DESCRIPTION
If the user doesn't have a `user_id` then they are probably coming from our landing page website, otherwise they are logged into our clinical app.