### PR TITLE
Better Auth Error messages Elements

### DIFF
--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@photonhealth/elements",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "description": "",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/elements/src/photon-authorized/index.tsx
+++ b/packages/elements/src/photon-authorized/index.tsx
@@ -61,7 +61,10 @@ export const PhotonAuthorized = (p: { children: JSXElement; permissions?: Permis
           <Show
             when={!authenticated()}
             fallback={
-              <Show when={!inOrg()} fallback={<AlertMessage message="Access Denied" />}>
+              <Show
+                when={!inOrg()}
+                fallback={<AlertMessage message="You are not authorized to prescribe" />}
+              >
                 <AlertMessage message="You tried logging in with an account not associated with any organizations" />
               </Show>
             }


### PR DESCRIPTION
don't love the nested fallback `Show` ... but Solid wants to have a single return unlike React