### PR TITLE
Fix Pharmacy selection between tabs

### DIFF
--- a/packages/components/src/systems/PharmacySearch/index.tsx
+++ b/packages/components/src/systems/PharmacySearch/index.tsx
@@ -213,7 +213,7 @@ export default function PharmacySearch(props: PharmacyProps) {
       />
       <InputGroup
         label={
-          <div class="w-full flex items-center">
+          <div class="w-full flex flex-col sm:flex-row sm:items-center mb-2">
             <label class="whitespace-nowrap mr-1">Showing near:</label>
             <a
               href="#!"


### PR DESCRIPTION
I fixed an issue, but it broke something else. Pharmacy Ids weren't being reset when switching to a tab the second time.

also, bonus the location goes to a new line on smoller screens:
<img width="352" alt="Screen Shot 2023-10-18 at 2 56 00 PM" src="https://github.com/Photon-Health/client/assets/700617/55d41fad-266a-439f-88d9-1412a0b7584b">
