### PR TITLE
Hide address form on prescription only form

### DIFF
--- a/packages/elements/src/photon-multirx-form/components/PatientCard.tsx
+++ b/packages/elements/src/photon-multirx-form/components/PatientCard.tsx
@@ -74,8 +74,10 @@ export const PatientCard = (props: {
   });
 
   const patientId = createMemo(() => props.store.patient?.value?.id || props?.patientId);
+  // Show the address form only if the patient doesnt have an address
   const showAddressForm = createMemo(
-    () => props.store.patient?.value?.id && !props.store.patient?.value?.address
+    () =>
+      props.store.patient?.value?.id && !props.store.patient?.value?.address && props.enableOrder
   );
 
   return (

--- a/packages/elements/src/photon-multirx-form/index.tsx
+++ b/packages/elements/src/photon-multirx-form/index.tsx
@@ -359,7 +359,11 @@ customElement(
                 weightUnit={props.weightUnit}
                 enableMedHistory={props.enableMedHistory}
               />
-              <Show when={store.patient?.value?.address}>
+              <Show
+                when={
+                  store.patient?.value?.address || (store.patient?.value?.id && !props.enableOrder)
+                }
+              >
                 <Show when={showForm() || isEditing()}>
                   <div ref={prescriptionRef}>
                     <AddPrescriptionCard


### PR DESCRIPTION
When we released the combined order/presccription view, we added a requirement to set address. That was carried over to the single prescription workflow, where an address _should not_ be required to prescribe