### PR TITLE
Remove client styles

### DIFF
--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@photonhealth/elements",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "description": "",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/elements/src/photon-client/index.tsx
+++ b/packages/elements/src/photon-client/index.tsx
@@ -3,7 +3,6 @@ import { createEffect, createSignal } from 'solid-js';
 import { PhotonClient } from '@photonhealth/sdk';
 import { SDKProvider } from '@photonhealth/components';
 import { makeTimer } from '@solid-primitives/timer';
-import photonStyles from '@photonhealth/components/dist/style.css?inline';
 import { PhotonClientStore } from '../store';
 import { hasAuthParams } from '../utils';
 import { PhotonContext } from '../context';
@@ -150,7 +149,6 @@ customElement(
 
     return (
       <div ref={ref}>
-        <style>{photonStyles}</style>
         <PhotonContext.Provider value={store()}>
           <SDKProvider client={sdk} toastBuffer={props?.toastBuffer || 0}>
             <slot />


### PR DESCRIPTION
Element styles are leaking into a customer's styles. Although Shadow DOM usually prevents this, our client which imports styles wraps their code which could be the issue.

https://photonhealth.slack.com/archives/C03TRQ4NLE5/p1699918542888819