### PR TITLE
Fix disabled create order still allowing creation

### DIFF
--- a/apps/app/src/views/routes/Prescriptions.tsx
+++ b/apps/app/src/views/routes/Prescriptions.tsx
@@ -124,7 +124,8 @@ const ActionsView = (props: ActionsViewProps) => {
             toast({
               description:
                 'A new order cannot be created for a depleted prescription. Please create a new prescription.',
-              status: 'error'
+              status: 'error',
+              position: 'top'
             });
             event.preventDefault();
             return;

--- a/apps/app/src/views/routes/Prescriptions.tsx
+++ b/apps/app/src/views/routes/Prescriptions.tsx
@@ -114,6 +114,13 @@ const ActionsView = (props: ActionsViewProps) => {
         as={RouterLink}
         to={`/orders/new?patientId=${patientId}&prescriptionIds=${prescriptionId}`}
         isDisabled={disableCreateOrder}
+        onClick={(event) => {
+          // Lame, but w/o this the redirect will still happen
+          if (disableCreateOrder) {
+            event.preventDefault();
+            return;
+          }
+        }}
       />
     </HStack>
   );

--- a/apps/app/src/views/routes/Prescriptions.tsx
+++ b/apps/app/src/views/routes/Prescriptions.tsx
@@ -2,8 +2,10 @@ import { Link as RouterLink, useLocation, useSearchParams, useNavigate } from 'r
 
 import {
   Badge,
+  Box,
   Select,
   HStack,
+  Icon,
   IconButton,
   Skeleton,
   SkeletonCircle,
@@ -13,7 +15,7 @@ import {
   Tooltip,
   useToast
 } from '@chakra-ui/react';
-import { FiInfo, FiShoppingCart } from 'react-icons/fi';
+import { FiInfo, FiShoppingCart, FiX } from 'react-icons/fi';
 import { useEffect, useRef, useState } from 'react';
 import { useDebounce } from 'use-debounce';
 
@@ -122,10 +124,34 @@ const ActionsView = (props: ActionsViewProps) => {
           // Lame, but w/o this the redirect will still happen
           if (disableCreateOrder) {
             toast({
-              description:
-                'A new order cannot be created for a depleted prescription. Please create a new prescription.',
-              status: 'error',
-              position: 'top'
+              position: 'top',
+              // TODO: Override default solid theme with this outline variant
+              render: ({ onClose }) => (
+                <Box
+                  color="gray.800"
+                  p={4}
+                  borderWidth="2px"
+                  borderRadius="md"
+                  bg="white"
+                  borderColor="blue.500"
+                >
+                  <HStack align="start">
+                    <Icon as={FiInfo} color="blue.500" boxSize="5" />
+                    <Text>
+                      A new order cannot be created for a depleted prescription. Please create a new
+                      prescription.
+                    </Text>
+                    <IconButton
+                      color="muted"
+                      icon={<FiX fontSize="1.25rem" />}
+                      variant="ghost"
+                      aria-label="close"
+                      title="Close"
+                      onClick={onClose}
+                    />
+                  </HStack>
+                </Box>
+              )
             });
             event.preventDefault();
             return;

--- a/apps/app/src/views/routes/Prescriptions.tsx
+++ b/apps/app/src/views/routes/Prescriptions.tsx
@@ -10,7 +10,8 @@ import {
   SkeletonText,
   Stack,
   Text,
-  Tooltip
+  Tooltip,
+  useToast
 } from '@chakra-ui/react';
 import { FiInfo, FiShoppingCart } from 'react-icons/fi';
 import { useEffect, useRef, useState } from 'react';
@@ -96,6 +97,9 @@ interface ActionsViewProps {
 
 const ActionsView = (props: ActionsViewProps) => {
   const { prescriptionId, patientId, disableCreateOrder = false } = props;
+
+  const toast = useToast();
+
   return (
     <HStack spacing="0">
       <IconButton
@@ -117,6 +121,11 @@ const ActionsView = (props: ActionsViewProps) => {
         onClick={(event) => {
           // Lame, but w/o this the redirect will still happen
           if (disableCreateOrder) {
+            toast({
+              description:
+                'A new order cannot be created for a depleted prescription. Please create a new prescription.',
+              status: 'error'
+            });
             event.preventDefault();
             return;
           }


### PR DESCRIPTION
Clicking the disabled create order icon button on prescriptions list will still take you to the create order page.

<img width="195" alt="image" src="https://github.com/Photon-Health/client/assets/3934326/044266d9-a0e2-43d0-bb35-85e7f700973e">

Added toast on click:

<img width="344" alt="image" src="https://github.com/Photon-Health/client/assets/3934326/47893674-cb70-4a9b-bbeb-fdec2923e8a5">
