### PR TITLE
Fix get directions intermittently failing

### DIFF
--- a/apps/patient/src/views/Status.tsx
+++ b/apps/patient/src/views/Status.tsx
@@ -108,7 +108,7 @@ export const Status = () => {
 
   const handleGetDirections = () => {
     const url = `http://maps.google.com/?q=${pharmacy.name}, ${formatAddress(pharmacy.address)}`;
-    window.open(url, '_blank').focus();
+    window.open(url);
   };
 
   const initializePharmacy = async (p: types.Pharmacy) => {


### PR DESCRIPTION
Noticed errors on pizza tracker "get directions" in Datadog. Looks like `focus()` is not needed here. Removing has the same behavior of opening in new tab but appears more reliable.

MDN on focus(): 

> It may fail due to user settings and the window isn't guaranteed to be frontmost before this method returns.