### PR TITLE
Refetch Patient List

### DIFF
--- a/apps/app/src/views/routes/Patients.tsx
+++ b/apps/app/src/views/routes/Patients.tsx
@@ -180,6 +180,10 @@ export const Patients = () => {
     }
   }, [loading, patients]);
 
+  useEffect(() => {
+    refetch();
+  }, [refetch]);
+
   const skeletonRows = new Array(25).fill(0).map(renderSkeletonRow);
 
   return (


### PR DESCRIPTION
After creating a patient (in elements), we navigate back to the patient list page but the new patient isn't there. This refetches the list.