### PR TITLE
[Suggestion] Attach SDK and Elements versions to requests

### DIFF
--- a/packages/elements/src/photon-client/index.tsx
+++ b/packages/elements/src/photon-client/index.tsx
@@ -6,6 +6,7 @@ import { makeTimer } from '@solid-primitives/timer';
 import { PhotonClientStore } from '../store';
 import { hasAuthParams } from '../utils';
 import { PhotonContext } from '../context';
+import * as packageJson from '../../package.json';
 
 type PhotonClientProps = {
   domain?: string;
@@ -20,6 +21,8 @@ type PhotonClientProps = {
   autoLogin: boolean;
   toastBuffer?: number;
 };
+
+const version = packageJson?.version ?? 'unknown';
 
 customElement(
   'photon-client',
@@ -98,15 +101,18 @@ customElement(
   (props: PhotonClientProps) => {
     let ref: any;
 
-    const sdk = new PhotonClient({
-      domain: props.domain,
-      audience: props.audience,
-      uri: props.uri,
-      clientId: props.id!,
-      redirectURI: props.redirectUri ? props.redirectUri : window.location.origin,
-      organization: props.org,
-      developmentMode: props.developmentMode
-    });
+    const sdk = new PhotonClient(
+      {
+        domain: props.domain,
+        audience: props.audience,
+        uri: props.uri,
+        clientId: props.id!,
+        redirectURI: props.redirectUri ? props.redirectUri : window.location.origin,
+        organization: props.org,
+        developmentMode: props.developmentMode
+      },
+      version
+    );
     const client = new PhotonClientStore(sdk);
     if (props.developmentMode) {
       console.info('[PhotonClient]: Development mode enabled');

--- a/packages/sdk/tsconfig.json
+++ b/packages/sdk/tsconfig.json
@@ -8,6 +8,7 @@
     "strict": true,
     "noEmit": true,
     "jsx": "preserve",
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "resolveJsonModule": true
   }
 }


### PR DESCRIPTION
Here's a suggestion for how we can send the elements+sdk versions. We should then make sure we're logging this on the BE and then generate a metrics view to show which versions are being used by which customers.

I'm open to other approaches as well, this just seemed like the minimal set of changes.

We'd have to have our customers upgrade their libraries to get these changes.

One other approach would be, instead of passing in the elements version to the `PhotonClient` constructor, we could attach something to the global context or something. 