### PR TITLE
Fix auth on browsers with ITP (i.e. safari)

### DIFF
--- a/apps/app/src/configs/auth.ts
+++ b/apps/app/src/configs/auth.ts
@@ -1,6 +1,6 @@
-import { Auth0ProviderOptions } from '@auth0/auth0-react';
+// import { Auth0ProviderOptions } from '@auth0/auth0-react';
 
-export const auth0Config: Auth0ProviderOptions = {
+export const auth0Config = {
   domain: process.env.REACT_APP_AUTH0_DOMAIN as string,
   clientId: process.env.REACT_APP_AUTH0_CLIENT_ID as string,
   audience: process.env.REACT_APP_AUTH0_AUDIENCE as string,

--- a/apps/app/src/configs/auth.ts
+++ b/apps/app/src/configs/auth.ts
@@ -1,5 +1,3 @@
-// import { Auth0ProviderOptions } from '@auth0/auth0-react';
-
 export const auth0Config = {
   domain: process.env.REACT_APP_AUTH0_DOMAIN as string,
   clientId: process.env.REACT_APP_AUTH0_CLIENT_ID as string,

--- a/apps/app/src/views/routes/SelectOrg.tsx
+++ b/apps/app/src/views/routes/SelectOrg.tsx
@@ -76,6 +76,7 @@ export const SelectOrg = () => {
               onClick={() => {
                 setOrganization(id);
                 login({
+                  organizationId: id,
                   appState: {
                     returnTo: from
                   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
       ],
       "dependencies": {
         "@apollo/client": "^3.7.10",
-        "@auth0/auth0-react": "^1.12.0",
+        "@auth0/auth0-react": "^2.2.4",
         "@chakra-ui/icons": "^2.0.19",
         "@chakra-ui/pro-theme": "^0.0.66",
         "@chakra-ui/react": "^2.8.0",
@@ -421,10 +421,11 @@
       }
     },
     "node_modules/@auth0/auth0-react": {
-      "version": "1.12.1",
-      "license": "MIT",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@auth0/auth0-react/-/auth0-react-2.2.4.tgz",
+      "integrity": "sha512-l29PQC0WdgkCoOc6WeMAY26gsy/yXJICW0jHfj0nz8rZZphYKrLNqTRWFFCMJY+sagza9tSgB1kG/UvQYgGh9A==",
       "dependencies": {
-        "@auth0/auth0-spa-js": "^1.22.6"
+        "@auth0/auth0-spa-js": "^2.1.3"
       },
       "peerDependencies": {
         "react": "^16.11.0 || ^17 || ^18",
@@ -432,17 +433,9 @@
       }
     },
     "node_modules/@auth0/auth0-spa-js": {
-      "version": "1.22.6",
-      "license": "MIT",
-      "dependencies": {
-        "abortcontroller-polyfill": "^1.7.3",
-        "browser-tabs-lock": "^1.2.15",
-        "core-js": "^3.25.4",
-        "es-cookie": "~1.3.2",
-        "fast-text-encoding": "^1.0.6",
-        "promise-polyfill": "^8.2.3",
-        "unfetch": "^4.2.0"
-      }
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@auth0/auth0-spa-js/-/auth0-spa-js-2.1.3.tgz",
+      "integrity": "sha512-NMTBNuuG4g3rame1aCnNS5qFYIzsTUV5qTFPRfTyYFS1feS6jsCBR+eTq9YkxCp1yuoM2UIcjunPaoPl77U9xQ=="
     },
     "node_modules/@aw-web-design/x-default-browser": {
       "version": "1.4.126",
@@ -16984,10 +16977,6 @@
       "version": "2.0.6",
       "license": "BSD-3-Clause"
     },
-    "node_modules/abortcontroller-polyfill": {
-      "version": "1.7.5",
-      "license": "MIT"
-    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "license": "MIT",
@@ -18239,14 +18228,6 @@
     "node_modules/browser-process-hrtime": {
       "version": "1.0.0",
       "license": "BSD-2-Clause"
-    },
-    "node_modules/browser-tabs-lock": {
-      "version": "1.2.15",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "lodash": ">=4.17.21"
-      }
     },
     "node_modules/browserify-zlib": {
       "version": "0.1.4",
@@ -20974,10 +20955,6 @@
       "version": "1.0.0",
       "license": "MIT"
     },
-    "node_modules/es-cookie": {
-      "version": "1.3.2",
-      "license": "MIT"
-    },
     "node_modules/es-get-iterator": {
       "version": "1.1.3",
       "license": "MIT",
@@ -22486,10 +22463,6 @@
       "dependencies": {
         "fast-decode-uri-component": "^1.0.1"
       }
-    },
-    "node_modules/fast-text-encoding": {
-      "version": "1.0.6",
-      "license": "Apache-2.0"
     },
     "node_modules/fast-url-parser": {
       "version": "1.1.3",
@@ -31053,10 +31026,6 @@
         "asap": "~2.0.3"
       }
     },
-    "node_modules/promise-polyfill": {
-      "version": "8.3.0",
-      "license": "MIT"
-    },
     "node_modules/promiseback": {
       "version": "2.0.3",
       "dev": true,
@@ -36704,10 +36673,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/unfetch": {
-      "version": "4.2.0",
-      "license": "MIT"
-    },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",
       "license": "MIT",
@@ -38602,7 +38567,7 @@
     },
     "packages/elements": {
       "name": "@photonhealth/elements",
-      "version": "0.2.15",
+      "version": "0.3.0",
       "license": "ISC",
       "dependencies": {
         "@photonhealth/components": "*",
@@ -38809,7 +38774,7 @@
     },
     "packages/react": {
       "name": "@photonhealth/react",
-      "version": "1.0.18",
+      "version": "1.0.19",
       "license": "ISC",
       "dependencies": {
         "@photonhealth/sdk": "*"
@@ -38817,11 +38782,11 @@
     },
     "packages/sdk": {
       "name": "@photonhealth/sdk",
-      "version": "1.0.18",
+      "version": "1.1.0",
       "license": "ISC",
       "dependencies": {
         "@apollo/client": "^3.6.9",
-        "@auth0/auth0-spa-js": "^1.22.2",
+        "@auth0/auth0-spa-js": "^2.1.3",
         "@nanostores/react": "^0.4.1",
         "nanostores": "^0.7.4"
       },

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
   },
   "dependencies": {
     "@apollo/client": "^3.7.10",
-    "@auth0/auth0-react": "^1.12.0",
+    "@auth0/auth0-react": "^2.2.4",
     "@chakra-ui/icons": "^2.0.19",
     "@chakra-ui/pro-theme": "^0.0.66",
     "@chakra-ui/react": "^2.8.0",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@apollo/client": "^3.6.9",
-    "@auth0/auth0-spa-js": "^1.22.2",
+    "@auth0/auth0-spa-js": "^2.1.3",
     "@nanostores/react": "^0.4.1",
     "nanostores": "^0.7.4"
   },

--- a/packages/sdk/src/auth.ts
+++ b/packages/sdk/src/auth.ts
@@ -142,8 +142,7 @@ export class AuthManager {
     const opts: GetTokenSilentlyOptions | GetTokenWithPopupOptions = {
       authorizationParams: {
         audience: audience || this.audience || undefined,
-        ...(this.organization ? { organization: this.organization } : {}),
-        scope: 'openid profile email offline_access'
+        ...(this.organization ? { organization: this.organization } : {})
       }
     };
 

--- a/packages/sdk/src/auth.ts
+++ b/packages/sdk/src/auth.ts
@@ -99,7 +99,6 @@ export class AuthManager {
       authorizationParams = Object.assign(opts, { appState });
     }
     opts.authorizationParams = authorizationParams;
-    console.log('login', opts, organizationId, this.organization);
 
     return this.authentication.loginWithRedirect(opts);
   }

--- a/packages/sdk/src/auth.ts
+++ b/packages/sdk/src/auth.ts
@@ -5,7 +5,8 @@ import {
   LogoutOptions as Auth0LogoutOptions,
   RedirectLoginOptions,
   RedirectLoginResult,
-  User
+  User,
+  AuthorizationParams
 } from '@auth0/auth0-spa-js';
 
 const CODE_RE = /[?&]code=[^&]+/;
@@ -83,20 +84,22 @@ export class AuthManager {
    * @returns
    */
   public async login({ organizationId, invitation, appState }: LoginOptions): Promise<void> {
-    let opts: RedirectLoginOptions<any> = { redirectMethod: 'assign' };
-
+    const opts: RedirectLoginOptions<any> = {};
+    let authorizationParams: AuthorizationParams = {};
     if (organizationId || this.organization) {
-      opts = Object.assign(opts, {
+      authorizationParams = Object.assign(opts, {
         organization: organizationId || this.organization
       });
     }
     if (invitation) {
-      opts = Object.assign(opts, { invitation });
+      authorizationParams = Object.assign(opts, { invitation });
     }
 
     if (appState) {
-      opts = Object.assign(opts, { appState });
+      authorizationParams = Object.assign(opts, { appState });
     }
+    opts.authorizationParams = authorizationParams;
+    console.log('login', opts, organizationId, this.organization);
 
     return this.authentication.loginWithRedirect(opts);
   }
@@ -108,8 +111,10 @@ export class AuthManager {
    */
   public async logout({ returnTo, federated = false }: LogoutOptions): Promise<void> {
     const opts: Auth0LogoutOptions = {
-      ...(returnTo ? { returnTo } : {}),
-      ...(federated ? { federated } : {})
+      logoutParams: {
+        ...(returnTo ? { returnTo } : {}),
+        ...(federated ? { federated } : {})
+      }
     };
 
     return this.authentication.logout(opts);
@@ -136,8 +141,11 @@ export class AuthManager {
     }
   ): Promise<string> {
     const opts: GetTokenSilentlyOptions | GetTokenWithPopupOptions = {
-      audience: audience || this.audience || undefined,
-      ...(this.organization ? { organization: this.organization } : {})
+      authorizationParams: {
+        audience: audience || this.audience || undefined,
+        ...(this.organization ? { organization: this.organization } : {}),
+        scope: 'openid profile email offline_access'
+      }
     };
 
     let token;
@@ -150,6 +158,7 @@ export class AuthManager {
         throw e;
       }
     }
+    if (!token) throw new Error('Missing token');
     return token;
   }
 
@@ -162,10 +171,12 @@ export class AuthManager {
     { audience }: { audience?: string } = {
       audience: this.audience
     }
-  ): Promise<string> {
+  ): Promise<string | undefined> {
     const opts: GetTokenWithPopupOptions = {
-      audience: audience || this.audience || undefined,
-      ...(this.organization ? { organization: this.organization } : {})
+      authorizationParams: {
+        audience: audience || this.audience || undefined,
+        ...(this.organization ? { organization: this.organization } : {})
+      }
     };
 
     return this.authentication.getTokenWithPopup(opts);

--- a/packages/sdk/src/lib.ts
+++ b/packages/sdk/src/lib.ts
@@ -1,4 +1,4 @@
-import { Auth0Client } from '@auth0/auth0-spa-js';
+import { Auth0Client, Auth0ClientOptions } from '@auth0/auth0-spa-js';
 import {
   ApolloClient,
   InMemoryCache,
@@ -112,12 +112,6 @@ export class PhotonClient {
     }: PhotonClientOptions,
     elementsVersion?: string
   ) {
-    this.auth0Client = new Auth0Client({
-      domain: domain ? domain : developmentMode ? 'auth.neutron.health' : 'auth.photon.health',
-      client_id: clientId,
-      redirect_uri: redirectURI,
-      cacheLocation: 'memory'
-    });
     this.audience = audience ? audience : lambdasApiUrl[env];
     this.uri = uri ? uri : `${lambdasApiUrl[env]}/graphql`;
     this.clinicalUrl = uri ? getClinicalUrl(uri) : clinicalAppUrl[env];
@@ -129,6 +123,18 @@ export class PhotonClient {
       this.clinicalApiUri = `${clinicalApiUrl['neutron']}/graphql'`;
     }
 
+    const params: Auth0ClientOptions = {
+      domain: domain ? domain : developmentMode ? 'auth.neutron.health' : 'auth.photon.health',
+      clientId,
+      cacheLocation: 'localstorage',
+      useRefreshTokens: true,
+      useRefreshTokensFallback: true,
+      authorizationParams: {
+        redirect_uri: redirectURI,
+        audience: this.audience
+      }
+    };
+    this.auth0Client = new Auth0Client(params);
     this.organization = organization;
     this.authentication = new AuthManager({
       authentication: this.auth0Client,


### PR DESCRIPTION
Was able to get auth to work on safari (and presumably other browser with ITP (Intelligent Tracking Prevention) enabled ). The key was using [Refresh Token Rotation](https://auth0.com/docs/secure/tokens/refresh-tokens/refresh-token-rotation) and setting storage to be done in localstorage instead of cookies.


I also upgraded the version of auth0 we were using but this didnt end up having an impact, but left it as it took some work to get upgraded and we were very behind