### PR TITLE
Fix status stepper states

### DIFF
--- a/apps/patient/src/components/StatusStepper.tsx
+++ b/apps/patient/src/components/StatusStepper.tsx
@@ -17,11 +17,7 @@ import { ExtendedFulfillmentType } from '../utils/models';
 import { countFillsAndRemoveDuplicates } from '../utils/general';
 import { useOrderContext } from '../views/Main';
 
-export const STATES = {
-  PICK_UP: ['SENT', 'RECEIVED', 'READY', 'PICKED_UP'],
-  COURIER: ['SENT', 'PREPARING', 'IN_TRANSIT', 'DELIVERED'],
-  MAIL_ORDER: ['SENT', 'FILLING', 'SHIPPED', 'DELIVERED']
-};
+export const STATES = ['SENT', 'RECEIVED', 'READY', 'PICKED_UP'];
 
 interface Props {
   fulfillmentType: ExtendedFulfillmentType;
@@ -30,11 +26,8 @@ interface Props {
 }
 
 export const StatusStepper = ({ status, fulfillmentType, patientAddress }: Props) => {
-  // We don't have courier states, so get index from pickup and fake it
-  const key = fulfillmentType === 'COURIER' ? 'PICK_UP' : fulfillmentType;
-  const initialStepIdx = STATES[key].findIndex((state) => state === status);
-  const states = STATES[fulfillmentType]; // map index to faux states
-  const activeStep = initialStepIdx + 1; // step to do next
+  const currentStepIdx = STATES.findIndex((state) => state === status);
+  const activeStep = currentStepIdx + 1; // step to do next
 
   const { order } = useOrderContext();
 
@@ -53,12 +46,12 @@ export const StatusStepper = ({ status, fulfillmentType, patientAddress }: Props
             size="lg"
             colorScheme="green"
           >
-            {states.map((state, id) => {
+            {STATES.map((state, id) => {
               const title = t[fulfillmentType][state].status;
-              const isDelivery = state === 'IN_TRANSIT' || state === 'SHIPPED';
-              const description = isDelivery
-                ? `${t[fulfillmentType][state].description(isMultiRx)}${patientAddress}.`
-                : t[fulfillmentType][state].description(isMultiRx);
+              const isDelivery = fulfillmentType === 'COURIER' || fulfillmentType === 'MAIL_ORDER';
+              const description = `${t[fulfillmentType][state].description(isMultiRx)}${
+                isDelivery ? patientAddress : ''
+              }`;
 
               return (
                 <Step key={id}>

--- a/apps/patient/src/utils/text.ts
+++ b/apps/patient/src/utils/text.ts
@@ -181,21 +181,21 @@ export const orderStateMapping = {
       description: (isPlural: boolean) => text.sent(isPlural),
       cta: (isPlural: boolean) => text.receivedRx(isPlural)
     },
-    PREPARING: {
+    RECEIVED: {
       heading: text.preparingOrder,
       subheading: (isPlural: boolean) => text.sentWithOrderSms(isPlural),
       status: text.preparing,
       description: (isPlural: boolean) => text.preparingRxDelivery(isPlural),
       cta: (isPlural: boolean) => text.receivedRx(isPlural)
     },
-    IN_TRANSIT: {
+    READY: {
       heading: text.orderInTransit,
       subheading: (isPlural: boolean) => text.sentWithOrderSms(isPlural),
       status: text.inTransit,
       description: (isPlural: boolean) => text.rxInTransit(isPlural),
       cta: (isPlural: boolean) => text.receivedRx(isPlural)
     },
-    DELIVERED: {
+    PICKED_UP: {
       heading: text.orderDelivered,
       subheading: (isPlural: boolean) => text.sentWithOrderSms(isPlural),
       status: text.delivered,
@@ -215,21 +215,21 @@ export const orderStateMapping = {
       description: (isPlural: boolean) => text.sent(isPlural),
       cta: (isPlural: boolean) => text.receivedRx(isPlural)
     },
-    FILLING: {
+    RECEIVED: {
       heading: text.preparingOrder,
       subheading: text.preparingDelivery,
       status: text.preparing,
       description: (isPlural: boolean) => text.preparingRxDelivery(isPlural),
       cta: (isPlural: boolean) => text.receivedRx(isPlural)
     },
-    SHIPPED: {
+    READY: {
       heading: text.orderInTransit,
       subheading: (isPlural: boolean) => text.outForDelivery(isPlural),
       status: text.inTransit,
       description: (isPlural: boolean) => text.rxInTransit(isPlural),
       cta: (isPlural: boolean) => text.receivedRx(isPlural)
     },
-    DELIVERED: {
+    PICKED_UP: {
       heading: text.orderDelivered,
       subheading: () => '', // it'll still show text us prompt
       status: text.delivered,


### PR DESCRIPTION
This fixes an issue for the mail order status stepper not finding the right states. I was mapping what we do have to different states for courier and mail order, kind of like what we might have someday, but that's superfluous so I'm just removing and showing different copy for each state based on fulfillment type.