### PR TITLE
Enable urgency selection

### DIFF
--- a/apps/patient/src/App.tsx
+++ b/apps/patient/src/App.tsx
@@ -6,6 +6,7 @@ import { NoMatch } from './views/NoMatch';
 import { Pharmacy } from './views/Pharmacy';
 import { Review } from './views/Review';
 import { Canceled } from './views/Canceled';
+import { Urgency } from './views/Urgency';
 
 export const App = () => {
   return (
@@ -13,6 +14,7 @@ export const App = () => {
       <Routes>
         <Route path="/" element={<Main />}>
           <Route path="/review" element={<Review />} />
+          <Route path="/urgency" element={<Urgency />} />
           <Route path="/pharmacy" element={<Pharmacy />} />
           <Route path="/status" element={<Status />} />
           <Route path="/canceled" element={<Canceled />} />

--- a/apps/patient/src/utils/text.ts
+++ b/apps/patient/src/utils/text.ts
@@ -62,19 +62,11 @@ export const text = {
   quantity: 'Quantity',
   questions: 'If you have any questions, please text us at +1 (513) 866-3212.',
   readyBy: 'Ready by',
-  readyByOptions: [
-    '10:00 am',
-    '12:00 pm',
-    '2:00 pm',
-    '4:00 pm',
-    '6:00 pm',
-    'After hours',
-    'Tomorrow'
-  ],
+
   readyBySelected: (isPlural: boolean) =>
     `We'll do our best to ensure your ${
-      isPlural ? 'prescriptions' : 'prescription'
-    } are ready by your selected time.`,
+      isPlural ? 'prescriptions are' : 'prescription is'
+    } ready by your selected time.`,
   readyPickUp: 'Ready for pick up',
   readyWhen: 'When do you want your order ready by?',
   receivedPreparing: 'The pharmacy has received your order and is preparing it.',
@@ -133,6 +125,16 @@ export const text = {
   track: 'Track your order',
   tracking: 'Tracking #:',
   tryPhoton: 'Try Photon',
+  urgencyOptions: [
+    'As soon as possible',
+    '10:00 am',
+    '12:00 pm',
+    '2:00 pm',
+    '4:00 pm',
+    '6:00 pm',
+    'After hours',
+    'Tomorrow'
+  ],
   useLoc: 'Use my current location',
   weSent: (isPlural: boolean) =>
     `We sent your ${isPlural ? 'prescriptions' : 'prescription'} to the pharmacy.`

--- a/apps/patient/src/utils/text.ts
+++ b/apps/patient/src/utils/text.ts
@@ -68,7 +68,7 @@ export const text = {
       isPlural ? 'prescriptions are' : 'prescription is'
     } ready by your selected time.`,
   readyPickUp: 'Ready for pick up',
-  readyWhen: 'When do you want your order ready by?',
+  readyWhen: 'When do you need your order ready by?',
   receivedPreparing: 'The pharmacy has received your order and is preparing it.',
   receivedRx: (isPlural: boolean) => `I received my ${isPlural ? 'prescriptions' : 'prescription'}`,
   refills: 'Refills',

--- a/apps/patient/src/views/Review.tsx
+++ b/apps/patient/src/views/Review.tsx
@@ -37,8 +37,8 @@ export const Review = () => {
 
   const handleCtaClick = () => {
     const toUrl = isDemo
-      ? `/pharmacy?demo=true&phone=${phone}`
-      : `/pharmacy?orderId=${order.id}&token=${token}`;
+      ? `/urgency?demo=true&phone=${phone}`
+      : `/urgency?orderId=${order.id}&token=${token}`;
     navigate(toUrl);
   };
 

--- a/apps/patient/src/views/Urgency.tsx
+++ b/apps/patient/src/views/Urgency.tsx
@@ -25,8 +25,8 @@ export const Urgency = () => {
 
   const navigate = useNavigate();
 
-  const [selectedIdx, setSelectedIdx] = useState(undefined);
-  const showFooter = typeof selectedIdx !== 'undefined';
+  const [selectedIdx, setSelectedIdx] = useState(null);
+  const showFooter = selectedIdx !== null;
 
   const handleCtaClick = () => {
     if (!isDemo) {

--- a/apps/patient/src/views/Urgency.tsx
+++ b/apps/patient/src/views/Urgency.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Box, Button, Container, Heading, Text, VStack } from '@chakra-ui/react';
+import { Box, Button, Card, CardBody, Container, Heading, Text, VStack } from '@chakra-ui/react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { Helmet } from 'react-helmet';
 import dayjs from 'dayjs';
@@ -69,25 +69,20 @@ export const Urgency = () => {
             {t.urgencyOptions.map((option, i) => {
               const isDisabled = checkDisabled(option);
               return (
-                <Button
+                <Card
                   key={option}
-                  bgColor={selectedIdx === i ? 'gray.700' : undefined}
-                  _active={
-                    !isDisabled
-                      ? {
-                          bgColor: 'gray.700',
-                          textColor: 'white'
-                        }
-                      : undefined
-                  }
-                  size="lg"
-                  w="full"
-                  isActive={selectedIdx === i}
+                  bgColor={isDisabled ? 'gray.100' : 'white'}
+                  border={isDisabled ? 'gray.100' : '2px solid'}
+                  borderColor={selectedIdx === i ? 'brand.600' : 'white'}
                   onClick={() => setSelectedIdx(i)}
-                  isDisabled={isDisabled}
+                  m="auto"
+                  w="full"
+                  cursor={isDisabled ? 'not-allowed' : 'pointer'}
                 >
-                  {option}
-                </Button>
+                  <CardBody p={3} m="auto">
+                    <Text fontWeight="medium">{option}</Text>
+                  </CardBody>
+                </Card>
               );
             })}
           </VStack>


### PR DESCRIPTION
Re-enable our urgency selection view. It sits between review and pharmacy selection. I'm also tracking these selections in datadog with a new custom event.

https://github.com/Photon-Health/client/assets/3934326/c6c56866-587f-4c67-ba37-1a8944516058

Example export of selection data:

<img width="702" alt="image" src="https://github.com/Photon-Health/client/assets/3934326/1636de9d-ba53-4ebd-a91f-8f6f8195f52c">

