### PR TITLE
Remove extra trailing slash from photon api url

### DIFF
--- a/packages/sdk/src/utils.ts
+++ b/packages/sdk/src/utils.ts
@@ -95,7 +95,7 @@ export const clinicalApiUrl: { [key in Env]: string } = {
   tau: 'http://clinical-api.tau.health:8080',
   boson: 'https://clinical-api.boson.health',
   neutron: 'https://clinical-api.neutron.health',
-  photon: 'https://clinical-api.photon.health/'
+  photon: 'https://clinical-api.photon.health'
 };
 
 export function getClinicalUrl(uri: string): string | undefined {


### PR DESCRIPTION
This slash looks to be causing the settings users tables to not load.