### PR TITLE
logout on userID diff

### DIFF
--- a/packages/elements/src/photon-client/index.tsx
+++ b/packages/elements/src/photon-client/index.tsx
@@ -7,6 +7,7 @@ import { PhotonClientStore } from '../store';
 import { hasAuthParams } from '../utils';
 import { PhotonContext } from '../context';
 import pkg from '../../package.json';
+import { type User } from '@auth0/auth0-react';
 
 type PhotonClientProps = {
   domain?: string;
@@ -21,6 +22,7 @@ type PhotonClientProps = {
   autoLogin: boolean;
   toastBuffer?: number;
   env?: Env;
+  externalUserId?: string;
 };
 
 const version = pkg?.version ?? 'unknown';
@@ -104,6 +106,13 @@ customElement(
       reflect: false,
       notify: false,
       parse: false
+    },
+    externalUserId: {
+      attribute: 'userId',
+      value: undefined,
+      reflect: true,
+      notify: true,
+      parse: false
     }
   },
   (props: PhotonClientProps) => {
@@ -149,6 +158,23 @@ customElement(
         handleRedirect();
       } else if (store()) {
         checkSession();
+      }
+    });
+
+    createEffect(() => {
+      if (!store()?.authentication.state.isLoading && props.externalUserId != null) {
+        if (
+          !(store().authentication.state.user as User).sub
+            ?.split('|')
+            .some((s) => s === props.externalUserId)
+        ) {
+          store()?.authentication.logout();
+          const args: any = { appState: {} };
+          if (props.redirectPath) {
+            args.appState.returnTo = props.redirectPath;
+          }
+          store()?.authentication.login(args);
+        }
       }
     });
 

--- a/packages/elements/src/photon-client/index.tsx
+++ b/packages/elements/src/photon-client/index.tsx
@@ -164,9 +164,8 @@ customElement(
     createEffect(() => {
       if (!store()?.authentication.state.isLoading && props.externalUserId != null) {
         if (
-          !(store().authentication.state.user as User).sub
-            ?.split('|')
-            .some((s) => s === props.externalUserId)
+          (store().authentication.state.user as User).sub?.split('|').reverse()[0] !==
+          props.externalUserId
         ) {
           store()?.authentication.logout();
           const args: any = { appState: {} };


### PR DESCRIPTION
For sesame (and anyone else I guess). We'll allow putting in a `userId` which we'll then check against **at initial render time** against the `sub`. For google that takes the form of `google-oauth2|<string>` and we match against that string. For Sesame, it looks like `oidc|Sesame-2|2a8a5791-292a-4eeb-8169-ca9b7fa3059b` so we'll expect `2a8a5791-292a-4eeb-8169-ca9b7fa3059b`

**At initial render time** means that if they simply change the props **nothing will happen**. To get around this, they should wrap it in a div with a key like

```tsx
<div key={userId}>
  <photon-client userId={userId}>
    <photon-prescribe-workflow/>
  </photon-client>
</div>
```

Note that we need to also update the docs.