### PR TITLE
External Order ID prop on Prescribe Element

### DIFF
--- a/packages/elements/index.html
+++ b/packages/elements/index.html
@@ -11,6 +11,7 @@
       id="7N9QZujlNJHL8EIPqXpu1wq8OuXqoxKb"
       org="org_KzSVZBQixLRkqj5d"
       domain="auth.boson.health"
+      env="boson"
       audience="https://api.boson.health"
       uri="https://api.boson.health/graphql"
     >

--- a/packages/elements/src/photon-multirx-form/index.tsx
+++ b/packages/elements/src/photon-multirx-form/index.tsx
@@ -72,6 +72,7 @@ type PrescribeProps = {
   toastBuffer: number;
   formStore?: any;
   formActions?: any;
+  externalOrderId?: string;
 };
 
 function PrescribeWorkflow(props: PrescribeProps) {
@@ -304,6 +305,7 @@ function PrescribeWorkflow(props: PrescribeProps) {
 
         const { data: orderData, errors } = await orderMutation({
           variables: {
+            ...(props.externalOrderId ? { externalId: props.externalOrderId } : {}),
             patientId: props.formStore.patient?.value.id,
             pharmacyId: props?.pharmacyId || props.formStore.pharmacy?.value || '',
             fulfillmentType: props.formStore.fulfillmentType?.value || '',
@@ -493,7 +495,8 @@ customElement(
     weightUnit: 'lbs',
     triggerSubmit: false,
     setTriggerSubmit: undefined,
-    toastBuffer: 0
+    toastBuffer: 0,
+    externalOrderId: undefined
   },
   (props: PrescribeProps) => {
     const { store, actions } = createFormStore({
@@ -530,6 +533,7 @@ customElement(
           toastBuffer={props.toastBuffer}
           formStore={store}
           formActions={actions}
+          externalOrderId={props.externalOrderId}
         />
       </RecentOrders>
     );


### PR DESCRIPTION
- allows customers to add an external id to be associated with the created order
- bumps version to 0.5.3