### PR TITLE
Fixes Recent Orders Card grabbing cached data

### DIFF
--- a/packages/components/src/systems/RecentOrders/RecentOrders.tsx
+++ b/packages/components/src/systems/RecentOrders/RecentOrders.tsx
@@ -156,7 +156,8 @@ function RecentOrders(props: SDKProviderProps) {
       query: GetPatientOrdersQuery,
       variables: {
         patientId: props.patientId
-      }
+      },
+      fetchPolicy: 'network-only'
     });
 
     const orders = data?.patient?.orders;


### PR DESCRIPTION
1. creates an order for a patient
2. navigates back to prescribe workflow without refreshing
3. Recent orders card doesn't show for patient
4. refresh page
5. Recent order card appears for patient