### PR TITLE
hopefully fix auth0 login_required bug

### DIFF
--- a/packages/sdk/src/auth.ts
+++ b/packages/sdk/src/auth.ts
@@ -152,11 +152,12 @@ export class AuthManager {
     } catch (e) {
       if ((e as Error).message.includes('Consent required')) {
         token = await this.authentication.getTokenWithPopup(opts);
-      } else {
-        throw e;
       }
     }
-    if (!token) throw new Error('Missing token');
+    if (!token) {
+      await this.authentication.loginWithRedirect();
+      throw new Error(); // Needed just because this needs to resolve to something
+    }
     return token;
   }
 


### PR DESCRIPTION
We _think_ that the bug where you can be seemingly logged in but not actually is caused by `getAccessToken` returning null for the token. To repro, you can open two tabs, log in, then log out of one and navigate around in the other tab. In previous versions you would see a `Login Required` error message. Now you should get redirected to the login page.

We use `loginWithRedirect` so that if there's auto-login set up, it _should_ just re-execute the SSO handshake