### PR TITLE
Solid query and mutation

### DIFF
--- a/packages/components/src/systems/DraftPrescriptions/index.tsx
+++ b/packages/components/src/systems/DraftPrescriptions/index.tsx
@@ -64,7 +64,7 @@ const GetPrescription = gql`
   }
 `;
 
-export type DraftPrescription = Omit<PrescriptionTemplate, 'id' | 'name' | 'isPrivate'> & {
+export type DraftPrescription = PrescriptionTemplate & {
   refillsInput?: number;
   addToTemplates?: boolean;
   catalogId?: string;

--- a/packages/components/src/systems/DraftPrescriptions/index.tsx
+++ b/packages/components/src/systems/DraftPrescriptions/index.tsx
@@ -64,7 +64,7 @@ const GetPrescription = gql`
   }
 `;
 
-export type DraftPrescription = PrescriptionTemplate & {
+export type DraftPrescription = Omit<PrescriptionTemplate, 'id' | 'name' | 'isPrivate'> & {
   refillsInput?: number;
   addToTemplates?: boolean;
   catalogId?: string;

--- a/packages/components/src/systems/RecentOrders/RecentOrders.tsx
+++ b/packages/components/src/systems/RecentOrders/RecentOrders.tsx
@@ -9,6 +9,7 @@ import RecentOrdersCombineDialog from './RecentOrdersCombineDialog';
 import type { DraftPrescription } from '../DraftPrescriptions';
 import { Address } from '../PatientInfo';
 import { BaseOptions, createQuery } from '../../utils/createQuery';
+import type { OrderStateString } from '../../particles/OrderStatusBadge/OrderStatusBadge';
 
 const GetPatientOrdersQuery = gql`
   query GetPatientOrders($patientId: ID!) {
@@ -57,7 +58,7 @@ type Fill = {
 type Order = {
   id: string;
   createdAt: string;
-  state: string;
+  state: OrderStateString;
   fills: Fill[];
 };
 

--- a/packages/components/src/systems/RecentOrders/RecentOrdersCombineDialog.tsx
+++ b/packages/components/src/systems/RecentOrders/RecentOrdersCombineDialog.tsx
@@ -47,7 +47,9 @@ type SuccessResponse = {
 };
 
 type SuccessCreatePrescriptions = { createPrescriptions: SuccessResponse[] };
-type VariablesCreatePrescriptions = { prescriptions: Omit<DraftPrescription, 'treatment'>[] };
+type VariablesCreatePrescriptions = {
+  prescriptions: Omit<DraftPrescription, 'id' | 'name' | 'isPrivate' | 'treatment'>[];
+};
 
 type SuccessCombineOrders = { updateOrder: SuccessResponse };
 type VariablesCombineOrders = { orderId: string; fills: { prescriptionId: string }[] };

--- a/packages/components/src/systems/RecentOrders/RecentOrdersCombineDialog.tsx
+++ b/packages/components/src/systems/RecentOrders/RecentOrdersCombineDialog.tsx
@@ -13,6 +13,7 @@ import triggerToast from '../../utils/toastTriggers';
 import { Address } from '../PatientInfo';
 import { dispatchDatadogAction } from '../../utils/dispatchDatadogAction';
 import { createMutation } from '../../utils/createMutation';
+import { DraftPrescription } from '../DraftPrescriptions';
 
 const CREATE_PRESCRIPTIONS_MUTATION = gql`
   mutation RecentOrdersCombineDialogCreatePrescriptions($prescriptions: [PrescriptionInput!]!) {
@@ -55,7 +56,7 @@ export default function RecentOrdersCombineDialog() {
 
   const [createPrescriptionsMutation, newPrescriptions] = createMutation<
     SuccessResponse,
-    InputValues
+    { prescriptions: DraftPrescription[] }
   >(CREATE_PRESCRIPTIONS_MUTATION, {
     client: client!.apollo
   });
@@ -113,10 +114,9 @@ export default function RecentOrdersCombineDialog() {
   });
 
   const createPrescriptions = async () => {
-    return client!.apollo.mutate({
-      mutation: CREATE_PRESCRIPTIONS_MUTATION,
+    return createPrescriptionsMutation({
       variables: {
-        prescriptions: state.draftPrescriptions?.map((draft) => ({
+        prescriptions: (state.draftPrescriptions || []).map((draft) => ({
           daysSupply: draft.daysSupply,
           dispenseAsWritten: draft.dispenseAsWritten,
           dispenseQuantity: draft.dispenseQuantity,
@@ -127,7 +127,8 @@ export default function RecentOrdersCombineDialog() {
           patientId: state.patientId,
           // +1 here because we're using the refillsInput
           fillsAllowed: draft.refillsInput ? draft.refillsInput + 1 : 1,
-          treatmentId: draft.treatment.id
+          treatmentId: draft.treatment.id,
+          treatment: draft.treatment
         }))
       }
     });

--- a/packages/components/src/systems/RecentOrders/RecentOrdersCombineDialog.tsx
+++ b/packages/components/src/systems/RecentOrders/RecentOrdersCombineDialog.tsx
@@ -244,7 +244,7 @@ export default function RecentOrdersCombineDialog() {
               <For each={fillsWithRoutingState()}>
                 {(fill) => (
                   <div>
-                    <Text size="sm">{fill.treatment.name}</Text>
+                    <Text size="sm">{fill?.treatment?.name}</Text>
                     <br />
                     <Text size="sm" color="gray">
                       {formatRxString({

--- a/packages/components/src/systems/RecentOrders/RecentOrdersIssueDialog.tsx
+++ b/packages/components/src/systems/RecentOrders/RecentOrdersIssueDialog.tsx
@@ -210,7 +210,7 @@ export default function RecentOrdersIssueDialog() {
               <For each={fills()}>
                 {(fill) => (
                   <div>
-                    <Text size="sm">{fill.treatment.name}</Text>
+                    <Text size="sm">{fill?.treatment?.name}</Text>
                     <br />
                     <Text size="sm" color="gray">
                       {formatRxString({

--- a/packages/components/src/systems/RecentOrders/RecentOrdersIssueDialog.tsx
+++ b/packages/components/src/systems/RecentOrders/RecentOrdersIssueDialog.tsx
@@ -154,19 +154,15 @@ export default function RecentOrdersIssueDialog() {
         }
       }
     });
-  };
 
-  createEffect(() => {
-    if (data()) {
-      triggerToast({
-        header: 'Issue reported',
-        body: 'The customer support team will respond to you shortly.',
-        status: 'success'
-      });
-      dispatchTicketCreatedDuplicate();
-      actions.setIsIssueDialogOpen(false);
-    }
-  });
+    triggerToast({
+      header: 'Issue reported',
+      body: 'The customer support team will respond to you shortly.',
+      status: 'success'
+    });
+    dispatchTicketCreatedDuplicate();
+    actions.setIsIssueDialogOpen(false);
+  };
 
   const { form, errors } = createForm({
     onSubmit: async (values) => {

--- a/packages/components/src/utils/createMutation.ts
+++ b/packages/components/src/utils/createMutation.ts
@@ -1,3 +1,9 @@
+/**
+ * createQuery originates from the solid-apollo package
+ * https://github.com/merged-js/solid-apollo/blob/main/src/createMutation.ts
+ *
+ * Modified to fix types, enforces passing a client to work
+ */
 import { ApolloClient, mergeOptions } from '@apollo/client/core';
 import type {
   DefaultContext,

--- a/packages/components/src/utils/createMutation.ts
+++ b/packages/components/src/utils/createMutation.ts
@@ -1,0 +1,87 @@
+import { ApolloClient, mergeOptions } from '@apollo/client/core';
+import type {
+  DefaultContext,
+  OperationVariables,
+  MutationOptions,
+  FetchResult
+} from '@apollo/client/core';
+import type { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
+import type { GraphQLError } from 'graphql';
+import type { Accessor } from 'solid-js';
+import { createResource, createSignal, untrack } from 'solid-js';
+
+interface BaseOptions<TData, TVariables, TContext>
+  extends Omit<MutationOptions<TData, TVariables, TContext>, 'mutation'> {
+  ignoreResults?: boolean;
+  client: ApolloClient<any>; // enforce a client being present since we have two
+}
+
+type CreateMutationOptions<
+  TData,
+  TVariables extends OperationVariables,
+  TContext extends Record<string, any>
+> = BaseOptions<TData, TVariables, TContext> | Accessor<BaseOptions<TData, TVariables, TContext>>;
+
+export const createMutation = <
+  TData = any,
+  TVariables extends OperationVariables = OperationVariables,
+  TContext extends Record<string, any> = DefaultContext // Changed here: Added 'extends Record<string, any>'
+>(
+  mutation: DocumentNode<TData, TVariables>,
+  options: CreateMutationOptions<TData, TVariables, TContext>
+) => {
+  const resolvedOptions = typeof options === 'function' ? options() : options; // could be accessor or object
+  const client = resolvedOptions.client;
+  let resolveResultPromise: ((data: TData) => void) | null = null;
+  let rejectResultPromise: ((error: GraphQLError) => void) | null = null;
+
+  const [executionOptions, setExecutionOptions] = createSignal<
+    false | MutationOptions<TData, TVariables, TContext>
+  >(false);
+  const [resource] = createResource(executionOptions, async (opts) => {
+    let result: FetchResult<TData>;
+    try {
+      result = await client.mutate<TData, TVariables, TContext>(opts);
+    } catch (error) {
+      if (rejectResultPromise) {
+        rejectResultPromise(error as GraphQLError);
+        rejectResultPromise = null;
+      }
+      throw error;
+    }
+    const { data, errors } = result;
+    if (errors) {
+      if (rejectResultPromise) {
+        rejectResultPromise(errors[0]);
+        rejectResultPromise = null;
+      }
+      throw errors[0];
+    }
+
+    if (data !== undefined && data !== null) {
+      if (resolveResultPromise) {
+        resolveResultPromise(data);
+        resolveResultPromise = null;
+      }
+      return data;
+    } else {
+      throw new Error('Mutation did not return any data.');
+    }
+  });
+
+  return [
+    async (opts: Omit<BaseOptions<TData, TVariables, TContext>, 'client'>) => {
+      const mergedOptions = mergeOptions<MutationOptions<TData, TVariables, TContext>>(opts, {
+        mutation,
+        ...(typeof options === 'function' ? untrack(options) : options)
+      });
+
+      setExecutionOptions(mergedOptions);
+      return new Promise<TData>((resolve, reject) => {
+        resolveResultPromise = resolve;
+        rejectResultPromise = reject;
+      });
+    },
+    resource
+  ] as const;
+};

--- a/packages/components/src/utils/createQuery.ts
+++ b/packages/components/src/utils/createQuery.ts
@@ -2,7 +2,7 @@
  * createQuery originates from the solid-apollo package
  * https://github.com/merged-js/solid-apollo/blob/main/src/createQuery.ts
  *
- * Modified slightly to fix types
+ * Modified slightly to fix types, enforces passing a client to work
  */
 import type { WatchQueryOptions, OperationVariables, ApolloClient } from '@apollo/client/core';
 import type { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
@@ -10,7 +10,7 @@ import type { Accessor } from 'solid-js';
 import { createResource, onCleanup } from 'solid-js';
 import { createStore, reconcile } from 'solid-js/store';
 
-interface BaseOptions<TData, TVariables extends OperationVariables = OperationVariables>
+export interface BaseOptions<TData, TVariables extends OperationVariables = OperationVariables>
   extends Omit<WatchQueryOptions<TVariables, TData>, 'query'> {
   skip?: boolean;
   client: ApolloClient<any>; // enforce a client being present since we have two

--- a/packages/components/src/utils/createQuery.ts
+++ b/packages/components/src/utils/createQuery.ts
@@ -1,0 +1,80 @@
+/**
+ * createQuery originates from the solid-apollo package
+ * https://github.com/merged-js/solid-apollo/blob/main/src/createQuery.ts
+ *
+ * Modified slightly to fix types
+ */
+import type { WatchQueryOptions, OperationVariables, ApolloClient } from '@apollo/client/core';
+import type { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
+import type { Accessor } from 'solid-js';
+import { createResource, onCleanup } from 'solid-js';
+import { createStore, reconcile } from 'solid-js/store';
+
+interface BaseOptions<TData, TVariables extends OperationVariables = OperationVariables>
+  extends Omit<WatchQueryOptions<TVariables, TData>, 'query'> {
+  skip?: boolean;
+  client: ApolloClient<any>; // enforce a client being present since we have two
+}
+
+type CreateQueryOptions<TData, TVariables extends OperationVariables = OperationVariables> =
+  | BaseOptions<TData, TVariables>
+  | Accessor<BaseOptions<TData, TVariables>>;
+
+export const createQuery = <
+  TData extends object,
+  TVariables extends OperationVariables = OperationVariables
+>(
+  query: DocumentNode<TData, TVariables>,
+  options: CreateQueryOptions<TData, TVariables>
+) => {
+  const resolvedOptions = typeof options === 'function' ? options() : options; // could be accessor or object
+  const optionsAccessor = () => {
+    if (typeof options !== 'function') {
+      if (options.skip) {
+        console.warn(
+          'you passed options.skip to createQuery, but the options are not an acccessor.\nThis query will never execute!\n\nReplace your options with a function.'
+        );
+      }
+
+      return options;
+    }
+    const opts = typeof options === 'function' ? options() : options;
+    if (opts.skip) {
+      return false;
+    }
+    return opts;
+  };
+  const client = resolvedOptions.client;
+
+  const [resource] = createResource<TData, BaseOptions<TData, TVariables>>(
+    optionsAccessor,
+    (opts) => {
+      const observable = client.watchQuery<TData, TVariables>({ query, ...opts });
+      const [state, setState] = createStore<TData>({} as any);
+
+      let resolved = false;
+      return new Promise((resolve, reject) => {
+        const sub = observable.subscribe({
+          error: reject,
+          next: ({ data, error }) => {
+            if (error) {
+              reject(error);
+            }
+
+            if (!resolved) {
+              resolved = true;
+              setState(data);
+              resolve(state);
+            } else {
+              setState(reconcile(data));
+            }
+          }
+        });
+
+        onCleanup(() => sub.unsubscribe());
+      });
+    }
+  );
+
+  return resource;
+};

--- a/packages/components/src/utils/createQuery.ts
+++ b/packages/components/src/utils/createQuery.ts
@@ -2,7 +2,7 @@
  * createQuery originates from the solid-apollo package
  * https://github.com/merged-js/solid-apollo/blob/main/src/createQuery.ts
  *
- * Modified slightly to fix types, enforces passing a client to work
+ * Modified to fix types, enforces passing a client to work
  */
 import type { WatchQueryOptions, OperationVariables, ApolloClient } from '@apollo/client/core';
 import type { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';

--- a/packages/components/src/utils/createQuery.ts
+++ b/packages/components/src/utils/createQuery.ts
@@ -28,6 +28,7 @@ export const createQuery = <
   options: CreateQueryOptions<TData, TVariables>
 ) => {
   const resolvedOptions = typeof options === 'function' ? options() : options; // could be accessor or object
+  const client = resolvedOptions.client;
   const optionsAccessor = () => {
     if (typeof options !== 'function') {
       if (options.skip) {
@@ -44,7 +45,6 @@ export const createQuery = <
     }
     return opts;
   };
-  const client = resolvedOptions.client;
 
   const [resource] = createResource<TData, BaseOptions<TData, TVariables>>(
     optionsAccessor,

--- a/packages/components/src/utils/uniqueFills.ts
+++ b/packages/components/src/utils/uniqueFills.ts
@@ -1,14 +1,15 @@
-import { Fill, Order } from '@photonhealth/sdk/dist/types';
+import { Fill } from '@photonhealth/sdk/dist/types';
 
-export default function uniqueFills(order: Order): Fill[] {
+export default function uniqueFills(order: { fills: any[] }): Partial<Fill>[] {
   const treatmentNames = new Set<string>();
 
   return order.fills.filter((fill) => {
-    if (treatmentNames.has(fill.treatment.name)) {
+    const treatmentName = fill.treatment?.name;
+    if (!treatmentName || treatmentNames.has(treatmentName)) {
       return false;
     }
 
-    treatmentNames.add(fill.treatment.name);
+    treatmentNames.add(treatmentName);
     return true;
   });
 }


### PR DESCRIPTION
This ports over the `createQuery` and `createMutation` functions from [solid-apollo](https://github.com/merged-js/solid-apollo).

I've updated the `RecentOrders` to demonstrate how to use both functions.