### PR TITLE
fail if not ready

### DIFF
--- a/.github/workflows/merge-bot.yml
+++ b/.github/workflows/merge-bot.yml
@@ -18,19 +18,23 @@ on:
 jobs:
   merge:
     name: Merge
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'ready') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.head_ref }}
+      - name: Fail if not ready
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'ready') }}
+        run: exit 1
       - uses: tibdex/github-app-token@v1
         id: generate-token
         with:
           app_id: ${{ secrets.CPR_APP_ID }}
           private_key: ${{ secrets.CPR_APP_SECRET }}
+      - run: gh --version
       - name: Merge when ready
+        if: success()
         run: |
-          gh pr merge --auto --merge
+          GH_DEBUG=api gh pr merge --auto --merge
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}

--- a/.github/workflows/merge-bot.yml
+++ b/.github/workflows/merge-bot.yml
@@ -23,18 +23,21 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.head_ref }}
-      - name: Fail if not ready
-        if: ${{ !contains(github.event.pull_request.labels.*.name, 'ready') }}
-        run: exit 1
       - uses: tibdex/github-app-token@v1
         id: generate-token
         with:
           app_id: ${{ secrets.CPR_APP_ID }}
           private_key: ${{ secrets.CPR_APP_SECRET }}
-      - run: gh --version
+      - name: Fail if not ready
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'ready') }}
+        run: |
+          gh pr merge --disable-auto --merge
+          exit 1
+        env:
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
       - name: Merge when ready
         if: success()
         run: |
-          GH_DEBUG=api gh pr merge --auto --merge
+          gh pr merge --auto --merge
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
If the `ready` label is attached to the PR, the merge bot will succeed. If the `ready` label is not attached to the PR, the merge bot will fail (instead of skip) and will disable auto-merge (in case it was already labeled ready). 

This is so we can include a rule in `neutron/photon` that requires merge bot to pass. In the past, it was only required to not fail.