### PR TITLE
in <SelectOrg />, pass orgId to login if theres only one organization

### DIFF
--- a/apps/app/src/views/routes/SelectOrg.tsx
+++ b/apps/app/src/views/routes/SelectOrg.tsx
@@ -43,7 +43,8 @@ export const SelectOrg = () => {
         login({
           appState: {
             returnTo: from
-          }
+          },
+          organizationId: organizations[0].id
         });
       }
     }


### PR DESCRIPTION
Maybe something is hitting this? 
Would explain why:
- We don't see this as much as other people
- When we do see this, it redirects us to `<SelectOrg/>`
