### PR TITLE
Fix disabled urgency option radio still selectable

### DIFF
--- a/apps/patient/src/views/ReadyBy.tsx
+++ b/apps/patient/src/views/ReadyBy.tsx
@@ -142,7 +142,13 @@ export const ReadyBy = () => {
                   >
                     <CardBody p={3}>
                       <HStack align="start">
-                        <Radio mt={1} value={option.label} colorScheme="brand" />
+                        <Radio
+                          mt={1}
+                          value={option.label}
+                          colorScheme="brand"
+                          onClick={(e) => isDisabled && e.preventDefault()}
+                          cursor={isDisabled ? 'not-allowed' : 'pointer'}
+                        />
                         <VStack spacing={1}>
                           <HStack alignSelf="start">
                             {option.icon ? <Icon as={RxLightningBolt} color="yellow.500" /> : null}


### PR DESCRIPTION
The Radio on disabled urgency options would still enable if you clicked it directly.

<img width="355" alt="image" src="https://github.com/Photon-Health/client/assets/3934326/7a70b753-ad2a-408b-b24a-8546aee50d8b">
