### PR TITLE
Disable ready by option if it's within 30 minutes

### DIFF
--- a/apps/patient/src/views/ReadyBy.tsx
+++ b/apps/patient/src/views/ReadyBy.tsx
@@ -31,7 +31,8 @@ import { FiCheck } from 'react-icons/fi';
 
 const checkDisabled = (option: string): boolean => {
   const currentTime = dayjs();
-  const timetoCheckDayJs = dayjs(option, 'h:mm a');
+  // If the option is within 30 minutes, disable it
+  const timetoCheckDayJs = dayjs(option, 'h:mm a').subtract(30, 'minutes');
   return currentTime.isAfter(timetoCheckDayJs);
 };
 


### PR DESCRIPTION
We're looking for a reasonable cut-off. If they select a time that's 5min away, there's no way we can fill that. 30min seems like a good place to start.