### PR TITLE
Fix multi-medication order names missing comma

### DIFF
--- a/apps/app/src/views/routes/Orders.tsx
+++ b/apps/app/src/views/routes/Orders.tsx
@@ -91,7 +91,7 @@ const renderRow = (order: Order) => {
   const { id, pharmacy, patient } = order;
   const extId = order.externalId || <Text as="i">None</Text>;
 
-  const fills = getMedicationNames(order.fills);
+  const medNames = getMedicationNames(order.fills).join(', ');
 
   const pharmacyView = pharmacy?.name ? (
     <Popover>
@@ -126,7 +126,7 @@ const renderRow = (order: Order) => {
     id,
     externalId: extId,
     createdAt: formatDate(order.createdAt),
-    fills: <Text fontWeight="medium">{fills}</Text>,
+    fills: <Text fontWeight="medium">{medNames}</Text>,
     status: (
       <OrderStatusBadge
         fulfillmentState={order.fulfillment?.state as OrderFulfillmentState}

--- a/apps/app/src/views/routes/Patient.tsx
+++ b/apps/app/src/views/routes/Patient.tsx
@@ -300,7 +300,7 @@ export const Patient = () => {
                 <Table bg="transparent" size="sm">
                   <Tbody>
                     {orders.map(({ id: orderId, fulfillment, fills, createdAt, state }, i) => {
-                      const fillsFormatted = getMedicationNames(fills);
+                      const medNames = getMedicationNames(fills).join(', ');
 
                       return i < 5 ? (
                         <Tr
@@ -312,7 +312,7 @@ export const Patient = () => {
                           <Td px={0} py={3} whiteSpace="pre-wrap" borderColor="gray.200">
                             <HStack w="full" justify="space-between">
                               <VStack alignItems="start">
-                                <Text>{fillsFormatted}</Text>
+                                <Text>{medNames}</Text>
                                 <HStack>
                                   <OrderStatusBadge
                                     fulfillmentState={fulfillment?.state as OrderFulfillmentState}


### PR DESCRIPTION
Orders with multiple meds were missing comma separator

![image](https://github.com/Photon-Health/client/assets/3934326/518da4a7-b9df-457a-8f7d-654a63a0bc08)
