### PR TITLE
Fix disabled ready by radio border still selectable

### DIFF
--- a/apps/patient/src/views/ReadyBy.tsx
+++ b/apps/patient/src/views/ReadyBy.tsx
@@ -148,6 +148,7 @@ export const ReadyBy = () => {
                           value={option.label}
                           colorScheme="brand"
                           onClick={(e) => isDisabled && e.preventDefault()}
+                          isDisabled={isDisabled}
                           cursor={isDisabled ? 'not-allowed' : 'pointer'}
                         />
                         <VStack spacing={1}>


### PR DESCRIPTION
Fooled me twice those bugga's! 🤕 

The radio components border was still selectable causing folks to still select disabled times.