### PR TITLE
Fix Auto Login Flag

### DIFF
--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@photonhealth/elements",
-  "version": "0.7.2",
+  "version": "0.7.3-rc1",
   "description": "",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/elements/src/photon-client/photon-client-component.tsx
+++ b/packages/elements/src/photon-client/photon-client-component.tsx
@@ -70,7 +70,7 @@ const Component = (props: PhotonClientProps) => {
   createEffect(() => {
     if (hasAuthParams() && store()) {
       handleRedirect();
-    } else if (store() && props.autoLogin) {
+    } else if (store()) {
       checkSession();
     }
   });

--- a/packages/elements/src/photon-multirx-form/photon-prescribe-workflow.tsx
+++ b/packages/elements/src/photon-multirx-form/photon-prescribe-workflow.tsx
@@ -108,7 +108,8 @@ export function PrescribeWorkflow(props: PrescribeProps) {
     if (
       !client?.authentication.state.isAuthenticated &&
       !client?.authentication.state.isLoading &&
-      !client?.authentication.state.error
+      !client?.authentication.state.error &&
+      client?.autoLogin // don't attempt to login if auto-login=false
     ) {
       client?.authentication.login({ appState: { returnTo: window.location.pathname } });
     }

--- a/packages/elements/src/store.ts
+++ b/packages/elements/src/store.ts
@@ -279,8 +279,6 @@ export class PhotonClientStore {
       const user = await this.sdk.authentication.getUser();
       const hasOrgs = !!this.sdk?.organization && !!user?.org_id;
 
-      try {
-        const token = await this.sdk.authentication.getAccessToken();
       let permissions: Permission[] = [];
 
       if (this.autoLogin || authenticated) {

--- a/packages/elements/src/store.ts
+++ b/packages/elements/src/store.ts
@@ -279,14 +279,20 @@ export class PhotonClientStore {
       const user = await this.sdk.authentication.getUser();
       const hasOrgs = !!this.sdk?.organization && !!user?.org_id;
 
-      let permissions: Permission[];
       try {
         const token = await this.sdk.authentication.getAccessToken();
+      let permissions: Permission[] = [];
 
-        const decoded: { permissions: Permission[] } = jwtDecode(token);
-        permissions = decoded?.permissions || [];
-      } catch (err) {
-        permissions = [];
+      if (this.autoLogin || authenticated) {
+        // getAccessToken is triggering the SSO screen to appear, so for auto-login=false, we don't want to call it
+        try {
+          const token = await this.sdk.authentication.getAccessToken();
+
+          const decoded: { permissions: Permission[] } = jwtDecode(token);
+          permissions = decoded?.permissions || [];
+        } catch (err) {
+          permissions = [];
+        }
       }
 
       this.setStore('authentication', {


### PR DESCRIPTION
A log in was being triggered immediately on page load even if the flag `auto-login="false"` on the `photon-client`. 