### PR TITLE
Fix package.json paths in source map upload

### DIFF
--- a/.github/workflows/upload-source-maps-to-datadog.yml
+++ b/.github/workflows/upload-source-maps-to-datadog.yml
@@ -23,8 +23,8 @@ jobs:
       - name: Upload source maps to Datadog - Patient App
         run: |
           export DATADOG_API_KEY=${{ secrets.DATADOG_API_KEY }}
-          SERVICE_NAME=$(node -p "require('./package.json').name")
-          PACKAGE_VERSION=$(node -p "require('./package.json').version")
+          SERVICE_NAME=$(node -p "require('.apps/patient/package.json').name")
+          PACKAGE_VERSION=$(node -p "require('.apps/patient/package.json').version")
           npx datadog-ci sourcemaps upload dist/apps/patient \
             --service=${SERVICE_NAME} \
             --release-version=${PACKAGE_VERSION} \
@@ -33,8 +33,8 @@ jobs:
       - name: Upload source maps to Datadog - Clinical App
         run: |
           export DATADOG_API_KEY=${{ secrets.DATADOG_API_KEY }}
-          SERVICE_NAME=$(node -p "require('./package.json').name")
-          PACKAGE_VERSION=$(node -p "require('./package.json').version")
+          SERVICE_NAME=$(node -p "require('.apps/app/package.json').name")
+          PACKAGE_VERSION=$(node -p "require('.apps/app/package.json').version")
           npx datadog-ci sourcemaps upload dist/apps/app \
             --service=${SERVICE_NAME} \
             --release-version=${PACKAGE_VERSION} \


### PR DESCRIPTION
It was looking at root where there's another package.json, we need the app specific one to get the correct name and version.