### PR TITLE
Use `github.ref` to get env for source map upload

### DIFF
--- a/.github/workflows/upload-source-maps-to-datadog.yml
+++ b/.github/workflows/upload-source-maps-to-datadog.yml
@@ -25,7 +25,7 @@ jobs:
           export DATADOG_API_KEY=${{ secrets.DATADOG_API_KEY }}
           SERVICE_NAME=$(node -p "require('.apps/patient/package.json').name")
           PACKAGE_VERSION=$(node -p "require('.apps/patient/package.json').version")
-          ENVIRONMENT=${{ github.event.pull_request.base.ref }}
+          ENVIRONMENT=${{ github.ref }}
           npx datadog-ci sourcemaps upload dist/apps/patient \
             --service=${SERVICE_NAME} \
             --release-version=${PACKAGE_VERSION} \
@@ -36,7 +36,7 @@ jobs:
           export DATADOG_API_KEY=${{ secrets.DATADOG_API_KEY }}
           SERVICE_NAME=$(node -p "require('.apps/app/package.json').name")
           PACKAGE_VERSION=$(node -p "require('.apps/app/package.json').version")
-          ENVIRONMENT=${{ github.event.pull_request.base.ref }}
+          ENVIRONMENT=${{ github.ref }}
           npx datadog-ci sourcemaps upload dist/apps/app \
             --service=${SERVICE_NAME} \
             --release-version=${PACKAGE_VERSION} \


### PR DESCRIPTION
It's still having trouble getting the env, since our target branches are boson, neutron, photon, I think we can just use `github.ref`.