### PR TITLE
Remove combine modal error

### DIFF
--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@photonhealth/elements",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/elements/src/photon-multirx-form/photon-prescribe-workflow.tsx
+++ b/packages/elements/src/photon-multirx-form/photon-prescribe-workflow.tsx
@@ -189,7 +189,6 @@ export function PrescribeWorkflow(props: PrescribeProps) {
 
   // before submitting the form, show combine dialog if there is a routing order for the patient
   const displayCombineDialog = () => {
-    dispatchOrderError();
     return recentOrdersActions.setIsCombineDialogOpen(
       true,
       () => submitForm(props.enableOrder),


### PR DESCRIPTION
This addresses the Blueberry comment [here](https://blueberrymed.slack.com/docs/T6AM2J4UD/F06QGB4328G?focus_section_id=temp:C:RUT638e4be724cd48db9b62ec036): `Error events are emitted with empty errors arrays.`

We are sending event messages, tho this situation we are emitting an event without details. 

I'd opt for removing this error since there technically isn't one, we're just letting them know that they have another order that this can be combined with. And I think the modal gives that context well.