### PR TITLE
Pass entire order for order combined event

### DIFF
--- a/apps/app/src/views/routes/PrescriptionForm.tsx
+++ b/apps/app/src/views/routes/PrescriptionForm.tsx
@@ -62,8 +62,8 @@ export const PrescriptionForm = () => {
       });
       ref.current.addEventListener(
         'photon-order-combined',
-        (e: { detail: { orderId: string } }) => {
-          navigate(`/orders/${e.detail.orderId}`);
+        (e: { detail: { order: { id: string } } }) => {
+          navigate(`/orders/${e.detail.order.id}`);
         }
       );
       ref.current.addEventListener(


### PR DESCRIPTION
`photon-order-combined` was only passing the order id, it should pass the whole order 

https://photonhealth.slack.com/archives/C05LVD54ZC0/p1710867443642649?thread_ts=1710790007.564709&cid=C05LVD54ZC0