### PR TITLE
Fix Reroute Error + Can reroute on First Pharmacy Selection

### DIFF
--- a/apps/patient/src/api/internal.ts
+++ b/apps/patient/src/api/internal.ts
@@ -95,12 +95,11 @@ export const markOrderAsPickedUp = async (orderId: string) => {
   }
 };
 
-export const rerouteOrder = async (orderId: string, pharmacyId: string, patientId: string) => {
+export const rerouteOrder = async (orderId: string, pharmacyId: string) => {
   try {
     const response: { rerouteOrder: boolean } = await graphQLClient.request(REROUTE_ORDER, {
       orderId,
-      pharmacyId,
-      patientId
+      pharmacyId
     });
     if (response?.rerouteOrder) {
       return true;

--- a/apps/patient/src/graphql/mutations.ts
+++ b/apps/patient/src/graphql/mutations.ts
@@ -13,8 +13,8 @@ export const SET_PREFERRED_PHARMACY = gql`
 `;
 
 export const REROUTE_ORDER = gql`
-  mutation RerouteOrder($orderId: ID!, $pharmacyId: String, $patientId: String) {
-    rerouteOrder(orderId: $orderId, pharmacyId: $pharmacyId, patientId: $patientId)
+  mutation RerouteOrder($orderId: ID!, $pharmacyId: ID!) {
+    rerouteOrder(orderId: $orderId, pharmacyId: $pharmacyId)
   }
 `;
 

--- a/apps/patient/src/views/Pharmacy.tsx
+++ b/apps/patient/src/views/Pharmacy.tsx
@@ -355,7 +355,7 @@ export const Pharmacy = () => {
 
     try {
       const result = isReroute
-        ? await rerouteOrder(order.id, selectedId, order.patient.id)
+        ? await rerouteOrder(order.id, selectedId)
         : await setOrderPharmacy(order.id, selectedId, order.readyBy, order.readyByTime);
 
       setTimeout(() => {
@@ -388,14 +388,14 @@ export const Pharmacy = () => {
 
             setOrder({
               ...order,
+              isReroutable: !isReroute,
               // Add selected pharmacy to order context so /status shows pharmacy on render
               pharmacy: selectedPharmacy
             });
             const query = queryString.stringify({
               orderId: order.id,
               token,
-              type,
-              ...(!isReroute ? { isFirstPharmacySelection: true } : {})
+              type
             });
             return navigate(`/status?${query}`);
           }, 1000);
@@ -411,7 +411,7 @@ export const Pharmacy = () => {
         const query = queryString.stringify({
           orderId: order.id,
           token,
-          rerouteFailed: true
+          rerouteAttempt: true
         });
         return navigate(`/status?${query}`);
       }

--- a/apps/patient/src/views/Pharmacy.tsx
+++ b/apps/patient/src/views/Pharmacy.tsx
@@ -408,10 +408,13 @@ export const Pharmacy = () => {
       showToastWarning();
       setSubmitting(false);
       if (isReroute) {
+        setOrder({
+          ...order,
+          isReroutable: false
+        });
         const query = queryString.stringify({
           orderId: order.id,
-          token,
-          rerouteAttempt: true
+          token
         });
         return navigate(`/status?${query}`);
       }

--- a/apps/patient/src/views/Pharmacy.tsx
+++ b/apps/patient/src/views/Pharmacy.tsx
@@ -394,7 +394,8 @@ export const Pharmacy = () => {
             const query = queryString.stringify({
               orderId: order.id,
               token,
-              type
+              type,
+              ...(!isReroute ? { isFirstPharmacySelection: true } : {})
             });
             return navigate(`/status?${query}`);
           }, 1000);
@@ -406,14 +407,15 @@ export const Pharmacy = () => {
     } catch (error) {
       showToastWarning();
       setSubmitting(false);
-      console.error(JSON.stringify(error, undefined, 2));
+      if (isReroute) {
+        const query = queryString.stringify({
+          orderId: order.id,
+          token,
+          rerouteFailed: true
+        });
+        return navigate(`/status?${query}`);
+      }
     }
-    const query = queryString.stringify({
-      orderId: order.id,
-      token,
-      rerouteFailed: true
-    });
-    return navigate(`/status?${query}`);
   };
 
   const handleSetPreferredPharmacy = async (pharmacyId: string) => {

--- a/apps/patient/src/views/Status.tsx
+++ b/apps/patient/src/views/Status.tsx
@@ -33,8 +33,7 @@ export const Status = () => {
   const type = searchParams.get('type');
   const isDemo = searchParams.get('demo');
   const phone = searchParams.get('phone');
-  const isFirstPharmacySelection = searchParams.get('firstPharmacySelection') || false;
-  const rerouteFailed = searchParams.get('rerouteFailed') || false;
+  console.log('order', order);
 
   const showFooterStates: types.FulfillmentState[] = ['RECEIVED', 'READY'];
   const [showFooter, setShowFooter] = useState<boolean>(
@@ -212,12 +211,7 @@ export const Status = () => {
                 pharmacy={pharmacyWithHours}
                 selected={true}
                 showDetails={fulfillmentType === 'PICK_UP'}
-                canReroute={
-                  !isDemo &&
-                  orgSettings.enablePatientRerouting &&
-                  order.isReroutable &&
-                  !rerouteFailed
-                }
+                canReroute={!isDemo && orgSettings.enablePatientRerouting && order.isReroutable}
                 onChangePharmacy={() => {
                   const query = queryString.stringify({
                     orderId: order.id,

--- a/apps/patient/src/views/Status.tsx
+++ b/apps/patient/src/views/Status.tsx
@@ -33,7 +33,6 @@ export const Status = () => {
   const type = searchParams.get('type');
   const isDemo = searchParams.get('demo');
   const phone = searchParams.get('phone');
-  console.log('order', order);
 
   const showFooterStates: types.FulfillmentState[] = ['RECEIVED', 'READY'];
   const [showFooter, setShowFooter] = useState<boolean>(

--- a/apps/patient/src/views/Status.tsx
+++ b/apps/patient/src/views/Status.tsx
@@ -33,6 +33,7 @@ export const Status = () => {
   const type = searchParams.get('type');
   const isDemo = searchParams.get('demo');
   const phone = searchParams.get('phone');
+  const isFirstPharmacySelection = searchParams.get('firstPharmacySelection') || false;
   const rerouteFailed = searchParams.get('rerouteFailed') || false;
 
   const showFooterStates: types.FulfillmentState[] = ['RECEIVED', 'READY'];


### PR DESCRIPTION
1. There was an error introduced with the reroute failed error that is fixed here
2. I simplified the logic about how the status page knows if an order reroute was just attempted, it also allows now for a reroute after the first selection