### PR TITLE
Fix gap above today/tomorrow section on small screens

### DIFF
--- a/apps/patient/src/views/ReadyBy.tsx
+++ b/apps/patient/src/views/ReadyBy.tsx
@@ -111,8 +111,16 @@ export const ReadyBy = () => {
         </Container>
       </Box>
 
-      {/* z-index set here to sit above ready by options but still below nav so shadow looks good*/}
-      <Box bgColor="white" style={{ position: 'sticky', top: 90, zIndex: 1 }} shadow="sm">
+      <Box
+        bgColor="white"
+        style={{
+          position: 'sticky',
+          top: process.env.REACT_APP_ENV_NAME === 'photon' ? 55 : 90,
+          // z-index set here to sit above ready by options but still below nav so shadow looks good
+          zIndex: 1
+        }}
+        shadow="sm"
+      >
         <Container p={4}>
           <HStack>
             {['Today', 'Tomorrow'].map((day) => (


### PR DESCRIPTION
Noticed in sessions that on prod where the blue "This is not a real prescription" banner shows and the readyBy options extend past the bottom of the page because it's an extra small screen (iPhone SE), that there's a gap above the sticky today/tomorrow section.

Removing this gap...
<img width="404" alt="image" src="https://github.com/Photon-Health/client/assets/3934326/7b868b37-76a5-4700-8c96-8fe5dad0fc96">
