### PR TITLE
Disable Next button when readyBy day is changed

### DIFF
--- a/apps/patient/src/views/ReadyBy.tsx
+++ b/apps/patient/src/views/ReadyBy.tsx
@@ -132,6 +132,8 @@ export const ReadyBy = () => {
                 backgroundColor="white"
                 onClick={(e) => {
                   e.preventDefault();
+                  setSelectedTime(undefined);
+                  setSelectedDay(undefined);
                   setActiveTab(day);
                 }}
                 borderRadius="xl"


### PR DESCRIPTION
This was highlighted by Jomi, change is to prevent accidental selections.
[See ticket](https://www.notion.so/photons/Dismiss-Next-button-when-a-user-toggles-between-Today-Tomorrow-29c2d5bf3c014ce8a8c9a1e1a1742afd?pvs=4)

Example of footer hiding on day change...

https://github.com/Photon-Health/client/assets/3934326/2dc36f6c-6100-4e51-a44d-368f65a0e2bf

