### PR TITLE
Fix review rx accordion collapse

### DIFF
--- a/apps/patient/src/components/PrescriptionsList.tsx
+++ b/apps/patient/src/components/PrescriptionsList.tsx
@@ -1,6 +1,7 @@
 import {
   Accordion,
   AccordionButton,
+  AccordionIcon,
   AccordionItem,
   AccordionPanel,
   Box,
@@ -42,7 +43,7 @@ export const PrescriptionsList = () => {
                         </Text>
                       </HStack>
                       <Box>
-                        <AccordionItem />
+                        <AccordionIcon />
                       </Box>
                     </AccordionButton>
                   </HStack>


### PR DESCRIPTION
Rx's were missing the collapse arrow at the top right of the accordion items. Just re-adding that.

<img width="270" alt="image" src="https://github.com/Photon-Health/client/assets/3934326/da9c6b53-25f1-4f3d-b1a4-e083b8588912">

After:

<img width="366" alt="image" src="https://github.com/Photon-Health/client/assets/3934326/2e7bae79-be60-4b41-a2c3-17496ff22563">
