### PR TITLE
Enable `topRankedWalgreens` on neutron

### DIFF
--- a/packages/settings/src/lib/neutron.ts
+++ b/packages/settings/src/lib/neutron.ts
@@ -72,7 +72,8 @@ const organizationSettings: {
       HONEYBEE_PHARMACY_ID,
       GOGOMEDS_PHARMACY_ID
     ],
-    topRankedCostco: true
+    topRankedCostco: true,
+    topRankedWalgreens: true
   },
   // NewCo (demo's)
   org_YiUudCToTSrjOuow: {

--- a/packages/settings/src/lib/neutron.ts
+++ b/packages/settings/src/lib/neutron.ts
@@ -72,7 +72,6 @@ const organizationSettings: {
       HONEYBEE_PHARMACY_ID,
       GOGOMEDS_PHARMACY_ID
     ],
-    topRankedCostco: true,
     topRankedWalgreens: true
   },
   // NewCo (demo's)


### PR DESCRIPTION
To test walgreens on neutron before blueberry launch on production.
Also disabled topRankedCostco on test org.