### PR TITLE
Disable topRankedWalgreens for Blueberry on production

### DIFF
--- a/packages/settings/src/lib/photon.ts
+++ b/packages/settings/src/lib/photon.ts
@@ -219,8 +219,7 @@ const organizationSettings: {
     ...defaultSettings,
     logo: 'blueberry_logo.png',
     accentColor: '#235AFF',
-    enableMedHistory: true,
-    topRankedWalgreens: true
+    enableMedHistory: true
   },
   // TBD Health
   org_XoBVNLkIWL6BP8vZ: {


### PR DESCRIPTION
This is for housekeeping so that boson and neutron have what is currently on photon