### PR TITLE
Filter pharmacy option if already in the list

### DIFF
--- a/apps/patient/src/utils/general.spec.ts
+++ b/apps/patient/src/utils/general.spec.ts
@@ -1,0 +1,60 @@
+import { preparePharmacyOptions } from './general'; // Update the import path according to your project structure
+import { types } from '@photonhealth/sdk';
+
+describe('preparePharmacyOptions', () => {
+  it('should dedupe pharmacy options when merging new and existing pharmacies', () => {
+    // Arrange
+    const existingPharmacies = [
+      { id: '1', name: 'Pharmacy A' },
+      { id: '2', name: 'Pharmacy B' }
+    ];
+
+    const newPharmacies = [
+      { id: '2', name: 'Pharmacy B' },
+      { id: '3', name: 'Pharmacy C' }
+    ];
+
+    // Act
+    const result = preparePharmacyOptions(newPharmacies, existingPharmacies);
+
+    // Assert
+    expect(result).toHaveLength(3); // Expected length after merging
+    expect(result).toEqual([
+      { id: 1, name: 'Pharmacy A' },
+      { id: 2, name: 'Pharmacy B' }, // Existing pharmacy
+      { id: 3, name: 'Pharmacy C' } // New pharmacy
+    ]);
+  });
+
+  it('should return existing pharmacies when newPharmacies is empty', () => {
+    // Arrange
+    const existingPharmacies = [
+      { id: 1, name: 'Pharmacy A' },
+      { id: 2, name: 'Pharmacy B' }
+    ];
+
+    const newPharmacies: types.Pharmacy[] = []; // Empty array
+
+    // Act
+    const result = preparePharmacyOptions(newPharmacies, existingPharmacies);
+
+    // Assert
+    expect(result).toEqual(existingPharmacies);
+  });
+
+  it('should return only newPharmacies when existingPharmacies is empty', () => {
+    // Arrange
+    const existingPharmacies: EnrichedPharmacy[] = []; // Empty array
+
+    const newPharmacies = [
+      { id: 1, name: 'Pharmacy A' },
+      { id: 2, name: 'Pharmacy B' }
+    ];
+
+    // Act
+    const result = preparePharmacyOptions(newPharmacies, existingPharmacies);
+
+    // Assert
+    expect(result).toEqual(newPharmacies);
+  });
+});

--- a/apps/patient/src/utils/general.spec.ts
+++ b/apps/patient/src/utils/general.spec.ts
@@ -1,5 +1,4 @@
-import { preparePharmacyOptions } from './general'; // Update the import path according to your project structure
-import { types } from '@photonhealth/sdk';
+import { preparePharmacyOptions } from './general';
 
 describe('preparePharmacyOptions', () => {
   it('should dedupe pharmacy options when merging new and existing pharmacies', () => {
@@ -20,20 +19,20 @@ describe('preparePharmacyOptions', () => {
     // Assert
     expect(result).toHaveLength(3); // Expected length after merging
     expect(result).toEqual([
-      { id: 1, name: 'Pharmacy A' },
-      { id: 2, name: 'Pharmacy B' }, // Existing pharmacy
-      { id: 3, name: 'Pharmacy C' } // New pharmacy
+      { id: '1', name: 'Pharmacy A' },
+      { id: '2', name: 'Pharmacy B' }, // Existing pharmacy
+      { id: '3', name: 'Pharmacy C' } // New pharmacy
     ]);
   });
 
   it('should return existing pharmacies when newPharmacies is empty', () => {
     // Arrange
     const existingPharmacies = [
-      { id: 1, name: 'Pharmacy A' },
-      { id: 2, name: 'Pharmacy B' }
+      { id: '1', name: 'Pharmacy A' },
+      { id: '2', name: 'Pharmacy B' }
     ];
 
-    const newPharmacies: types.Pharmacy[] = []; // Empty array
+    const newPharmacies = []; // Empty array
 
     // Act
     const result = preparePharmacyOptions(newPharmacies, existingPharmacies);
@@ -44,11 +43,11 @@ describe('preparePharmacyOptions', () => {
 
   it('should return only newPharmacies when existingPharmacies is empty', () => {
     // Arrange
-    const existingPharmacies: EnrichedPharmacy[] = []; // Empty array
+    const existingPharmacies = []; // Empty array
 
     const newPharmacies = [
-      { id: 1, name: 'Pharmacy A' },
-      { id: 2, name: 'Pharmacy B' }
+      { id: '1', name: 'Pharmacy A' },
+      { id: '2', name: 'Pharmacy B' }
     ];
 
     // Act

--- a/apps/patient/src/utils/general.ts
+++ b/apps/patient/src/utils/general.ts
@@ -107,7 +107,7 @@ function isCloseEvent(event: types.PharmacyEvent): event is types.PharmacyCloseE
 }
 
 /**
- * Dedupes pharmacy options when merging new and existing pharmacies
+ * Dedupes and enriches pharmacy options when merging new and existing pharmacies
  * @param newPharmacies Pharmacies query result
  * @param existingPharmacies Pre-loaded pharmacies
  * @returns Deduped list of enriched pharmacy options

--- a/apps/patient/src/utils/general.ts
+++ b/apps/patient/src/utils/general.ts
@@ -106,6 +106,23 @@ function isCloseEvent(event: types.PharmacyEvent): event is types.PharmacyCloseE
   return event.type === 'close';
 }
 
+/**
+ * Dedupes pharmacy options when merging new and existing pharmacies
+ * @param newPharmacies Pharmacies query result
+ * @param existingPharmacies Pre-loaded pharmacies
+ * @returns Deduped list of enriched pharmacy options
+ */
+export const preparePharmacyOptions = (
+  newPharmacies: types.Pharmacy[],
+  existingPharmacies: EnrichedPharmacy[] = []
+) => {
+  const existingPharmacyIds = new Set(existingPharmacies.map((p) => p.id));
+  const enrichedNewPharmacies = newPharmacies
+    .filter((p) => !existingPharmacyIds.has(p.id))
+    .map(preparePharmacy);
+  return [...existingPharmacies, ...enrichedNewPharmacies];
+};
+
 export const preparePharmacy = (pharmacy: types.Pharmacy): EnrichedPharmacy => {
   let is24Hr = false;
   let isClosingSoon = false;

--- a/apps/patient/src/utils/general.ts
+++ b/apps/patient/src/utils/general.ts
@@ -17,12 +17,13 @@ dayjs.extend(isoWeek);
 dayjs.extend(isBetween);
 dayjs.extend(isToday);
 
-export const titleCase = (str: string) =>
-  str
+export const titleCase = (str) => {
+  return str
     .toLowerCase()
     .split(' ')
     .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
     .join(' ');
+};
 
 export const formatAddress = (address: types.Address) => {
   const { city, postalCode, state, street1, street2 } = address;
@@ -112,16 +113,16 @@ function isCloseEvent(event: types.PharmacyEvent): event is types.PharmacyCloseE
  * @param existingPharmacies Pre-loaded pharmacies
  * @returns Deduped list of enriched pharmacy options
  */
-export const preparePharmacyOptions = (
+export function preparePharmacyOptions(
   newPharmacies: types.Pharmacy[],
   existingPharmacies: EnrichedPharmacy[] = []
-) => {
+) {
   const existingPharmacyIds = new Set(existingPharmacies.map((p) => p.id));
   const enrichedNewPharmacies = newPharmacies
     .filter((p) => !existingPharmacyIds.has(p.id))
     .map(preparePharmacy);
   return [...existingPharmacies, ...enrichedNewPharmacies];
-};
+}
 
 export const preparePharmacy = (pharmacy: types.Pharmacy): EnrichedPharmacy => {
   let is24Hr = false;

--- a/apps/patient/src/views/Pharmacy.tsx
+++ b/apps/patient/src/views/Pharmacy.tsx
@@ -16,7 +16,7 @@ import { Helmet } from 'react-helmet';
 import queryString from 'query-string';
 import { types } from '@photonhealth/sdk';
 import * as TOAST_CONFIG from '../configs/toast';
-import { formatAddress, preparePharmacy } from '../utils/general';
+import { formatAddress, preparePharmacyOptions } from '../utils/general';
 import { ExtendedFulfillmentType, Pharmacy as PharmacyWithHours } from '../utils/models';
 import { text as t } from '../utils/text';
 import {
@@ -41,7 +41,7 @@ import capsulePharmacyIdLookup from '../data/capsulePharmacyIds.json';
 import { Pharmacy as EnrichedPharmacy } from '../utils/models';
 import { isGLP } from '../utils/isGLP';
 
-const GET_PHARMACIES_COUNT = 5; // Number of pharmacies to fetch at a time
+const GET_PHARMACIES_LIMIT = 5; // Number of pharmacies to fetch at a time
 const PHARMACY_SEARCH_RADIUS_IN_MILES = 25;
 
 export const Pharmacy = () => {
@@ -239,7 +239,7 @@ export const Pharmacy = () => {
           longitude: lng,
           radius: PHARMACY_SEARCH_RADIUS_IN_MILES
         },
-        limit: GET_PHARMACIES_COUNT,
+        limit: GET_PHARMACIES_LIMIT,
         offset: 0,
         isOpenNow: enableOpenNow,
         is24hr: enable24Hr
@@ -267,7 +267,7 @@ export const Pharmacy = () => {
       return;
     }
 
-    const preparedPharmacies: PharmacyWithHours[] = pharmaciesResult.map(preparePharmacy);
+    const preparedPharmacies: PharmacyWithHours[] = preparePharmacyOptions(pharmaciesResult);
     setPharmacyOptions(preparedPharmacies);
 
     setLoadingPharmacies(false);
@@ -284,7 +284,7 @@ export const Pharmacy = () => {
 
       const newPharmacyOptions = pharmacies.slice(
         pharmacyOptions.length,
-        pharmacyOptions.length + GET_PHARMACIES_COUNT
+        pharmacyOptions.length + GET_PHARMACIES_LIMIT
       );
       const totalPharmacyOptions = [...pharmacyOptions, ...newPharmacyOptions];
       setPharmacyOptions(totalPharmacyOptions);
@@ -305,7 +305,7 @@ export const Pharmacy = () => {
           longitude,
           radius: PHARMACY_SEARCH_RADIUS_IN_MILES
         },
-        limit: GET_PHARMACIES_COUNT,
+        limit: GET_PHARMACIES_LIMIT,
         offset: pharmacyOptions.length,
         isOpenNow: enableOpenNow,
         is24hr: enable24Hr
@@ -327,8 +327,11 @@ export const Pharmacy = () => {
       }
     }
 
-    const preparedPharmacies: PharmacyWithHours[] = pharmaciesResult.map(preparePharmacy);
-    setPharmacyOptions([...pharmacyOptions, ...preparedPharmacies]);
+    const preparedPharmacies: PharmacyWithHours[] = preparePharmacyOptions(
+      pharmaciesResult,
+      pharmacyOptions
+    );
+    setPharmacyOptions(preparedPharmacies);
 
     setLoadingPharmacies(false);
   };

--- a/package-lock.json
+++ b/package-lock.json
@@ -37779,7 +37779,7 @@
     },
     "packages/elements": {
       "name": "@photonhealth/elements",
-      "version": "0.8.5",
+      "version": "0.8.6",
       "license": "ISC",
       "dependencies": {
         "@photonhealth/components": "*",


### PR DESCRIPTION
For top ranked pharmacies (Costco, Walgreens) we were potentially showing them twice in the list because they are two separate query results merged together. This dedupes.