### PR TITLE
Re-enable `topRankedWalgreens` for Blueberry

### DIFF
--- a/packages/settings/src/lib/photon.ts
+++ b/packages/settings/src/lib/photon.ts
@@ -219,7 +219,8 @@ const organizationSettings: {
     ...defaultSettings,
     logo: 'blueberry_logo.png',
     accentColor: '#235AFF',
-    enableMedHistory: true
+    enableMedHistory: true,
+    topRankedWalgreens: true
   },
   // TBD Health
   org_XoBVNLkIWL6BP8vZ: {


### PR DESCRIPTION
Re-enabling the Walgreens urgency pilot for Blueberry Pediatrics