### PR TITLE
Set `topRankedWalgreens` on photon

### DIFF
--- a/packages/settings/src/lib/photon.ts
+++ b/packages/settings/src/lib/photon.ts
@@ -219,7 +219,8 @@ const organizationSettings: {
     ...defaultSettings,
     logo: 'blueberry_logo.png',
     accentColor: '#235AFF',
-    enableMedHistory: true
+    enableMedHistory: true,
+    topRankedWalgreens: true
   },
   // TBD Health
   org_XoBVNLkIWL6BP8vZ: {


### PR DESCRIPTION
Though the previous deployment enabled this, our rollback overrode this change.