### PR TITLE
Fix location search console errors

### DIFF
--- a/apps/app/public/index.html
+++ b/apps/app/public/index.html
@@ -10,7 +10,10 @@
     <meta name="theme-color" content="#000000" />
     <meta name="description" content="Photon Health - Clinical App" />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo256.png" />
-    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAvuwwE6g2Bsmih66nu4dB7-H7U1_7KQ6g&libraries=places"></script>
+    <script
+      async
+      src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAvuwwE6g2Bsmih66nu4dB7-H7U1_7KQ6g&loading=async&callback=Function.prototype&libraries=places"
+    ></script>
     <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/

--- a/apps/patient/public/index.html
+++ b/apps/patient/public/index.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />

--- a/apps/patient/public/index.html
+++ b/apps/patient/public/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />
@@ -7,7 +7,10 @@
     <meta name="theme-color" content="#000000" />
     <meta name="description" content="Photon Health - Patient App" />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo256.png" />
-    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAvuwwE6g2Bsmih66nu4dB7-H7U1_7KQ6g&libraries=places"></script>
+    <script
+      async
+      src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAvuwwE6g2Bsmih66nu4dB7-H7U1_7KQ6g&loading=async&callback=Function.prototype&libraries=places"
+    ></script>
     <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/

--- a/packages/components/src/systems/LocationSelect/index.tsx
+++ b/packages/components/src/systems/LocationSelect/index.tsx
@@ -40,8 +40,10 @@ export default function LocationSelect(props: LocationSelectProps) {
     setNavigatorError(false);
     await asyncInterval(() => !!geocoder(), 10, 20);
     const locations = await getLocations(address, geocoder()!);
-    props.setLocation(locations[0]);
-    props.setOpen(false);
+    if (locations.length > 0) {
+      props.setLocation(locations[0]);
+      props.setOpen(false);
+    }
   };
 
   const getCurrentLocation = async () => {
@@ -54,7 +56,9 @@ export default function LocationSelect(props: LocationSelectProps) {
       } = await getNavigatorLocation({ timeout: 5000 });
       await asyncInterval(() => !!geocoder(), 10, 20);
       const locations = await getLocations({ latitude, longitude }, geocoder()!);
-      props.setLocation(locations[0]);
+      if (locations.length > 0) {
+        props.setLocation(locations[0]);
+      }
       props.setOpen(false);
     } catch {
       setNavigatorError(true);

--- a/packages/components/src/systems/PharmacySearch/index.tsx
+++ b/packages/components/src/systems/PharmacySearch/index.tsx
@@ -223,7 +223,9 @@ export default function PharmacySearch(props: PharmacySearchProps) {
 
   async function getAndSetLocation(address: string, geocoder: google.maps.Geocoder) {
     const locations = await getLocations(address || '', geocoder);
-    setLocation(locations[0]);
+    if (locations.length > 0) {
+      setLocation(locations[0]);
+    }
   }
 
   onMount(() => {

--- a/packages/components/src/utils/getLocations.ts
+++ b/packages/components/src/utils/getLocations.ts
@@ -11,6 +11,13 @@ const getLocation = async (
   addressOrLocation: string | Coordinates,
   geocoder: google.maps.Geocoder
 ): Promise<Location[]> => {
+  if (
+    typeof addressOrLocation !== 'string' &&
+    (!addressOrLocation.latitude || !addressOrLocation.longitude)
+  ) {
+    return [];
+  }
+
   const data = await geocoder.geocode({
     ...(typeof addressOrLocation === 'string'
       ? { address: addressOrLocation }

--- a/packages/components/src/utils/loadGoogleScript.ts
+++ b/packages/components/src/utils/loadGoogleScript.ts
@@ -11,8 +11,9 @@ export default function loadGoogleScript({ onLoad, onError }: LoadGoogleScriptOp
   } else if (!scriptLoading) {
     scriptLoading = true;
     const script = document.createElement('script');
+    script.async = true;
     script.src =
-      'https://maps.googleapis.com/maps/api/js?key=AIzaSyAvuwwE6g2Bsmih66nu4dB7-H7U1_7KQ6g&libraries=places';
+      'https://maps.googleapis.com/maps/api/js?key=AIzaSyAvuwwE6g2Bsmih66nu4dB7-H7U1_7KQ6g&loading=async&callback=Function.prototype&libraries=places';
     document.head.appendChild(script);
 
     script.onload = () => {


### PR DESCRIPTION
Our Google maps initialization is outdated, `callback` is now required, `async` is highly recommended. 
Fixes [this error](https://photonhealth.slack.com/archives/C03BV7ZBHLM/p1713284826939819)
> Google Maps JavaScript API error: NotLoadingAPIFromGoogleMapsError
https://developers.google.com/maps/documentation/javascript/error-messages#not-loading-api-from-google-maps-error

While fixing that, I noticed that latlng can be undefined in getLocations, added a check. Should revisit to see why it was passed in undefined, but it wasn't clear exactly where that's happening so this resolves for now.