### PR TITLE
Remove unnecessary console error

### DIFF
--- a/apps/patient/src/views/Main.tsx
+++ b/apps/patient/src/views/Main.tsx
@@ -48,7 +48,6 @@ export const Main = () => {
   useEffect(() => {
     if (location.pathname !== '/canceled') {
       if (!isDemo && (!orderId || !token)) {
-        console.error('Missing orderId or token in search params');
         navigate('/no-match', { replace: true });
       }
     }


### PR DESCRIPTION
This error has been spammy forever, now it's polluting frontend DataDog errors. We don't act on these, so removing.