### PR TITLE
Revert google async load

### DIFF
--- a/apps/app/public/index.html
+++ b/apps/app/public/index.html
@@ -10,10 +10,7 @@
     <meta name="theme-color" content="#000000" />
     <meta name="description" content="Photon Health - Clinical App" />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo256.png" />
-    <script
-      async
-      src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAvuwwE6g2Bsmih66nu4dB7-H7U1_7KQ6g&loading=async&callback=Function.prototype&libraries=places"
-    ></script>
+    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAvuwwE6g2Bsmih66nu4dB7-H7U1_7KQ6g&callback=Function.prototype&libraries=places"></script>
     <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/

--- a/apps/patient/public/index.html
+++ b/apps/patient/public/index.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />

--- a/apps/patient/public/index.html
+++ b/apps/patient/public/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />
@@ -7,10 +7,7 @@
     <meta name="theme-color" content="#000000" />
     <meta name="description" content="Photon Health - Patient App" />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo256.png" />
-    <script
-      async
-      src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAvuwwE6g2Bsmih66nu4dB7-H7U1_7KQ6g&loading=async&callback=Function.prototype&libraries=places"
-    ></script>
+    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAvuwwE6g2Bsmih66nu4dB7-H7U1_7KQ6g&callback=Function.prototype&libraries=places"></script>
     <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/

--- a/packages/components/src/utils/loadGoogleScript.ts
+++ b/packages/components/src/utils/loadGoogleScript.ts
@@ -11,9 +11,8 @@ export default function loadGoogleScript({ onLoad, onError }: LoadGoogleScriptOp
   } else if (!scriptLoading) {
     scriptLoading = true;
     const script = document.createElement('script');
-    script.async = true;
     script.src =
-      'https://maps.googleapis.com/maps/api/js?key=AIzaSyAvuwwE6g2Bsmih66nu4dB7-H7U1_7KQ6g&loading=async&callback=Function.prototype&libraries=places';
+      'https://maps.googleapis.com/maps/api/js?key=AIzaSyAvuwwE6g2Bsmih66nu4dB7-H7U1_7KQ6g&callback=Function.prototype&libraries=places';
     document.head.appendChild(script);
 
     script.onload = () => {


### PR DESCRIPTION
Google isn't loading in time for component render on boson after recent google script tag update, removing optional async tags fixes this