### PR TITLE
Add a general notes parameter to the prescribe element

### DIFF
--- a/packages/elements/index.html
+++ b/packages/elements/index.html
@@ -24,6 +24,8 @@
           enable-local-pickup="true"
           enable-med-history="true"
           mail-order-ids="phr_01GA9HPVBVJ0E65P819FD881N0,phr_01GCA54GVKA06C905DETQ9SY98"
+          general-notes="Some additional notes to add to the message."
+          weight="23"
         ></photon-prescribe-workflow>
       </div>
     </photon-client>

--- a/packages/elements/index.html
+++ b/packages/elements/index.html
@@ -24,7 +24,7 @@
           enable-local-pickup="true"
           enable-med-history="true"
           mail-order-ids="phr_01GA9HPVBVJ0E65P819FD881N0,phr_01GCA54GVKA06C905DETQ9SY98"
-          general-notes="Some additional notes to add to the message."
+          additional-notes="Some additional notes to add to the message."
           weight="23"
         ></photon-prescribe-workflow>
       </div>

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@photonhealth/elements",
-  "version": "0.8.8",
+  "version": "0.9.0",
   "description": "",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/elements/src/photon-multirx-form-wrapper/photon-multirx-form-wrapper-component.tsx
+++ b/packages/elements/src/photon-multirx-form-wrapper/photon-multirx-form-wrapper-component.tsx
@@ -30,6 +30,7 @@ const Component = (props: {
   prescriptionIds?: string;
   weight?: number;
   weightUnit?: string;
+  generalNotes?: string;
   enableLocalPickup?: boolean;
   enableSendToPatient?: boolean;
   enableCombineAndDuplicate?: boolean;
@@ -230,6 +231,7 @@ const Component = (props: {
                 prescription-ids={props.prescriptionIds}
                 weight={props.weight}
                 weight-unit={props.weightUnit}
+                general-notes={props.generalNotes}
                 enable-med-history={props.enableMedHistory}
                 enable-order={props.enableOrder}
                 enable-local-pickup={props.enableLocalPickup}
@@ -285,6 +287,7 @@ customElement(
     prescriptionIds: undefined,
     weight: undefined,
     weightUnit: 'lbs',
+    generalNotes: undefined,
     enableLocalPickup: false,
     enableSendToPatient: false,
     enableMedHistory: false,

--- a/packages/elements/src/photon-multirx-form-wrapper/photon-multirx-form-wrapper-component.tsx
+++ b/packages/elements/src/photon-multirx-form-wrapper/photon-multirx-form-wrapper-component.tsx
@@ -30,7 +30,7 @@ const Component = (props: {
   prescriptionIds?: string;
   weight?: number;
   weightUnit?: string;
-  generalNotes?: string;
+  additionalNotes?: string;
   enableLocalPickup?: boolean;
   enableSendToPatient?: boolean;
   enableCombineAndDuplicate?: boolean;
@@ -231,7 +231,7 @@ const Component = (props: {
                 prescription-ids={props.prescriptionIds}
                 weight={props.weight}
                 weight-unit={props.weightUnit}
-                general-notes={props.generalNotes}
+                additional-notes={props.additionalNotes}
                 enable-med-history={props.enableMedHistory}
                 enable-order={props.enableOrder}
                 enable-local-pickup={props.enableLocalPickup}
@@ -287,7 +287,7 @@ customElement(
     prescriptionIds: undefined,
     weight: undefined,
     weightUnit: 'lbs',
-    generalNotes: undefined,
+    additionalNotes: undefined,
     enableLocalPickup: false,
     enableSendToPatient: false,
     enableMedHistory: false,

--- a/packages/elements/src/photon-multirx-form/components/AddPrescriptionCard.tsx
+++ b/packages/elements/src/photon-multirx-form/components/AddPrescriptionCard.tsx
@@ -20,7 +20,6 @@ import { setBasePath } from '@shoelace-style/shoelace/dist/utilities/base-path.j
 import { createSignal, Show, onMount } from 'solid-js';
 import repopulateForm from '../util/repopulateForm';
 import clearForm from '../util/clearForm';
-import { formatPatientWeight } from '../util/formatPatientWeight';
 import { usePhoton } from '../../context';
 import { GraphQLError } from 'graphql';
 
@@ -48,6 +47,7 @@ export const AddPrescriptionCard = (props: {
   store: Record<string, any>;
   weight?: number;
   weightUnit?: string;
+  prefillNotes?: string;
   enableCombineAndDuplicate?: boolean;
 }) => {
   const client = usePhoton();
@@ -67,17 +67,7 @@ export const AddPrescriptionCard = (props: {
     }
 
     // initialize values in the prescribe form
-    clearForm(
-      props.actions,
-      props.weight ? { notes: formatPatientWeight(props.weight, props?.weightUnit) } : undefined
-    );
-
-    if (props.weight) {
-      props.actions.updateFormValue({
-        key: 'notes',
-        value: formatPatientWeight(props.weight, props.weightUnit)
-      });
-    }
+    clearForm(props.actions, props?.prefillNotes ? { notes: props.prefillNotes } : undefined);
   });
 
   const templateMutation = client!
@@ -149,10 +139,7 @@ export const AddPrescriptionCard = (props: {
           'addToTemplates'
         ]);
         setOffCatalog(undefined);
-        clearForm(
-          props.actions,
-          props.weight ? { notes: formatPatientWeight(props.weight, props?.weightUnit) } : undefined
-        );
+        clearForm(props.actions, props.prefillNotes ? { notes: props.prefillNotes } : undefined);
         if (addToTemplate) {
           try {
             const { errors } = await templateMutation({
@@ -234,12 +221,7 @@ export const AddPrescriptionCard = (props: {
               if (e.detail.data.__typename === 'PrescriptionTemplate') {
                 repopulateForm(props.actions, {
                   ...e.detail.data,
-                  notes: [
-                    e.detail.data?.notes,
-                    props.weight && formatPatientWeight(props.weight, props?.weightUnit)
-                  ]
-                    .filter((x) => x)
-                    .join('\n\n')
+                  notes: [e.detail.data?.notes, props.prefillNotes].filter((x) => x).join('\n\n')
                 });
               } else {
                 props.actions.updateFormValue({

--- a/packages/elements/src/photon-multirx-form/photon-prescribe-workflow-component.tsx
+++ b/packages/elements/src/photon-multirx-form/photon-prescribe-workflow-component.tsx
@@ -34,6 +34,7 @@ const Component = (props: PrescribeProps) => {
         address={props.address}
         weight={props.weight}
         weightUnit={props.weightUnit}
+        generalNotes={props.generalNotes}
         triggerSubmit={props.triggerSubmit}
         toastBuffer={props.toastBuffer}
         formStore={store}
@@ -63,6 +64,7 @@ customElement(
     address: undefined,
     weight: undefined,
     weightUnit: 'lbs',
+    generalNotes: undefined,
     triggerSubmit: false,
     setTriggerSubmit: undefined,
     toastBuffer: 0,

--- a/packages/elements/src/photon-multirx-form/photon-prescribe-workflow-component.tsx
+++ b/packages/elements/src/photon-multirx-form/photon-prescribe-workflow-component.tsx
@@ -34,7 +34,7 @@ const Component = (props: PrescribeProps) => {
         address={props.address}
         weight={props.weight}
         weightUnit={props.weightUnit}
-        generalNotes={props.generalNotes}
+        additionalNotes={props.additionalNotes}
         triggerSubmit={props.triggerSubmit}
         toastBuffer={props.toastBuffer}
         formStore={store}
@@ -64,7 +64,7 @@ customElement(
     address: undefined,
     weight: undefined,
     weightUnit: 'lbs',
-    generalNotes: undefined,
+    additionalNotes: undefined,
     triggerSubmit: false,
     setTriggerSubmit: undefined,
     toastBuffer: 0,

--- a/packages/elements/src/photon-multirx-form/photon-prescribe-workflow.tsx
+++ b/packages/elements/src/photon-multirx-form/photon-prescribe-workflow.tsx
@@ -66,6 +66,7 @@ export type PrescribeProps = {
   address?: Address;
   weight?: number;
   weightUnit?: string;
+  generalNotes?: string;
   triggerSubmit: boolean;
   setTriggerSubmit?: (val: boolean) => void;
   toastBuffer: number;
@@ -89,6 +90,17 @@ export function PrescribeWorkflow(props: PrescribeProps) {
   );
   const [, recentOrdersActions] = useRecentOrders();
 
+  // we can ignore the warnings to put inside of a createEffect, the generalNotes or weight shouldn't be updating
+  let prefillNotes = '';
+  if (props.generalNotes) {
+    prefillNotes = `${props.generalNotes}
+
+`;
+  }
+  if (props.weight) {
+    prefillNotes = `${prefillNotes}${formatPatientWeight(props.weight, props?.weightUnit)}`;
+  }
+
   onMount(() => {
     if (props.address) {
       // if manually overriding address, update the store on mount
@@ -99,10 +111,7 @@ export function PrescribeWorkflow(props: PrescribeProps) {
     }
 
     ref.addEventListener('photon-ticket-created-duplicate', () => {
-      clearForm(
-        props.formActions,
-        props.weight ? { notes: formatPatientWeight(props.weight, props?.weightUnit) } : undefined
-      );
+      clearForm(props.formActions, prefillNotes ? { notes: prefillNotes } : undefined);
     });
   });
 
@@ -435,6 +444,7 @@ export function PrescribeWorkflow(props: PrescribeProps) {
                       store={props.formStore}
                       weight={props.weight}
                       weightUnit={props.weightUnit}
+                      prefillNotes={prefillNotes}
                       enableCombineAndDuplicate={props.enableCombineAndDuplicate}
                     />
                   </div>

--- a/packages/elements/src/photon-multirx-form/photon-prescribe-workflow.tsx
+++ b/packages/elements/src/photon-multirx-form/photon-prescribe-workflow.tsx
@@ -66,7 +66,7 @@ export type PrescribeProps = {
   address?: Address;
   weight?: number;
   weightUnit?: string;
-  generalNotes?: string;
+  additionalNotes?: string;
   triggerSubmit: boolean;
   setTriggerSubmit?: (val: boolean) => void;
   toastBuffer: number;
@@ -90,10 +90,10 @@ export function PrescribeWorkflow(props: PrescribeProps) {
   );
   const [, recentOrdersActions] = useRecentOrders();
 
-  // we can ignore the warnings to put inside of a createEffect, the generalNotes or weight shouldn't be updating
+  // we can ignore the warnings to put inside of a createEffect, the additionalNotes or weight shouldn't be updating
   let prefillNotes = '';
-  if (props.generalNotes) {
-    prefillNotes = `${props.generalNotes}
+  if (props.additionalNotes) {
+    prefillNotes = `${props.additionalNotes}
 
 `;
   }


### PR DESCRIPTION
This adds a new `general-notes="These are some notes"` to the prescribe elements. A customer was asking for a way to apply it to all Rxs, not just template overrides.

General Notes alongside a set patient weight
<img width="661" alt="Screen Shot 2024-04-17 at 2 48 17 PM" src="https://github.com/Photon-Health/client/assets/700617/d7eed901-27f4-4386-aaf7-015054f3e93c">

If you add only `weight="23"`:
<img width="658" alt="Screen Shot 2024-04-17 at 2 48 37 PM" src="https://github.com/Photon-Health/client/assets/700617/0e1de55b-bcbe-4ce4-b56a-55b426135cd6">

When a template is selected, the template notes prepend to the general notes:
<img width="647" alt="Screen Shot 2024-04-17 at 2 49 16 PM" src="https://github.com/Photon-Health/client/assets/700617/a08067c4-2d7b-46cc-97fd-181c6ae5555d">
