### PR TITLE
Fix err fetching catalogs in advanced search

### DIFF
--- a/packages/elements/src/photon-med-search/photon-med-search-component.tsx
+++ b/packages/elements/src/photon-med-search/photon-med-search-component.tsx
@@ -18,11 +18,9 @@ import { MedicationConceptDropdown } from './components/MedicationConceptDropdow
 import { MedicationFilterDropdown } from './components/MedicationFilterDropdown';
 
 const GET_CATALOGS = gql`
-  query GetProducts($medId: String!) {
-    medicationProducts(id: $medId) {
+  query GetCatalogs {
+    catalogs {
       id
-      name
-      controlled
     }
   }
 `;
@@ -77,7 +75,7 @@ customElement(
 
     onMount(async () => {
       const { data } = await client!.apollo.query({ query: GET_CATALOGS });
-      if (data?.catalogs.length > 0) {
+      if (data.catalogs.length > 0) {
         setCatalogId(data.catalogs[0].id);
       }
     });

--- a/packages/elements/src/photon-med-search/photon-med-search-component.tsx
+++ b/packages/elements/src/photon-med-search/photon-med-search-component.tsx
@@ -77,7 +77,7 @@ customElement(
 
     onMount(async () => {
       const { data } = await client!.apollo.query({ query: GET_CATALOGS });
-      if (data.catalogs.length > 0) {
+      if (data?.catalogs.length > 0) {
         setCatalogId(data.catalogs[0].id);
       }
     });


### PR DESCRIPTION
On `/prescriptions/new`, we've been seeing `TypeError: Cannot read properties of null (reading &#x27;catalogs&#x27;)`, this was due to incorrect query being used in med search.