### PR TITLE
Better error handling on internal patient queries

### DIFF
--- a/apps/patient/src/api/internal.ts
+++ b/apps/patient/src/api/internal.ts
@@ -67,12 +67,9 @@ export const getPharmacies = async ({
       throw new Error('No pharmacies found near location');
     }
   } catch (e: any) {
-    const error = e as any;
-    if (error?.response?.errors?.[0].message === 'No pharmacies found near location') {
-      throw new Error(error.response.errors[0].message);
-    } else {
-      throw error;
-    }
+    const errorMessage =
+      e?.response?.errors?.[0]?.message ?? 'Unknown error occurred on getPharmacies.';
+    throw new Error(errorMessage);
   }
 };
 
@@ -91,8 +88,10 @@ export const markOrderAsPickedUp = async (orderId: string) => {
     } else {
       throw new Error('Unable to mark order as picked up');
     }
-  } catch (error: any) {
-    throw new Error(error.response.errors[0].message);
+  } catch (e: any) {
+    const errorMessage =
+      e?.response?.errors?.[0]?.message ?? 'Unknown error occurred on markOrderAsPickedUp.';
+    throw new Error(errorMessage);
   }
 };
 
@@ -107,8 +106,10 @@ export const rerouteOrder = async (orderId: string, pharmacyId: string) => {
     } else {
       throw new Error('Unable to reroute order');
     }
-  } catch (error: any) {
-    throw new Error(error.response.errors[0].message);
+  } catch (e: any) {
+    const errorMessage =
+      e?.response?.errors?.[0]?.message ?? 'Unknown error occurred on rerouteOrder.';
+    throw new Error(errorMessage);
   }
 };
 
@@ -136,8 +137,10 @@ export const setOrderPharmacy = async (
     } else {
       throw new Error('Unable to set order pharmacy');
     }
-  } catch (error: any) {
-    throw new Error(error.response.errors[0].message);
+  } catch (e: any) {
+    const errorMessage =
+      e?.response?.errors?.[0]?.message ?? 'Unknown error occurred on setOrderPharmacy.';
+    throw new Error(errorMessage);
   }
 };
 
@@ -156,8 +159,10 @@ export const setPreferredPharmacy = async (patientId: string, pharmacyId: string
     } else {
       throw new Error('Unable to set preferred pharmacy');
     }
-  } catch (error: any) {
-    throw new Error(error.response.errors[0].message);
+  } catch (e: any) {
+    const errorMessage =
+      e?.response?.errors?.[0]?.message ?? 'Unknown error occurred on setPreferredPharmacy.';
+    throw new Error(errorMessage);
   }
 };
 


### PR DESCRIPTION
This attempts to resolve our new highest frequency frontend error [details here](https://app.datadoghq.com/rum/error-tracking/issue/1f72a946-a6a7-11ed-b1c7-da7ad0900002?fromUser=false&refresh_mode=sliding&view=spans&from_ts=1712340879416&to_ts=1713550475087&live=true). Impacting 3% of sessions.

> TypeError:
undefined is not an object (evaluating 't.t0.response.errors')

This double-checks that we have errors present before throwing one on our internal patient queries. I'm not sure exactly which one is causing most of these, but this'll tell us now.