### PR TITLE
Don't error when no pharmacies are present

### DIFF
--- a/apps/patient/src/api/internal.ts
+++ b/apps/patient/src/api/internal.ts
@@ -61,11 +61,12 @@ export const getPharmacies = async ({
         name
       }
     );
+
     if (response?.pharmaciesByLocation?.length > 0) {
       return response.pharmaciesByLocation;
-    } else {
-      throw new Error('No pharmacies found near location');
     }
+
+    return [];
   } catch (e: any) {
     const errorMessage =
       e?.response?.errors?.[0]?.message ?? 'Unknown error occurred on getPharmacies.';

--- a/apps/patient/src/views/Pharmacy.tsx
+++ b/apps/patient/src/views/Pharmacy.tsx
@@ -350,14 +350,15 @@ export const Pharmacy = () => {
         }
 
         const pharmacies = await loadPharmacies({ latitude, longitude, enable24Hr, enableOpenNow });
+
+        if (pharmacies?.length === 0) {
+          toast({ ...TOAST_CONFIG.WARNING, title: 'No pharmacies found near location' });
+        }
+
         setTopRankedPharmacies(topRankedPharmacies);
         setPharmacyResults(pharmacies);
       } catch (error: any) {
-        const noPharmaciesErr = 'No pharmacies found near location';
-        const genericError = 'Unable to get pharmacies';
-        const toastMsg = error?.message === noPharmaciesErr ? noPharmaciesErr : genericError;
-        toast({ ...TOAST_CONFIG.WARNING, title: toastMsg });
-
+        toast({ ...TOAST_CONFIG.WARNING, title: 'Unable to get pharmacies' });
         console.log('Get pharmacies error: ', error);
       }
       setLoadingPharmacies(false);


### PR DESCRIPTION
This is another longstanding error that isn't an error. When there's no pharmacies near the patient we don't need to throw an error, we can just notify the patient.