### PR TITLE
Add Medication List to the Status page on the Patient app

### DIFF
--- a/apps/patient/src/components/BrandedOptions.tsx
+++ b/apps/patient/src/components/BrandedOptions.tsx
@@ -1,4 +1,4 @@
-import { Heading, SlideFade, Text, VStack } from '@chakra-ui/react';
+import { Card, Heading, SlideFade, Text, useBreakpointValue, VStack } from '@chakra-ui/react';
 
 import { text as t } from '../utils/text';
 import { BrandedPharmacyCard } from './BrandedPharmacyCard';
@@ -12,6 +12,7 @@ interface Props {
 
 export const BrandedOptions = ({ options, location, selectedId, handleSelect }: Props) => {
   if (!location) return null;
+  const isMobile = useBreakpointValue({ base: true, md: false });
 
   return (
     <VStack spacing={2} align="span" w="full">
@@ -25,12 +26,21 @@ export const BrandedOptions = ({ options, location, selectedId, handleSelect }: 
       </SlideFade>
 
       {options.map((id) => (
-        <BrandedPharmacyCard
-          key={id}
-          pharmacyId={id}
-          selectedId={selectedId}
-          handleSelect={handleSelect}
-        />
+        <SlideFade offsetY="60px" in={true} key={`courier-pharmacy-${id}`}>
+          <Card
+            bgColor="white"
+            cursor="pointer"
+            border="2px solid"
+            borderColor={selectedId === id ? 'brand.500' : 'white'}
+            mx={isMobile ? -3 : undefined}
+          >
+            <BrandedPharmacyCard
+              pharmacyId={id}
+              selectedId={selectedId}
+              handleSelect={handleSelect}
+            />
+          </Card>
+        </SlideFade>
       ))}
     </VStack>
   );

--- a/apps/patient/src/components/BrandedPharmacyCard.tsx
+++ b/apps/patient/src/components/BrandedPharmacyCard.tsx
@@ -1,12 +1,4 @@
-import {
-  Card,
-  CardBody,
-  Image,
-  SlideFade,
-  Text,
-  VStack,
-  useBreakpointValue
-} from '@chakra-ui/react';
+import { Image, Text, VStack, Box, Container } from '@chakra-ui/react';
 
 import capsuleLogo from '../assets/capsule_logo.png';
 import amazonPharmacyLogo from '../assets/amazon_pharmacy.png';
@@ -45,8 +37,6 @@ for (let i = 0; i < capsulePharmacyIds.length; i++) {
 }
 
 export const BrandedPharmacyCard = ({ pharmacyId, selectedId, handleSelect }: Props) => {
-  const isMobile = useBreakpointValue({ base: true, md: false });
-
   const brand = PHARMACY_BRANDING[pharmacyId];
   if (!brand) return null;
 
@@ -57,22 +47,20 @@ export const BrandedPharmacyCard = ({ pharmacyId, selectedId, handleSelect }: Pr
   ) : null;
 
   return (
-    <SlideFade offsetY="60px" in={true} key={`courier-pharmacy-${pharmacyId}`}>
-      <Card
+    <Container>
+      <Box
+        py={2}
         bgColor="white"
         cursor="pointer"
         onClick={() => handleSelect?.(pharmacyId)}
         border="2px solid"
         borderColor={selectedId === pharmacyId ? 'brand.500' : 'white'}
-        mx={isMobile ? -3 : undefined}
       >
-        <CardBody p={3}>
-          <VStack align="start" spacing={1}>
-            <Image src={brand.logo} width="auto" height="30px" />
-            {tagline}
-          </VStack>
-        </CardBody>
-      </Card>
-    </SlideFade>
+        <VStack align="start" spacing={1}>
+          <Image src={brand.logo} width="auto" height="30px" />
+          {tagline}
+        </VStack>
+      </Box>
+    </Container>
   );
 };

--- a/apps/patient/src/components/PharmacyCardNew.tsx
+++ b/apps/patient/src/components/PharmacyCardNew.tsx
@@ -1,0 +1,202 @@
+import { memo } from 'react';
+import {
+  Box,
+  Button,
+  Collapse,
+  HStack,
+  Tag,
+  TagLabel,
+  TagLeftIcon,
+  Text,
+  VStack,
+  Image,
+  Container
+} from '@chakra-ui/react';
+import { FiStar, FiRefreshCcw, FiNavigation } from 'react-icons/fi';
+import dayjs from 'dayjs';
+import customParseFormat from 'dayjs/plugin/customParseFormat';
+import { types } from '@photonhealth/sdk';
+import { Pharmacy as EnrichedPharmacy } from '../utils/models';
+import { text as t } from '../utils/text';
+
+import { formatAddress } from '../utils/general';
+
+dayjs.extend(customParseFormat);
+
+interface HoursProps {
+  isOpen?: boolean;
+  isClosingSoon?: boolean;
+  is24Hr?: boolean;
+  opens?: string;
+  closes?: string;
+}
+
+const Hours = ({ is24Hr, isOpen, isClosingSoon, opens, closes }: HoursProps) => {
+  const color = isClosingSoon ? 'orange.500' : isOpen ? 'green' : 'red';
+  const text = is24Hr ? t.open24hrs : isClosingSoon ? t.closingSoon : isOpen ? t.open : t.closed;
+
+  return (
+    <HStack w="full" whiteSpace="nowrap" overflow="hidden">
+      {isOpen != null || isClosingSoon ? (
+        <Text fontSize="sm" color={color}>
+          {text}
+        </Text>
+      ) : null}
+      {!is24Hr && ((isOpen && closes) || (!isOpen && opens)) ? (
+        <Text color="gray.400">&bull;</Text>
+      ) : null}
+      {!is24Hr && isClosingSoon ? (
+        <Text fontSize="sm" color="gray.500" isTruncated>
+          {closes}
+        </Text>
+      ) : null}
+      {!is24Hr && !isClosingSoon && isOpen && closes ? (
+        <Text fontSize="sm" color="gray.500" isTruncated>
+          {closes}
+        </Text>
+      ) : null}
+      {!is24Hr && !isClosingSoon && !isOpen && opens ? (
+        <Text fontSize="sm" color="gray.500" isTruncated>
+          {opens}
+        </Text>
+      ) : null}
+    </HStack>
+  );
+};
+
+interface DistanceAddressProps {
+  distance?: number;
+  address?: types.Address | null;
+}
+
+const DistanceAddress = ({ distance, address }: DistanceAddressProps) => {
+  if (!address) return null;
+  return (
+    <Text fontSize="sm" color="gray.500" display="inline">
+      {distance ? `${distance.toFixed(1)} mi` : ''}
+      {distance && (
+        <Box as="span" display="inline" mx={2}>
+          &bull;
+        </Box>
+      )}
+      {formatAddress(address)}
+    </Text>
+  );
+};
+
+interface PharmacyCardProps {
+  pharmacy: EnrichedPharmacy;
+  preferred?: boolean;
+  savingPreferred?: boolean;
+  selected?: boolean;
+  canReroute?: boolean;
+  onSelect?: () => void;
+  onSetPreferred?: () => void;
+  onChangePharmacy?: () => void;
+  onGetDirections?: () => void;
+  selectable?: boolean;
+  showDetails?: boolean;
+}
+
+export const PharmacyCardNew = memo(function PharmacyCard({
+  pharmacy,
+  preferred = false,
+  savingPreferred = false,
+  selected = false,
+  canReroute = true,
+  onSelect,
+  onChangePharmacy,
+  onSetPreferred,
+  onGetDirections,
+  selectable = false,
+  showDetails = true
+}: PharmacyCardProps) {
+  if (!pharmacy) return null;
+
+  return (
+    <Box onClick={() => onSelect && onSelect()} cursor={selectable ? 'pointer' : undefined} py={4}>
+      <Container>
+        <VStack align="start" w="full" spacing={showDetails ? 1 : 0}>
+          <HStack spacing={2}>
+            {preferred ? (
+              <Tag size="sm" colorScheme="blue">
+                <TagLeftIcon boxSize="12px" as={FiStar} />
+                <TagLabel> {t.preferred}</TagLabel>
+              </Tag>
+            ) : null}
+            {pharmacy?.showReadyIn30Min ? (
+              <Tag size="sm" bgColor="yellow.200">
+                <TagLabel>Ready in 30 minutes</TagLabel>
+              </Tag>
+            ) : null}
+          </HStack>
+          <VStack align="start" w="full" spacing={0}>
+            <HStack spacing={2}>
+              {pharmacy?.logo ? <Image src={pharmacy.logo} width="auto" height="19px" /> : null}
+              <Text fontSize="md">{pharmacy.name}</Text>
+            </HStack>
+            {showDetails ? (
+              <>
+                <Hours
+                  isOpen={pharmacy.isOpen}
+                  is24Hr={pharmacy.is24Hr}
+                  isClosingSoon={pharmacy.isClosingSoon}
+                  opens={pharmacy.opens}
+                  closes={pharmacy.closes}
+                />
+                <DistanceAddress distance={pharmacy.distance} address={pharmacy.address} />
+              </>
+            ) : null}
+          </VStack>
+        </VStack>
+        {showDetails ? (
+          <Collapse in={selected && !preferred} animateOpacity>
+            <VStack mt={4}>
+              {onSetPreferred ? (
+                <Button
+                  mx="auto"
+                  size="sm"
+                  variant="ghost"
+                  color="link"
+                  onClick={onSetPreferred}
+                  isLoading={savingPreferred}
+                  leftIcon={<FiStar />}
+                >
+                  {t.makePreferred}
+                </Button>
+              ) : null}
+              {onGetDirections ? (
+                <Button
+                  mx="auto"
+                  size="md"
+                  variant="solid"
+                  onClick={onGetDirections}
+                  leftIcon={<FiNavigation />}
+                  w="full"
+                  bg="gray.900"
+                  color="white"
+                >
+                  {t.directions}
+                </Button>
+              ) : null}
+              {onChangePharmacy && canReroute ? (
+                <Button
+                  mx="auto"
+                  size="md"
+                  variant="outline"
+                  onClick={onChangePharmacy}
+                  leftIcon={<FiRefreshCcw />}
+                  bg="gray.50"
+                  color="blue.500"
+                  w="full"
+                >
+                  {t.changePharmacy}
+                </Button>
+              ) : null}
+            </VStack>
+          </Collapse>
+        ) : null}
+      </Container>
+    </Box>
+  );
+});

--- a/apps/patient/src/components/PrescriptionsList.tsx
+++ b/apps/patient/src/components/PrescriptionsList.tsx
@@ -4,15 +4,12 @@ import {
   AccordionIcon,
   AccordionItem,
   AccordionPanel,
-  Box,
-  Card,
-  CardBody,
   Container,
+  Heading,
   HStack,
   Text,
   VStack
 } from '@chakra-ui/react';
-import { FaPrescription } from 'react-icons/fa';
 import { text as t } from '../utils/text';
 import { formatDate } from '../utils/general';
 import { useOrderContext } from '../views/Main';
@@ -21,35 +18,38 @@ export const PrescriptionsList = () => {
   const { flattenedFills } = useOrderContext();
 
   return (
-    <Container pb={32}>
+    <Container>
       <VStack spacing={4} align="span" pt={5}>
-        <Accordion allowToggle defaultIndex={[0]}>
+        <Heading as="h4" size="md">
+          Order Details
+        </Heading>
+        <Accordion allowToggle>
           {flattenedFills.map(({ id, treatment, prescription: rx, count }) => {
             const prescription = rx!;
             return (
-              <AccordionItem border="none" mb={3} key={id}>
-                <Card w="full" backgroundColor="white" borderRadius="lg">
-                  <CardBody p={0}>
+              <AccordionItem border="none" mb={5} key={id}>
+                {({ isExpanded }) => (
+                  <>
                     <HStack>
                       <AccordionButton
-                        p={5}
+                        p={0}
                         _expanded={{ bg: 'transparent' }}
                         _focus={{ bg: 'transparent' }}
                       >
-                        <HStack me="auto">
-                          <Box me={2}>
-                            <FaPrescription size="1.3em" />
-                          </Box>
-                          <Text align="start" data-dd-privacy="mask">
+                        <VStack me="auto" w="full" align="start">
+                          <Text align="start" data-dd-privacy="mask" as="b">
                             {treatment.name}
                           </Text>
-                        </HStack>
-                        <Box>
-                          <AccordionIcon />
-                        </Box>
+                          <HStack>
+                            <Text fontSize="sm" color="gray.500">
+                              {isExpanded ? 'Show less ' : 'Show more '}
+                            </Text>
+                            <AccordionIcon />
+                          </HStack>
+                        </VStack>
                       </AccordionButton>
                     </HStack>
-                    <AccordionPanel mt={0} p={5} borderTop="1px" borderColor="gray.100">
+                    <AccordionPanel mt={0} px={0} pt={2} pb={4}>
                       <VStack align="span">
                         <HStack>
                           <HStack w="50%">
@@ -75,8 +75,8 @@ export const PrescriptionsList = () => {
                         </HStack>
                       </VStack>
                     </AccordionPanel>
-                  </CardBody>
-                </Card>
+                  </>
+                )}
               </AccordionItem>
             );
           })}

--- a/apps/patient/src/components/index.tsx
+++ b/apps/patient/src/components/index.tsx
@@ -6,6 +6,7 @@ export * from './LocationModal';
 export * from './Logo';
 export * from './Nav';
 export * from './PharmacyCard';
+export * from './PharmacyCardNew';
 export * from './PharmacyFilters';
 export * from './PickupOptions';
 export * from './PoweredBy';

--- a/apps/patient/src/views/Review.tsx
+++ b/apps/patient/src/views/Review.tsx
@@ -34,7 +34,7 @@ export const Review = () => {
         <title>{t.reviewRx(isMultiRx)}</title>
       </Helmet>
 
-      <Box bgColor="white" shadow="sm">
+      <Box bgColor="white">
         <Container>
           <VStack spacing={4} align="span" py={4}>
             <VStack spacing={2} align="start">
@@ -55,7 +55,9 @@ export const Review = () => {
         </Container>
       </Box>
 
-      <PrescriptionsList />
+      <Box bgColor="white" mt={2}>
+        <PrescriptionsList />
+      </Box>
 
       <FixedFooter show={true}>
         <Container as={VStack} w="full">

--- a/apps/patient/src/views/Status.tsx
+++ b/apps/patient/src/views/Status.tsx
@@ -11,10 +11,11 @@ import {
   BrandedPharmacyCard,
   DemoCtaModal,
   FixedFooter,
-  PharmacyCard,
+  PharmacyCardNew,
   PoweredBy,
   StatusStepper
 } from '../components';
+import { PrescriptionsList } from '../components/PrescriptionsList';
 import * as TOAST_CONFIG from '../configs/toast';
 import { formatAddress, getFulfillmentType, preparePharmacy } from '../utils/general';
 import { orderStateMapping as m, text as t } from '../utils/text';
@@ -201,7 +202,7 @@ export const Status = () => {
         <title>{t.track}</title>
       </Helmet>
 
-      <Box bgColor="white" shadow="sm">
+      <Box bgColor="white">
         <Container>
           <VStack spacing={2} align="start" py={4}>
             <Heading as="h3" size="lg">
@@ -251,30 +252,35 @@ export const Status = () => {
       </Box>
 
       {/* Bottom padding is added so stepper can be seen when footer is showing on smaller screens */}
-      <Container pb={showFooter ? 32 : 8}>
+      <Box bgColor="white" mt={2}>
+        {order?.pharmacy?.id && isDeliveryPharmacy ? (
+          <BrandedPharmacyCard pharmacyId={order.pharmacy.id} />
+        ) : pharmacyWithHours ? (
+          <PharmacyCardNew
+            pharmacy={pharmacyWithHours}
+            selected={true}
+            showDetails={fulfillmentType === 'PICK_UP'}
+            canReroute={!isDemo && orgSettings.enablePatientRerouting && order.isReroutable}
+            onChangePharmacy={() => {
+              const query = queryString.stringify({
+                orderId: order.id,
+                token,
+                reroute: true,
+                ...(!pharmacyWithHours.isOpen ? { openNow: true } : {})
+              });
+              navigate(`/pharmacy?${query}`);
+            }}
+            onGetDirections={handleGetDirections}
+          />
+        ) : null}
+      </Box>
+
+      <Box bgColor="white" mt={2}>
+        <PrescriptionsList />
+      </Box>
+
+      <Container>
         <VStack spacing={6} align="start" pt={5}>
-          <Box width="full">
-            {order?.pharmacy?.id && isDeliveryPharmacy ? (
-              <BrandedPharmacyCard pharmacyId={order.pharmacy.id} />
-            ) : pharmacyWithHours ? (
-              <PharmacyCard
-                pharmacy={pharmacyWithHours}
-                selected={true}
-                showDetails={fulfillmentType === 'PICK_UP'}
-                canReroute={!isDemo && orgSettings.enablePatientRerouting && order.isReroutable}
-                onChangePharmacy={() => {
-                  const query = queryString.stringify({
-                    orderId: order.id,
-                    token,
-                    reroute: true,
-                    ...(!pharmacyWithHours.isOpen ? { openNow: true } : {})
-                  });
-                  navigate(`/pharmacy?${query}`);
-                }}
-                onGetDirections={handleGetDirections}
-              />
-            ) : null}
-          </Box>
           <StatusStepper
             fulfillmentType={fulfillmentType}
             status={successfullySubmitted ? 'PICKED_UP' : fulfillmentState || 'SENT'}

--- a/package-lock.json
+++ b/package-lock.json
@@ -37796,7 +37796,7 @@
     },
     "packages/elements": {
       "name": "@photonhealth/elements",
-      "version": "0.8.6",
+      "version": "0.9.1",
       "license": "ISC",
       "dependencies": {
         "@photonhealth/components": "*",


### PR DESCRIPTION
While I'm adding the medication list to the status page, I'm doing some stylistic changes that align with the work Jomi's been doing:

https://www.figma.com/file/uqg6p7hSsIbigwvirml92h/%F0%9F%94%8B-Optimization-Squad?type=design&node-id=1636-11254&mode=design&t=cCzzYfjpwpLZeaHy-0

This creates one duplicate component the `PharmacyCardStatus` which I believe we either can get rid of once the designs are merged or have a tailored display for the status page. 
