### PR TITLE
Two Auth0 Providers

### DIFF
--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@photonhealth/elements",
-  "version": "0.9.2",
+  "version": "0.9.1-rc.1",
   "description": "",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@photonhealth/elements",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/elements/src/photon-client/photon-client-component.tsx
+++ b/packages/elements/src/photon-client/photon-client-component.tsx
@@ -40,8 +40,6 @@ const Component = (props: PhotonClientProps) => {
     query: { photon: true }
   });
 
-  console.log('redirectURI', redirectURI);
-
   const sdk = new PhotonClient(
     {
       env: props.env,

--- a/packages/elements/src/photon-client/photon-client-component.tsx
+++ b/packages/elements/src/photon-client/photon-client-component.tsx
@@ -3,6 +3,7 @@ import { createEffect, createSignal } from 'solid-js';
 import { PhotonClient, Env } from '@photonhealth/sdk';
 import { SDKProvider } from '@photonhealth/components';
 import { makeTimer } from '@solid-primitives/timer';
+import queryString from 'query-string';
 import { PhotonClientStore } from '../store';
 import { hasAuthParams } from '../utils';
 import { PhotonContext } from '../context';
@@ -31,6 +32,16 @@ const version = pkg?.version ?? 'unknown';
 const Component = (props: PhotonClientProps) => {
   let ref: any;
 
+  const baseRedirectURI = props.redirectUri ? props.redirectUri : window.location.origin;
+  // In order to distinguish our requests from a potential other Auth0 instance on the same domain
+  // we add a query parameter to the redirect URI
+  const redirectURI = queryString.stringifyUrl({
+    url: baseRedirectURI,
+    query: { photon: true }
+  });
+
+  console.log('redirectURI', redirectURI);
+
   const sdk = new PhotonClient(
     {
       env: props.env,
@@ -39,7 +50,7 @@ const Component = (props: PhotonClientProps) => {
       connection: props.connection,
       uri: props.uri,
       clientId: props.id!,
-      redirectURI: props.redirectUri ? props.redirectUri : window.location.origin,
+      redirectURI,
       organization: props.org,
       developmentMode: props.developmentMode
     },

--- a/packages/elements/src/utils.ts
+++ b/packages/elements/src/utils.ts
@@ -14,12 +14,12 @@ export const validateProps = (props: Record<string, any>, required: string[]) =>
 const CODE_RE = /[?&]code=[^&]+/;
 const STATE_RE = /[?&]state=[^&]+/;
 const ERROR_RE = /[?&]error=[^&]+/;
-const PARENT_RE = /[?&]photon-parent-auth=[^&]+/; // if this is present, these are auth params for a different Auth0 instance
+const IS_PHOTON_RE = /[?&]photon=true[^&]+/; // if this is present, these are auth params for a different Auth0 instance
 
 export const hasAuthParams = (searchParams = window.location.search): boolean =>
   (CODE_RE.test(searchParams) || ERROR_RE.test(searchParams)) &&
   STATE_RE.test(searchParams) &&
-  !PARENT_RE.test(searchParams);
+  IS_PHOTON_RE.test(searchParams);
 
 export const toTitleCase = (str: string) => {
   return str.replace(/\w\S*/g, function (txt) {

--- a/packages/elements/src/utils.ts
+++ b/packages/elements/src/utils.ts
@@ -13,6 +13,7 @@ export const validateProps = (props: Record<string, any>, required: string[]) =>
 };
 
 export const hasAuthParams = (searchParams = window.location.search): boolean => {
+  if (!searchParams) return false;
   const parsedParams = queryString.parse(searchParams);
   const { code, state, error, photon } = parsedParams;
   // if photon is not present, then these are auth params for a different Auth0 instance so we should ignore them

--- a/packages/elements/src/utils.ts
+++ b/packages/elements/src/utils.ts
@@ -14,9 +14,12 @@ export const validateProps = (props: Record<string, any>, required: string[]) =>
 const CODE_RE = /[?&]code=[^&]+/;
 const STATE_RE = /[?&]state=[^&]+/;
 const ERROR_RE = /[?&]error=[^&]+/;
+const PARENT_RE = /[?&]photon-parent-auth=[^&]+/; // if this is present, these are auth params for a different Auth0 instance
 
 export const hasAuthParams = (searchParams = window.location.search): boolean =>
-  (CODE_RE.test(searchParams) || ERROR_RE.test(searchParams)) && STATE_RE.test(searchParams);
+  (CODE_RE.test(searchParams) || ERROR_RE.test(searchParams)) &&
+  STATE_RE.test(searchParams) &&
+  !PARENT_RE.test(searchParams);
 
 export const toTitleCase = (str: string) => {
   return str.replace(/\w\S*/g, function (txt) {

--- a/packages/elements/src/utils.ts
+++ b/packages/elements/src/utils.ts
@@ -1,4 +1,5 @@
 import { Permission } from '@photonhealth/sdk/dist/types';
+import queryString from 'query-string';
 
 export const validateProps = (props: Record<string, any>, required: string[]) => {
   const errors: string[] = [];
@@ -11,15 +12,12 @@ export const validateProps = (props: Record<string, any>, required: string[]) =>
   return errors;
 };
 
-const CODE_RE = /[?&]code=[^&]+/;
-const STATE_RE = /[?&]state=[^&]+/;
-const ERROR_RE = /[?&]error=[^&]+/;
-const IS_PHOTON_RE = /[?&]photon=true[^&]+/; // if this is present, these are auth params for a different Auth0 instance
-
-export const hasAuthParams = (searchParams = window.location.search): boolean =>
-  (CODE_RE.test(searchParams) || ERROR_RE.test(searchParams)) &&
-  STATE_RE.test(searchParams) &&
-  IS_PHOTON_RE.test(searchParams);
+export const hasAuthParams = (searchParams = window.location.search): boolean => {
+  const parsedParams = queryString.parse(searchParams);
+  const { code, state, error, photon } = parsedParams;
+  // if photon is not present, then these are auth params for a different Auth0 instance so we should ignore them
+  return (code || error) !== null && state !== null && photon !== null;
+};
 
 export const toTitleCase = (str: string) => {
   return str.replace(/\w\S*/g, function (txt) {


### PR DESCRIPTION
We have an issue where a customer is has an [Auth0 instance that's in conflict with our Element's instance](https://photonhealth.slack.com/archives/C06DCU1DTMJ/p1713253957783859). What's causing the issue is that both instances are picking up on the redirect url's params. So to solve this I've added a hardcoded param to our elements that won't do any checks if it's coming from the parent.

Any customer that is using their own Auth0 login will need to set `skipRedirectCallback` to look for the presence of `photon=true`:

``` tsx
    <Auth0Provider
      domain="customer-auth-domain"
      clientId="customer-auth-client-id"
      authorizationParams={{
        redirect_uri: `${window.location.origin}`
      }}
      skipRedirectCallback={window.location.href.includes('photon=true')}
    >
```

Then, when as high up in the customer's authenticated tree as possible, the'll place our `photon-client`:

``` tsx
      {!isAuthenticated ? (
        <LoginButton />
      ) : (
        <photon-client
          ...
          auto-login="true"
          redirect-uri={window.location.origin} 
        >
          {/* ETC */}
        </photon-client>
     }
```

🎥 Demo Video
https://www.loom.com/share/58814af997ea4367a705d253ee68a9c3

👀 Demo Branch
https://github.com/Photon-Health/client/tree/auth0
If you go here to `apps/auth` you can install and then `npm run dev` to recreate the scenario I'm showing in the video above.

### References

https://github.com/auth0/auth0-react/pull/416
This is the PR that allows for multiple contexts. Since we aren't using React, we don't need the context on the parent React component. However in the code there [was a hint to the answer.](https://github.com/auth0/auth0-react/blob/93d54c3863f95ca3f0f3ae51d6a859dbe6463f4b/src/auth0-provider.tsx#L176)


https://github.com/auth0-samples/auth0-link-accounts-sample/tree/react-variant/React
Here's a demo of the above PR 
