### PR TITLE
Chakra link styling fix

### DIFF
--- a/apps/app/src/views/components/ContactView.tsx
+++ b/apps/app/src/views/components/ContactView.tsx
@@ -1,4 +1,4 @@
-import { Link, Stack } from '@chakra-ui/react';
+import { Link, VStack } from '@chakra-ui/react';
 
 import { formatPhone } from '../../utils';
 
@@ -10,14 +10,14 @@ interface ContactViewProps {
 const ContactView = (props: ContactViewProps) => {
   const { phone, email } = props;
   return (
-    <Stack spacing="0" data-dd-privacy="mask">
+    <VStack spacing="0" data-dd-privacy="mask" alignItems="start">
       <Link fontWeight="medium" href={`tel:${phone}`} isExternal>
         {formatPhone(phone)}
       </Link>
       <Link href={`mailto:${email}`} isExternal>
         {email}
       </Link>
-    </Stack>
+    </VStack>
   );
 };
 

--- a/apps/app/src/views/components/TicketModal.tsx
+++ b/apps/app/src/views/components/TicketModal.tsx
@@ -124,7 +124,13 @@ export const TicketModal = ({
             >
               {({ handleSubmit, errors, touched, setFieldTouched }) => {
                 return (
-                  <Form onSubmit={handleSubmit} style={{ width: '100%' }}>
+                  <Form
+                    onSubmit={handleSubmit}
+                    style={{ width: '100%' }}
+                    placeholder={undefined}
+                    onPointerEnterCapture={undefined}
+                    onPointerLeaveCapture={undefined}
+                  >
                     <VStack spacing={4} width="100%">
                       <FormControl
                         isInvalid={!!errors.description && touched.description}


### PR DESCRIPTION
Link used to spread the whole distance of the parent:
https://www.notion.so/photons/Chakra-link-style-is-messed-up-on-Patient-Page-cce51b87e691408d9aaa174a8e5c41d6?pvs=4

![May-03-2024 10-46-30](https://github.com/Photon-Health/client/assets/700617/c1754cc8-47fe-43ee-a128-0c2573498843)

Also, `TicketModal` form was giving me this error:
```
Type '{ children: Element; onSubmit: (e?: FormEvent<HTMLFormElement> | undefined) => void; style: { width: string; }; }' is missing the following properties from type 'Pick<DetailedHTMLProps<FormHTMLAttributes<HTMLFormElement>, HTMLFormElement>, "children" | "id" | ... 260 more ... | "key">': placeholder, onPointerEnterCapture, onPointerLeaveCapture
``` 
so I modified it with some undefined values...
