### PR TITLE
Fix Deeplinking

### DIFF
--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@photonhealth/elements",
-  "version": "0.9.1-rc.1",
+  "version": "0.9.1-rc.2",
   "description": "",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/elements/src/utils.ts
+++ b/packages/elements/src/utils.ts
@@ -17,7 +17,7 @@ export const hasAuthParams = (searchParams = window.location.search): boolean =>
   const parsedParams = queryString.parse(searchParams);
   const { code, state, error, photon } = parsedParams;
   // if photon is not present, then these are auth params for a different Auth0 instance so we should ignore them
-  return (code || error) !== null && state !== null && photon !== null;
+  return (Boolean(code) || Boolean(error)) && Boolean(state) && Boolean(photon);
 };
 
 export const toTitleCase = (str: string) => {

--- a/packages/elements/src/utils.ts
+++ b/packages/elements/src/utils.ts
@@ -15,9 +15,12 @@ export const validateProps = (props: Record<string, any>, required: string[]) =>
 export const hasAuthParams = (searchParams = window.location.search): boolean => {
   if (!searchParams) return false;
   const parsedParams = queryString.parse(searchParams);
-  const { code, state, error, photon } = parsedParams;
   // if photon is not present, then these are auth params for a different Auth0 instance so we should ignore them
-  return (Boolean(code) || Boolean(error)) && Boolean(state) && Boolean(photon);
+  return (
+    'state' in parsedParams &&
+    'photon' in parsedParams &&
+    ('code' in parsedParams || 'error' in parsedParams)
+  );
 };
 
 export const toTitleCase = (str: string) => {


### PR DESCRIPTION
Deeplinking in the app was broken by this change:
https://github.com/Photon-Health/client/pull/1146/files
https://photonhealth.slack.com/archives/C02V18YAEE9/p1714751735133409

This condition was pretty shaky. I would rather something that looks like this:
``` ts
return (code || error) && state && photon;
```
but typescript was giving me 
```
Type 'string | (string | null)[] | null' is not assignable to type 'boolean'.
  Type 'null' is not assignable to type 'boolean'.
```