### PR TITLE
Add mail order options for GoalMD sandbox

### DIFF
--- a/packages/settings/src/lib/neutron.ts
+++ b/packages/settings/src/lib/neutron.ts
@@ -343,5 +343,11 @@ const organizationSettings: {
     mailOrderNavigate: true,
     mailOrderNavigateProviders: [AMAZON_PHARMACY_ID],
     enableCourierNavigate: true
+  },
+  // GoalMD
+  org_4CKpLMduRVMHl2Ft: {
+    ...defaultSettings,
+    mailOrder: true,
+    mailOrderProviders: [HONEYBEE_PHARMACY_ID, TRUEPILL_PHARMACY_ID]
   }
 };


### PR DESCRIPTION
Add Honeybee and TruePill as mail order options for GoalMD on neutron