### PR TITLE
Fix missing repository links in error stack frames

### DIFF
--- a/apps/app/buildspec.yml
+++ b/apps/app/buildspec.yml
@@ -45,16 +45,22 @@ phases:
     commands:
       - echo Installing Datadog CI
       - npm install -g @datadog/datadog-ci
+      - echo Fetching Secrets
+      - |
+        export DATADOG_API_KEY=$(aws secretsmanager get-secret-value --secret-id $DATADOG_SOURCE_MAPS_API_KEY --query 'SecretString' --output text)
+        export GITHUB_TOKEN=$(aws secretsmanager get-secret-value --secret-id $GITHUB_SOURCE_MAPS_ACCESS_TOKEN --query 'SecretString' --output text)
+        export SERVICE_NAME=$(node -p "require('./apps/app/package.json').name")
+        export PACKAGE_VERSION=$(git rev-parse HEAD)
+        export ENVIRONMENT=$OUTPUT_DIR
+        export REPOSITORY_URL="https://$GITHUB_TOKEN:x-oauth-basic@github.com/your-username/your-repository"
       - echo Uploading source maps to Datadog
       - |
         export DATADOG_API_KEY=$(aws secretsmanager get-secret-value --secret-id $DATADOG_SOURCE_MAPS_API_KEY --query 'SecretString' --output text)
-        SERVICE_NAME=$(node -p "require('./apps/app/package.json').name")
-        PACKAGE_VERSION=$(git rev-parse HEAD)
-        ENVIRONMENT=$OUTPUT_DIR
         npx datadog-ci sourcemaps upload dist/apps/app \
           --service=$SERVICE_NAME \
           --release-version=$PACKAGE_VERSION \
-          --minified-path-prefix=https://app.${ENVIRONMENT}.health
+          --minified-path-prefix=https://app.${ENVIRONMENT}.health \
+          --repository-url=$REPOSITORY_URL
 
 artifacts:
   files:

--- a/apps/patient/buildspec.yml
+++ b/apps/patient/buildspec.yml
@@ -45,16 +45,22 @@ phases:
     commands:
       - echo Installing Datadog CI
       - npm install -g @datadog/datadog-ci
+      - echo Fetching Secrets
+      - |
+        export DATADOG_API_KEY=$(aws secretsmanager get-secret-value --secret-id $DATADOG_SOURCE_MAPS_API_KEY --query 'SecretString' --output text)
+        export GITHUB_TOKEN=$(aws secretsmanager get-secret-value --secret-id $GITHUB_SOURCE_MAPS_ACCESS_TOKEN --query 'SecretString' --output text)
+        export SERVICE_NAME=$(node -p "require('./apps/patient/package.json').name")
+        export PACKAGE_VERSION=$(git rev-parse HEAD)
+        export ENVIRONMENT=$OUTPUT_DIR
+        export REPOSITORY_URL="https://$GITHUB_TOKEN:x-oauth-basic@github.com/your-username/your-repository"
       - echo Uploading source maps to Datadog
       - |
         export DATADOG_API_KEY=$(aws secretsmanager get-secret-value --secret-id $DATADOG_SOURCE_MAPS_API_KEY --query 'SecretString' --output text)
-        SERVICE_NAME=$(node -p "require('./apps/patient/package.json').name")
-        PACKAGE_VERSION=$(git rev-parse HEAD)
-        ENVIRONMENT=$OUTPUT_DIR
         npx datadog-ci sourcemaps upload dist/apps/patient \
           --service=$SERVICE_NAME \
           --release-version=$PACKAGE_VERSION \
-          --minified-path-prefix=https://orders.${ENVIRONMENT}.health
+          --minified-path-prefix=https://orders.${ENVIRONMENT}.health \
+          --repository-url=$REPOSITORY_URL
 
 artifacts:
   files:


### PR DESCRIPTION
Source maps are working. But they are showing previews of our minified files. I think this change will get us previews or links to the actual source code.

Adding --repository-url should get our issues in datadog links back to our source code.

Todo

- [ ] create GITHUB_SOURCE_MAPS_ACCESS_TOKEN in Github
- [ ] add to codebuild config