### PR TITLE
Add Datadog vars for APM source code integration

### DIFF
--- a/apps/app/buildspec.yml
+++ b/apps/app/buildspec.yml
@@ -12,6 +12,8 @@ phases:
       - npm install
   build:
     commands:
+      - export DD_GIT_COMMIT_SHA=$(git rev-parse HEAD)
+      - export DD_GIT_REPOSITORY_URL=$(git config --get remote.origin.url)
       - printenv
       - node -v
       - npm -v

--- a/apps/patient/buildspec.yml
+++ b/apps/patient/buildspec.yml
@@ -12,6 +12,8 @@ phases:
       - npm install
   build:
     commands:
+      - export DD_GIT_COMMIT_SHA=$(git rev-parse HEAD)
+      - export DD_GIT_REPOSITORY_URL=$(git config --get remote.origin.url)
       - printenv
       - node -v
       - npm -v


### PR DESCRIPTION
This is step one of [setting up a repo in DD](https://app.datadoghq.com/source-code/setup/apm#configure):

1. Associate a git commit with your telemetry - this
2. Configure your repository - this is where we actually link our account

Without a repo configured we can't get human-readable source map previews in our issues.