### PR TITLE
Small contrast fix on get directions btn

### DIFF
--- a/apps/patient/src/views/Status.tsx
+++ b/apps/patient/src/views/Status.tsx
@@ -286,6 +286,7 @@ export const Status = () => {
                 leftIcon={<FiNavigation />}
                 w="full"
                 bg="gray.900"
+                _hover={{ bg: 'gray.600' }}
                 color="white"
               >
                 {t.directions}


### PR DESCRIPTION
Hover before:

<img width="793" alt="image" src="https://github.com/Photon-Health/client/assets/3934326/377a1fef-107f-49a9-8e22-f3be2bae59ca">

Hover after:

<img width="742" alt="image" src="https://github.com/Photon-Health/client/assets/3934326/e39f69ee-a245-4406-b4f8-5a9fc1fbf456">
