### PR TITLE
Bump Elements Version

### DIFF
--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@photonhealth/elements",
-  "version": "0.9.1-rc.2",
+  "version": "0.9.2",
   "description": "",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
The RC works for our [customer](https://photonhealth.slack.com/archives/C06DCU1DTMJ/p1715867303641579?thread_ts=1713253957.783859&cid=C06DCU1DTMJ), so we can safely bump the version witch includes the following changes:

- https://github.com/Photon-Health/client/pull/1159
- https://github.com/Photon-Health/client/pull/1174
- https://github.com/Photon-Health/client/pull/1175