### PR TITLE
Fix pharmacy selection UI resetting if modal closed without location

### DIFF
--- a/apps/patient/src/views/Pharmacy.tsx
+++ b/apps/patient/src/views/Pharmacy.tsx
@@ -158,8 +158,10 @@ export const Pharmacy = () => {
   };
 
   const handleModalClose = ({ loc = undefined }: { loc?: string | undefined }) => {
-    reset();
-    setLocation(loc);
+    if (loc) {
+      reset();
+      setLocation(loc);
+    }
     setLocationModalOpen(false);
   };
 


### PR DESCRIPTION
Quirk that if we close the set location modal without location, it resets the whole UI to this...

<img width="398" alt="image" src="https://github.com/Photon-Health/client/assets/3934326/47da5843-6fab-44ec-9a26-1886a4b88d3f">
