### PR TITLE
Stand Alone Med History Card

### DIFF
--- a/apps/app/src/views/routes/PrescriptionForm.tsx
+++ b/apps/app/src/views/routes/PrescriptionForm.tsx
@@ -115,6 +115,7 @@ export const PrescriptionForm = () => {
           weight-unit={weightUnit}
           enable-order={orgSettings?.enableRxAndOrder ?? true}
           enable-med-history={orgSettings?.enableMedHistory ?? false}
+          enable-med-history-links={true}
           enable-local-pickup={orgSettings?.pickUp ?? false}
           enable-send-to-patient={orgSettings?.sendToPatient ?? false}
           enable-combine-and-duplicate={orgSettings?.enableCombineAndDuplicate ?? false}

--- a/packages/components/src/systems/PatientMedHistory/index.tsx
+++ b/packages/components/src/systems/PatientMedHistory/index.tsx
@@ -40,6 +40,7 @@ const ADD_MED_HISTORY = gql`
 
 type PatientMedHistoryProps = {
   patientId: string;
+  hideLink: boolean;
   openAddMedication?: () => void;
   newMedication?: Medication | SearchMedication;
 };
@@ -169,7 +170,9 @@ export default function PatientMedHistory(props: PatientMedHistoryProps) {
                 </div>
               </span>
             </Table.Col>
-            <Table.Col>Source</Table.Col>
+            <Show when={!props.hideLink}>
+              <Table.Col>Source</Table.Col>
+            </Show>
           </Table.Header>
           <Table.Body>
             <Show
@@ -187,19 +190,21 @@ export default function PatientMedHistory(props: PatientMedHistoryProps) {
                   <Table.Row>
                     <Table.Cell width="16rem">{med.medication?.name}</Table.Cell>
                     <Table.Cell>{formatDate(med.prescription?.writtenAt) || 'N/A'}</Table.Cell>
-                    <Table.Cell>
-                      {med.prescription?.id ? (
-                        <a
-                          class="text-blue-500 underline"
-                          target="_blank"
-                          href={`${baseURL()}${med.prescription?.id}`}
-                        >
-                          Link
-                        </a>
-                      ) : (
-                        'External'
-                      )}
-                    </Table.Cell>
+                    <Show when={!props.hideLink}>
+                      <Table.Cell>
+                        {med.prescription?.id ? (
+                          <a
+                            class="text-blue-500 underline"
+                            target="_blank"
+                            href={`${baseURL()}${med.prescription?.id}`}
+                          >
+                            Link
+                          </a>
+                        ) : (
+                          'External'
+                        )}
+                      </Table.Cell>
+                    </Show>
                   </Table.Row>
                 )}
               </For>

--- a/packages/components/src/systems/PatientMedHistory/index.tsx
+++ b/packages/components/src/systems/PatientMedHistory/index.tsx
@@ -40,7 +40,7 @@ const ADD_MED_HISTORY = gql`
 
 type PatientMedHistoryProps = {
   patientId: string;
-  hideLink: boolean;
+  enableLinks: boolean;
   openAddMedication?: () => void;
   newMedication?: Medication | SearchMedication;
 };
@@ -54,7 +54,7 @@ type GetPatientResponse = {
   };
 };
 
-const LoadingRowFallback = () => (
+const LoadingRowFallback = (props: { enableLinks: boolean }) => (
   <Table.Row>
     <Table.Cell>
       <Text sampleLoadingText={generateString(10, 25)} loading />
@@ -62,9 +62,11 @@ const LoadingRowFallback = () => (
     <Table.Cell>
       <Text sampleLoadingText={generateString(2, 8)} loading />
     </Table.Cell>
-    <Table.Cell>
-      <Text sampleLoadingText={generateString(4, 8)} loading />
-    </Table.Cell>
+    <Show when={props.enableLinks}>
+      <Table.Cell>
+        <Text sampleLoadingText={generateString(4, 8)} loading />
+      </Table.Cell>
+    </Show>
   </Table.Row>
 );
 
@@ -170,7 +172,7 @@ export default function PatientMedHistory(props: PatientMedHistoryProps) {
                 </div>
               </span>
             </Table.Col>
-            <Show when={!props.hideLink}>
+            <Show when={props.enableLinks}>
               <Table.Col>Source</Table.Col>
             </Show>
           </Table.Header>
@@ -179,9 +181,9 @@ export default function PatientMedHistory(props: PatientMedHistoryProps) {
               when={medHistory()}
               fallback={
                 <>
-                  <LoadingRowFallback />
-                  <LoadingRowFallback />
-                  <LoadingRowFallback />
+                  <LoadingRowFallback enableLinks={props.enableLinks} />
+                  <LoadingRowFallback enableLinks={props.enableLinks} />
+                  <LoadingRowFallback enableLinks={props.enableLinks} />
                 </>
               }
             >
@@ -190,7 +192,7 @@ export default function PatientMedHistory(props: PatientMedHistoryProps) {
                   <Table.Row>
                     <Table.Cell width="16rem">{med.medication?.name}</Table.Cell>
                     <Table.Cell>{formatDate(med.prescription?.writtenAt) || 'N/A'}</Table.Cell>
-                    <Show when={!props.hideLink}>
+                    <Show when={props.enableLinks}>
                       <Table.Cell>
                         {med.prescription?.id ? (
                           <a

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@photonhealth/elements",
-  "version": "0.9.2-rc.0",
+  "version": "0.10.0",
   "description": "",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/elements/src/index.ts
+++ b/packages/elements/src/index.ts
@@ -21,6 +21,7 @@ import './photon-state-input';
 import './photon-patient-dialog';
 import './photon-update-patient-dialog';
 import './photon-med-search';
+import './photon-med-history';
 import './photon-radio-card';
 import './photon-radio-group';
 import './photon-med-search-dialog';

--- a/packages/elements/src/photon-med-history/index.tsx
+++ b/packages/elements/src/photon-med-history/index.tsx
@@ -1,0 +1,1 @@
+export * from './photon-med-history';

--- a/packages/elements/src/photon-med-history/photon-med-history.tsx
+++ b/packages/elements/src/photon-med-history/photon-med-history.tsx
@@ -1,0 +1,24 @@
+import { customElement } from 'solid-element';
+import { PatientMedHistory } from '@photonhealth/components';
+import photonStyles from '@photonhealth/components/dist/style.css?inline';
+
+interface PatientMedProps {
+  patientId: string;
+}
+
+const PatientMedHistoryWrapper = (props: PatientMedProps) => {
+  return (
+    <div>
+      <style>{photonStyles}</style>
+      <PatientMedHistory patientId={props.patientId} hideLink={true} />
+    </div>
+  );
+};
+
+customElement(
+  'photon-med-history',
+  {
+    patientId: ''
+  },
+  PatientMedHistoryWrapper
+);

--- a/packages/elements/src/photon-med-history/photon-med-history.tsx
+++ b/packages/elements/src/photon-med-history/photon-med-history.tsx
@@ -10,7 +10,7 @@ const PatientMedHistoryWrapper = (props: PatientMedProps) => {
   return (
     <div>
       <style>{photonStyles}</style>
-      <PatientMedHistory patientId={props.patientId} hideLink={true} />
+      <PatientMedHistory patientId={props.patientId} enableLinks={false} />
     </div>
   );
 };

--- a/packages/elements/src/photon-multirx-form/components/PatientCard.tsx
+++ b/packages/elements/src/photon-multirx-form/components/PatientCard.tsx
@@ -130,7 +130,7 @@ export const PatientCard = (props: {
             patientId={patientId()}
             openAddMedication={() => setMedDialogOpen(true)}
             newMedication={newMedication()}
-            enableLinks={props.enableMedHistoryLinks}
+            enableLinks={props.enableMedHistoryLinks ?? false}
           />
           <photon-med-search-dialog
             title="Add Medication History"

--- a/packages/elements/src/photon-multirx-form/components/PatientCard.tsx
+++ b/packages/elements/src/photon-multirx-form/components/PatientCard.tsx
@@ -24,6 +24,7 @@ export const PatientCard = (props: {
   weight?: number;
   weightUnit?: string;
   enableMedHistory?: boolean;
+  hideLink: boolean;
 }) => {
   const [newMedication, setNewMedication] = createSignal<Medication | SearchMedication | undefined>(
     undefined
@@ -129,6 +130,7 @@ export const PatientCard = (props: {
             patientId={patientId()}
             openAddMedication={() => setMedDialogOpen(true)}
             newMedication={newMedication()}
+            hideLink={props.hideLink}
           />
           <photon-med-search-dialog
             title="Add Medication History"

--- a/packages/elements/src/photon-multirx-form/components/PatientCard.tsx
+++ b/packages/elements/src/photon-multirx-form/components/PatientCard.tsx
@@ -24,7 +24,7 @@ export const PatientCard = (props: {
   weight?: number;
   weightUnit?: string;
   enableMedHistory?: boolean;
-  hideLink: boolean;
+  enableMedHistoryLinks?: boolean;
 }) => {
   const [newMedication, setNewMedication] = createSignal<Medication | SearchMedication | undefined>(
     undefined
@@ -130,7 +130,7 @@ export const PatientCard = (props: {
             patientId={patientId()}
             openAddMedication={() => setMedDialogOpen(true)}
             newMedication={newMedication()}
-            hideLink={props.hideLink}
+            enableLinks={props.enableMedHistoryLinks}
           />
           <photon-med-search-dialog
             title="Add Medication History"

--- a/packages/elements/src/photon-multirx-form/photon-prescribe-workflow-component.tsx
+++ b/packages/elements/src/photon-multirx-form/photon-prescribe-workflow-component.tsx
@@ -27,6 +27,7 @@ const Component = (props: PrescribeProps) => {
         enableLocalPickup={props.enableLocalPickup}
         enableSendToPatient={props.enableSendToPatient}
         enableMedHistory={props.enableMedHistory}
+        enableMedHistoryLinks={props.enableMedHistoryLinks}
         enableCombineAndDuplicate={props.enableCombineAndDuplicate}
         mailOrderIds={props.mailOrderIds}
         pharmacyId={props.pharmacyId}
@@ -58,6 +59,7 @@ customElement(
     enableSendToPatient: false,
     enableCombineAndDuplicate: false,
     enableMedHistory: false,
+    enableMedHistoryLinks: false,
     mailOrderIds: undefined,
     pharmacyId: undefined,
     loading: false,

--- a/packages/elements/src/photon-multirx-form/photon-prescribe-workflow.tsx
+++ b/packages/elements/src/photon-multirx-form/photon-prescribe-workflow.tsx
@@ -59,6 +59,7 @@ export type PrescribeProps = {
   enableLocalPickup: boolean;
   enableSendToPatient: boolean;
   enableMedHistory: boolean;
+  enableMedHistoryLinks: boolean;
   enableCombineAndDuplicate: boolean;
   mailOrderIds?: string;
   pharmacyId?: string;
@@ -429,6 +430,7 @@ export function PrescribeWorkflow(props: PrescribeProps) {
                 weight={props.weight}
                 weightUnit={props.weightUnit}
                 enableMedHistory={props.enableMedHistory}
+                enableMedHistoryLinks={props.enableMedHistoryLinks ?? false}
               />
               <Show
                 when={


### PR DESCRIPTION
Can be used like:

``` html
<photon-med-history patient-id="pat_01GQ0XFBHSH3YXN936A2D2SD7Y"></photon-med-history>
```

Request Reference https://photonhealth.slack.com/archives/C033T9N949M/p1716470078960499

![Screen Shot 2024-05-24 at 1 45 50 PM](https://github.com/Photon-Health/client/assets/700617/d872c522-c74d-4c83-89c4-cdb213a90e8a)

ALSO, this removes[ auto enabled linking to the Photon App in the Medical history card rows. ](https://www.notion.so/photons/Embed-should-not-link-to-Photon-App-8a0a939c032241bc8b0220cc730a624a?pvs=4) 

Because this change changes the functionality of the card to opt in to the links, Elements are getting a minor bump to `0.10.0`. We can also safely move forward with the RC because [what we were testing works.](https://photonhealth.slack.com/archives/C05LVD54ZC0/p1716495725050929)