### PR TITLE
Default Add Medication to Catalog From Advanced Search

### DIFF
--- a/apps/app/src/views/components/AdvancedDrugSearch.tsx
+++ b/apps/app/src/views/components/AdvancedDrugSearch.tsx
@@ -315,10 +315,10 @@ export const AdvancedDrugSearch = ({
   const [debouncedFilterText] = useDebounce(filterText, 300);
   const [conceptId, setConceptId] = useState<string | undefined>();
   const [medId, setMedId] = useState<string | undefined>();
-  const [addToCatalog, setAddToCatalog] = useState<boolean>(false);
+  const [addToCatalog, setAddToCatalog] = useState<boolean>(true);
 
   const isMobile = useBreakpointValue({ base: true, md: false }) || forceMobile;
-
+  console.log('???');
   return (
     <VStack align="stretch">
       <Stack flexDir={isMobile ? 'column' : 'row'} gap="2" alignItems="flex-end">

--- a/apps/app/src/views/components/AdvancedDrugSearch.tsx
+++ b/apps/app/src/views/components/AdvancedDrugSearch.tsx
@@ -318,7 +318,7 @@ export const AdvancedDrugSearch = ({
   const [addToCatalog, setAddToCatalog] = useState<boolean>(true);
 
   const isMobile = useBreakpointValue({ base: true, md: false }) || forceMobile;
-  console.log('???');
+
   return (
     <VStack align="stretch">
       <Stack flexDir={isMobile ? 'column' : 'row'} gap="2" alignItems="flex-end">

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@photonhealth/elements",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/elements/src/photon-checkbox/photon-checkbox-component.tsx
+++ b/packages/elements/src/photon-checkbox/photon-checkbox-component.tsx
@@ -35,6 +35,7 @@ const Component = (props: {
   };
 
   onMount(() => {
+    setChecked(props.checked);
     dispatchChecked(checked());
   });
 

--- a/packages/elements/src/photon-med-search-dialog/photon-med-search-dialog-component.tsx
+++ b/packages/elements/src/photon-med-search-dialog/photon-med-search-dialog-component.tsx
@@ -17,8 +17,9 @@ const Component = (props: MedSearchDialogProps) => {
   const [medication, setMedication] = createSignal<Medication | SearchMedication | undefined>(
     undefined
   );
-  const [addToCatalog, setAddToCatalog] = createSignal<boolean>(false);
+  const [addToCatalog, setAddToCatalog] = createSignal<boolean>(true);
   const [catalogId, setCatalogId] = createSignal<string>('');
+  const [submitting, setSubmitting] = createSignal(false);
 
   const dispatchMedicationSelected = () => {
     const event = new CustomEvent('photon-medication-selected', {
@@ -41,6 +42,7 @@ const Component = (props: MedSearchDialogProps) => {
 
   const handleConfirm = async () => {
     if (addToCatalog()) {
+      setSubmitting(true);
       const addCatalogMutation = client!.getSDK().clinical.catalog.addToCatalog({});
       try {
         await addCatalogMutation({
@@ -57,6 +59,7 @@ const Component = (props: MedSearchDialogProps) => {
 
     dispatchMedicationSelected();
     props.open = false;
+    setSubmitting(false);
   };
 
   const handleCancel = () => {
@@ -91,6 +94,7 @@ const Component = (props: MedSearchDialogProps) => {
             Cancel
           </Button>
           <Button onClick={handleConfirm} disabled={!medication()}>
+          <Button onClick={handleConfirm} disabled={!medication()} loading={submitting()}>
             Select Medication
           </Button>
         </div>

--- a/packages/elements/src/photon-med-search-dialog/photon-med-search-dialog-component.tsx
+++ b/packages/elements/src/photon-med-search-dialog/photon-med-search-dialog-component.tsx
@@ -93,7 +93,6 @@ const Component = (props: MedSearchDialogProps) => {
           <Button variant="secondary" onClick={handleCancel}>
             Cancel
           </Button>
-          <Button onClick={handleConfirm} disabled={!medication()}>
           <Button onClick={handleConfirm} disabled={!medication()} loading={submitting()}>
             Select Medication
           </Button>

--- a/packages/elements/src/photon-med-search/photon-med-search-component.tsx
+++ b/packages/elements/src/photon-med-search/photon-med-search-component.tsx
@@ -24,6 +24,7 @@ const GET_CATALOGS = gql`
     }
   }
 `;
+
 const GET_PRODUCTS = gql`
   query GetProducts($medId: String!) {
     medicationProducts(id: $medId) {

--- a/packages/elements/src/photon-med-search/photon-med-search-component.tsx
+++ b/packages/elements/src/photon-med-search/photon-med-search-component.tsx
@@ -24,7 +24,6 @@ const GET_CATALOGS = gql`
     }
   }
 `;
-
 const GET_PRODUCTS = gql`
   query GetProducts($medId: String!) {
     medicationProducts(id: $medId) {

--- a/packages/elements/src/photon-med-search/photon-med-search-component.tsx
+++ b/packages/elements/src/photon-med-search/photon-med-search-component.tsx
@@ -50,7 +50,7 @@ customElement(
     const [concept, setConcept] = createSignal<SearchMedication | undefined>(undefined);
     const [medicationId, setMedicationId] = createSignal<string>('');
     const [products, setProducts] = createSignal<(Medication | SearchMedication)[]>([]);
-    const [addToCatalog, setAddToCatalog] = createSignal<boolean>(false);
+    const [addToCatalog, setAddToCatalog] = createSignal<boolean>(true);
     const [selectedMedication, setSelectedMedication] = createSignal<Medication | undefined>(
       undefined
     );

--- a/packages/elements/src/photon-med-search/photon-med-search-component.tsx
+++ b/packages/elements/src/photon-med-search/photon-med-search-component.tsx
@@ -107,7 +107,6 @@ customElement(
           variables: { medId: id }
         });
 
-        setAddToCatalog(false);
         setSelectedMedication(undefined);
         setProducts(data.medicationProducts);
       };


### PR DESCRIPTION
We saw a lot of providers repeatedly going to Advanced search to add medications. If we default add it to a customer's catalog we can mitigate that as the standard interface for adding medications.