### PR TITLE
"Refills" doesn't have a default

### DIFF
--- a/packages/elements/src/photon-multirx-form/components/AddPrescriptionCard.tsx
+++ b/packages/elements/src/photon-multirx-form/components/AddPrescriptionCard.tsx
@@ -373,7 +373,7 @@ export const AddPrescriptionCard = (props: {
             <photon-number-input
               class="flex-grow flex-shrink flex-1"
               label="Refills"
-              value={props.store.refillsInput?.value ?? 0}
+              value={props.store.refillsInput?.value}
               required="true"
               min={0}
               invalid={props.store.refillsInput?.error ?? false}

--- a/packages/elements/src/photon-multirx-form/util/clearForm.ts
+++ b/packages/elements/src/photon-multirx-form/util/clearForm.ts
@@ -24,7 +24,7 @@ const clearForm = (
   });
   actions.updateFormValue({
     key: 'refillsInput',
-    value: 0
+    value: undefined
   });
   actions.updateFormValue({
     key: 'instructions',


### PR DESCRIPTION
Entering before the 0 in the example below creates "20", while entering after is "2". It's tripping up some providers, so let's just not have 0 as a helper defaulted on the "refills" section.

https://www.loom.com/share/0831d27fc52b45a19da2905b18d2e95a