### PR TITLE
Add pharmacyId to deep link

### DIFF
--- a/apps/app/src/views/routes/PrescriptionForm.tsx
+++ b/apps/app/src/views/routes/PrescriptionForm.tsx
@@ -17,6 +17,7 @@ export const PrescriptionForm = () => {
   const { user } = usePhoton();
   const [params] = useSearchParams();
   const patientId = params.get('patientId') || '';
+  const pharmacyId = params.get('pharmacyId') || '';
   const templateIds = params.get('templateIds') || '';
   const prescriptionIds = params.get('prescriptionIds') || '';
   const weight = params.get('weight') || '';
@@ -110,6 +111,7 @@ export const PrescriptionForm = () => {
           ref={ref}
           template-ids={templateIds}
           patient-id={patientId}
+          pharmacy-id={pharmacyId}
           prescription-ids={prescriptionIds}
           weight={weight}
           weight-unit={weightUnit}

--- a/package-lock.json
+++ b/package-lock.json
@@ -40506,7 +40506,7 @@
     },
     "packages/elements": {
       "name": "@photonhealth/elements",
-      "version": "0.9.1",
+      "version": "0.10.2",
       "license": "ISC",
       "dependencies": {
         "@photonhealth/components": "*",

--- a/packages/elements/src/photon-multirx-form-wrapper/photon-multirx-form-wrapper-component.tsx
+++ b/packages/elements/src/photon-multirx-form-wrapper/photon-multirx-form-wrapper-component.tsx
@@ -291,6 +291,7 @@ customElement(
   {
     hideTemplates: false,
     patientId: undefined,
+    pharmacyId: undefined,
     templateIds: undefined,
     prescriptionIds: undefined,
     weight: undefined,

--- a/packages/elements/src/photon-multirx-form-wrapper/photon-multirx-form-wrapper-component.tsx
+++ b/packages/elements/src/photon-multirx-form-wrapper/photon-multirx-form-wrapper-component.tsx
@@ -66,15 +66,13 @@ const Component = (props: {
   const dispatchPrescriptionsCreated = (
     createOrder: boolean,
     prescriptionIds: string[],
-    patientId: string,
-    pharmacyId: string
+    patientId: string
   ) => {
     const event = new CustomEvent('photon-prescriptions-created', {
       composed: true,
       bubbles: true,
       detail: {
         patientId,
-        pharmacyId,
         prescriptionIds,
         createOrder
       }

--- a/packages/elements/src/photon-multirx-form-wrapper/photon-multirx-form-wrapper-component.tsx
+++ b/packages/elements/src/photon-multirx-form-wrapper/photon-multirx-form-wrapper-component.tsx
@@ -27,6 +27,7 @@ const Component = (props: {
   enableMedHistoryLinks: boolean;
   hideTemplates?: boolean;
   patientId?: string;
+  pharmacyId?: string;
   templateIds?: string;
   prescriptionIds?: string;
   weight?: number;
@@ -65,13 +66,15 @@ const Component = (props: {
   const dispatchPrescriptionsCreated = (
     createOrder: boolean,
     prescriptionIds: string[],
-    patientId: string
+    patientId: string,
+    pharmacyId: string
   ) => {
     const event = new CustomEvent('photon-prescriptions-created', {
       composed: true,
       bubbles: true,
       detail: {
         patientId,
+        pharmacyId,
         prescriptionIds,
         createOrder
       }
@@ -241,6 +244,7 @@ const Component = (props: {
                 enable-local-pickup={props.enableLocalPickup}
                 enable-send-to-patient={props.enableSendToPatient}
                 enable-combine-and-duplicate={props.enableCombineAndDuplicate}
+                pharmacy-id={props.pharmacyId}
                 mail-order-ids={props.mailOrderIds}
                 trigger-submit={triggerSubmit()}
                 set-trigger-submit={setTriggerSubmit}


### PR DESCRIPTION
This was a [request by Tellescope](https://photonhealth.slack.com/archives/C0578R92FKP/p1717594405532649?thread_ts=1715291373.980139&cid=C0578R92FKP) to also pass in a pre-selected mail order pharmacy.

<img width="657" alt="image" src="https://github.com/Photon-Health/client/assets/3934326/06ac30f8-ff75-45f5-881e-3b911f48b8aa">
