### PR TITLE
Track selected pharmacy rank in list

### DIFF
--- a/apps/patient/public/index.html
+++ b/apps/patient/public/index.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />

--- a/apps/patient/public/index.html
+++ b/apps/patient/public/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />
@@ -7,7 +7,22 @@
     <meta name="theme-color" content="#000000" />
     <meta name="description" content="Photon Health - Patient App" />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo256.png" />
+
+    <!-- Google maps -->
     <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAvuwwE6g2Bsmih66nu4dB7-H7U1_7KQ6g&callback=Function.prototype&libraries=places"></script>
+
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-WQ9PD39S25"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag() {
+        dataLayer.push(arguments);
+      }
+      gtag('js', new Date());
+
+      gtag('config', 'G-WQ9PD39S25');
+    </script>
+
     <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/

--- a/apps/patient/src/index.tsx
+++ b/apps/patient/src/index.tsx
@@ -5,7 +5,11 @@ import { App } from './App';
 
 import { datadogRum } from '@datadog/browser-rum';
 
+import ReactGA from 'react-ga';
+
 import pkg from '../package.json';
+
+ReactGA.initialize('G-WQ9PD39S25');
 
 datadogRum.init({
   applicationId: process.env.REACT_APP_DATADOG_RUM_APPLICATION_ID as string,

--- a/apps/patient/src/views/Pharmacy.tsx
+++ b/apps/patient/src/views/Pharmacy.tsx
@@ -434,7 +434,7 @@ export const Pharmacy = () => {
   ): void => {
     // Get pharmacy index in list
     const index = pharmacies.findIndex((p) => p.id === selectedPharmacyId);
-    if (index != -1) {
+    if (index !== -1) {
       ReactGA.event({
         category: 'Pharmacy',
         action: 'Select',

--- a/apps/patient/src/views/Pharmacy.tsx
+++ b/apps/patient/src/views/Pharmacy.tsx
@@ -42,6 +42,7 @@ import capsulePharmacyIdLookup from '../data/capsulePharmacyIds.json';
 import capsuleZipcodeLookup from '../data/capsuleZipcodes.json';
 import { Pharmacy as EnrichedPharmacy } from '../utils/models';
 import { isGLP } from '../utils/isGLP';
+import ReactGA from 'react-ga';
 
 const GET_PHARMACIES_COUNT = 5; // Number of pharmacies to fetch at a time
 const PHARMACY_SEARCH_RADIUS_IN_MILES = 25;
@@ -427,6 +428,22 @@ export const Pharmacy = () => {
     setShowFooter(true);
   };
 
+  const trackSelectedPharmacyRank = (
+    selectedPharmacyId: string,
+    pharmacies: EnrichedPharmacy[]
+  ): void => {
+    // Get pharmacy index in list
+    const index = pharmacies.findIndex((p) => p.id === selectedPharmacyId);
+    if (index != -1) {
+      ReactGA.event({
+        category: 'Pharmacy',
+        action: 'Select',
+        label: 'Pharmacy Rank',
+        value: index + 1
+      });
+    }
+  };
+
   const handleSubmit = async () => {
     if (!selectedId) {
       console.error('No selectedId. Cannot set pharmacy on order.');
@@ -465,6 +482,8 @@ export const Pharmacy = () => {
 
       return;
     }
+
+    trackSelectedPharmacyRank(selectedId, allPharmacies);
 
     try {
       const result = isReroute

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,6 +53,7 @@
         "react-app-rewired": "^2.2.1",
         "react-confirm": "^0.2.3",
         "react-dom": "18.2.0",
+        "react-ga": "^3.3.1",
         "react-icons": "^4.8.0",
         "react-infinite-scroll-component": "^6.1.0",
         "react-input-mask": "^3.0.0-alpha.2",
@@ -33415,6 +33416,15 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-ga": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/react-ga/-/react-ga-3.3.1.tgz",
+      "integrity": "sha512-4Vc0W5EvXAXUN/wWyxvsAKDLLgtJ3oLmhYYssx+YzphJpejtOst6cbIHCIyF50Fdxuf5DDKqRYny24yJ2y7GFQ==",
+      "peerDependencies": {
+        "prop-types": "^15.6.0",
+        "react": "^15.6.2 || ^16.0 || ^17 || ^18"
       }
     },
     "node_modules/react-helmet": {

--- a/package.json
+++ b/package.json
@@ -129,6 +129,7 @@
     "react-app-rewired": "^2.2.1",
     "react-confirm": "^0.2.3",
     "react-dom": "18.2.0",
+    "react-ga": "^3.3.1",
     "react-icons": "^4.8.0",
     "react-infinite-scroll-component": "^6.1.0",
     "react-input-mask": "^3.0.0-alpha.2",


### PR DESCRIPTION
To start getting a feel for how far down users are going into the list to find their pharmacy.

The reason why we're doing this with Google Analytics is so that we can pull this into Metabase.