### PR TITLE
Remove unnecessary GA setup tag

### DIFF
--- a/apps/patient/public/index.html
+++ b/apps/patient/public/index.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />

--- a/apps/patient/public/index.html
+++ b/apps/patient/public/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />
@@ -10,18 +10,6 @@
 
     <!-- Google maps -->
     <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAvuwwE6g2Bsmih66nu4dB7-H7U1_7KQ6g&callback=Function.prototype&libraries=places"></script>
-
-    <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-WQ9PD39S25"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag() {
-        dataLayer.push(arguments);
-      }
-      gtag('js', new Date());
-
-      gtag('config', 'G-WQ9PD39S25');
-    </script>
 
     <!--
       manifest.json provides metadata used when your web app is installed on a


### PR DESCRIPTION
Apparently since we're using react-ga4, we don't need to setup the usual google analytics tag in index.html. It handles that for us.