### PR TITLE
Fixing refills in Templates

### DIFF
--- a/apps/app/src/views/routes/Settings/components/templates/TemplateForm/components/RefillsInput.tsx
+++ b/apps/app/src/views/routes/Settings/components/templates/TemplateForm/components/RefillsInput.tsx
@@ -34,7 +34,7 @@ export const RefillsInput = ({ errors, touched, hidden, setFieldValue }: Refills
                 id="refillsInput"
                 min={0}
                 {...field}
-                onChange={(val: any) => setFieldValue(field.name, val)}
+                onChange={(val: string) => setFieldValue(field.name, Number(val))}
               >
                 <NumberInputField />
                 <NumberInputStepper>

--- a/apps/app/src/views/routes/Settings/components/templates/TemplateForm/index.tsx
+++ b/apps/app/src/views/routes/Settings/components/templates/TemplateForm/index.tsx
@@ -118,6 +118,7 @@ export const TemplateForm = ({
       fragment: CatalogTreatmentFieldsMap
     }
   });
+
   const [updatePrescriptionTemplateMutation, { loading: loadingUpdate }] =
     updatePrescriptionTemplate({
       refetchQueries: ['getCatalog'],

--- a/apps/app/src/views/routes/Settings/components/templates/TemplateForm/utils.ts
+++ b/apps/app/src/views/routes/Settings/components/templates/TemplateForm/utils.ts
@@ -9,7 +9,7 @@ export const TEMPLATE_SCHEMA = yup.object({
     })
     .required('Please select a treatment...'),
   dispenseAsWritten: yup.boolean().nullable().optional(),
-  dispenseQuantity: yup.number().min(1, 'Must be more than 0...').default(1).nullable().optional(),
+  dispenseQuantity: yup.number().min(1, 'Must be 1 or more...').default(1).nullable().optional(),
   dispenseUnit: yup.string().when('values.treatment.__typename', {
     is: 'MedicalEquipment',
     then: yup.string().default('Each'),
@@ -24,7 +24,7 @@ export const TEMPLATE_SCHEMA = yup.object({
   daysSupply: yup.number().when('values.treatment.__typename', {
     is: 'MedicalEquipment',
     then: yup.number().default(0),
-    otherwise: yup.number().min(0, 'Must be a number...').default(0)
+    otherwise: yup.number().min(1, 'Must be 1 or more...').default(0)
   }),
   instructions: yup.string().min(1, 'Please enter instructions for the patient...'),
   notes: yup.string(),
@@ -42,11 +42,11 @@ export const TEMPLATE_INITIAL_VALUES: TemplateSchemaType = {
   },
   name: '',
   dispenseAsWritten: false,
-  dispenseQuantity: 1,
+  dispenseQuantity: 0,
   dispenseUnit: 'Each',
   fillsAllowed: 1,
   refillsInput: 0,
-  daysSupply: 30,
+  daysSupply: 0,
   instructions: '',
   notes: '',
   isPublic: false


### PR DESCRIPTION
A provider said their template was defaulting to 10 refills instead of 1. Turns out it was a string adding to a number `"1" + 0`

Also, I picked up this ticket to have blank init values:
https://www.notion.so/photons/Template-Form-should-have-blank-defaults-ac3af176ae4740ce9b2e62caeb56eef5?pvs=4