### PR TITLE
handle infinite spinner issue in local pickup tab

### DIFF
--- a/packages/components/src/systems/PharmacySearch/index.tsx
+++ b/packages/components/src/systems/PharmacySearch/index.tsx
@@ -153,11 +153,12 @@ export default function PharmacySearch(props: PharmacySearchProps) {
       if (address) {
         const addressStr = formatAddress(address);
 
-        // Make sure that the geocoder is loaded
-        const isGeocoderLoaded = await asyncInterval(() => !!geocoder(), 10, 20);
+        const geo = geocoder();
 
-        if (isGeocoderLoaded) {
-          const geo = geocoder()!; // ts won't let it fly without the non-null assertion here
+        // Make sure that the geocoder is loaded
+        await asyncInterval(() => !!geo, 10, 20);
+
+        if (geo) {
           await getAndSetLocation(addressStr, geo);
         } else {
           throw new Error('Hit max attempts to load geocoder');

--- a/packages/components/src/systems/PharmacySearch/index.tsx
+++ b/packages/components/src/systems/PharmacySearch/index.tsx
@@ -96,23 +96,6 @@ export interface GetLastOrderResponse {
   }[];
 }
 
-async function hangingAsyncInterval(
-  callback: () => boolean,
-  interval: number,
-  maxAttempts: number
-): Promise<boolean> {
-  return new Promise((resolve) => {
-    const checkCondition = () => {
-      if (callback()) {
-        resolve(true);
-      } else {
-        setTimeout(checkCondition, interval); // No maxAttempts check, will run indefinitely
-      }
-    };
-    checkCondition();
-  });
-}
-
 export interface PharmacySearchProps {
   address?: string;
   patientId?: string;


### PR DESCRIPTION
[Ticket](https://www.notion.so/photons/Infinite-Spinner-on-Local-Pickup-688be7d4510f49c8babfbb416011490f?pvs=4)

I wasn't directly able to replicate this issue. But by simulating a geocoder load fail the spinner did hang. So by handling asyncInterval hitting max loading attempts and conditionally setting location, the UI appears to be working as intended.

I want to check if Jessica (from Sesame) still has this issue after merging.