### PR TITLE
Add close btn to demo modal

### DIFF
--- a/apps/patient/src/components/DemoCtaModal.tsx
+++ b/apps/patient/src/components/DemoCtaModal.tsx
@@ -2,6 +2,7 @@ import {
   Button,
   Image,
   Modal,
+  ModalCloseButton,
   ModalHeader,
   ModalOverlay,
   ModalContent,
@@ -12,7 +13,12 @@ import {
 
 import image from '../assets/conversation.png';
 
-export const DemoCtaModal = ({ isOpen }: { isOpen: boolean }) => {
+interface DemoCtaModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export const DemoCtaModal = ({ isOpen, onClose }: DemoCtaModalProps) => {
   const handleCtaClick = () => {
     window.open('https://www.photon.health/sign-up');
   };
@@ -25,6 +31,7 @@ export const DemoCtaModal = ({ isOpen }: { isOpen: boolean }) => {
           <Image src={image} width="auto" height="120px" mx="auto" pt={6} />
         </ModalBody>
         <ModalHeader alignSelf="center">Take your time back</ModalHeader>
+        <ModalCloseButton onClick={onClose} />
         <ModalBody pb={6}>
           <VStack spacing={1} align="stretch" textAlign="center" w="full">
             <Text align="start">

--- a/apps/patient/src/views/Status.tsx
+++ b/apps/patient/src/views/Status.tsx
@@ -204,7 +204,7 @@ export const Status = () => {
 
   return (
     <Box>
-      <DemoCtaModal isOpen={showDemoCtaModal} />
+      <DemoCtaModal isOpen={showDemoCtaModal} onClose={() => setShowDemoCtaModal(false)} />
       <Helmet>
         <title>{t.track}</title>
       </Helmet>


### PR DESCRIPTION
Also worth noting that you can re-open the modal by clicking "I picked up my prescriptions".

<img width="365" alt="Screenshot 2024-07-11 at 9 13 21 AM" src="https://github.com/Photon-Health/client/assets/3934326/4b228b5c-b559-4c1d-845f-c0b67bb46190">
