### PR TITLE
Confirm modal was too big

### DIFF
--- a/apps/app/src/views/components/GuardDialog.tsx
+++ b/apps/app/src/views/components/GuardDialog.tsx
@@ -29,14 +29,15 @@ const GuardDialog = ({ show, proceed, confirmation, options }: GuardDialogProps)
         left={0}
         align="center"
         justify="center"
-        backgroundColor="rgb(0, 0, 0, 0.4)"
+        backgroundColor="rgba(0, 0, 0, 0.4)"
       >
         <Box
           background={options.darkMode ? 'gray.700' : 'white'}
           rounded="md"
-          px={4}
-          py={4}
-          minW="40%"
+          px={{ base: 4, md: 6 }}
+          py={{ base: 4, md: 6 }}
+          maxW={{ base: '90%', md: '600px' }}
+          mx="auto"
         >
           <Text align="left" fontWeight="semibold" fontSize="xl" pb={2}>
             {confirmation}

--- a/apps/app/src/views/routes/Settings/components/invites/InviteItem.tsx
+++ b/apps/app/src/views/routes/Settings/components/invites/InviteItem.tsx
@@ -66,7 +66,7 @@ export const InviteItem = ({ invite: data }: { invite: FragmentType<typeof invit
             isDisabled={resendLoading || deleteLoading}
             onClick={async () => {
               const decision = await confirmWrapper('Resend Invite?', {
-                description: <Text mb={2}>This will resend invite</Text>,
+                description: <Text mb={2}>The user will receive a new signup link via email.</Text>,
                 cancelText: "No, Don't Resend",
                 confirmText: 'Yes, Resend',
                 colorScheme: 'blue'


### PR DESCRIPTION
[Was gonna fix this](https://www.notion.so/photons/Resend-invite-should-retain-provider-details-41cad117c2124885a459628852757175?pvs=4) ticket of mine, but it was all good.

but I saw the confirm modal, its so big
![image](https://github.com/user-attachments/assets/4a0193d1-13e2-41df-b2f8-5c3dddab73c2)

now it's better

<img width="455" alt="Screen Shot 2024-07-11 at 5 52 12 PM" src="https://github.com/user-attachments/assets/e0bc7dc8-359b-462e-a864-0d59e541bef7">
<img width="1156" alt="Screen Shot 2024-07-11 at 5 52 05 PM" src="https://github.com/user-attachments/assets/033196ab-6e29-407c-88e0-1133c735ae8e">

