### PR TITLE
Hide delivery header if no options

### DIFF
--- a/apps/patient/src/components/BrandedOptions.tsx
+++ b/apps/patient/src/components/BrandedOptions.tsx
@@ -12,6 +12,7 @@ interface Props {
 
 export const BrandedOptions = ({ options, location, selectedId, handleSelect }: Props) => {
   if (!location) return null;
+  if (options.length === 0) return null;
 
   return (
     <VStack spacing={2} align="span" w="full">


### PR DESCRIPTION
Small fix in case delivery is enabled but there are no options, for example if out of range of capsule or glp1's are present for sesame.

Fixes this
![Screenshot 2024-07-17 at 2 16 21 PM](https://github.com/user-attachments/assets/d16b4716-10d4-4876-9137-61526fcbb7b1)
