### PR TITLE
Refills have a max of 11

### DIFF
--- a/packages/elements/src/photon-multirx-form/components/AddPrescriptionCard.tsx
+++ b/packages/elements/src/photon-multirx-form/components/AddPrescriptionCard.tsx
@@ -1,4 +1,4 @@
-import { afterDate, message } from '../../validators';
+import { afterDate, message, between } from '../../validators';
 import { record, string, any, number, min, size, refine } from 'superstruct';
 import { format } from 'date-fns';
 import {
@@ -33,7 +33,7 @@ const validators = {
     'Please select a dispensing unit...'
   ),
   daysSupply: message(min(number(), 0), 'Days Supply must be at least 0'),
-  refillsInput: message(min(number(), 0), 'Refills must be at least 0'),
+  refillsInput: message(between(0, 11), 'Refills must be 0 to 11'),
   instructions: message(
     size(string(), 1, Infinity),
     'Please enter instructions for the patient...'
@@ -376,6 +376,7 @@ export const AddPrescriptionCard = (props: {
               value={props.store.refillsInput?.value}
               required="true"
               min={0}
+              max={11}
               invalid={props.store.refillsInput?.error ?? false}
               help-text={props.store.refillsInput?.error}
               on:photon-input-changed={(e: any) =>


### PR DESCRIPTION
Ticket Ref:
https://www.notion.so/photons/Prescriber-can-write-too-many-refills-c494b86437be4cb5ba861289a360b848?pvs=4

After speaking with Caitlyn and Shannon, we confirmed that 11 was the maximum amount of refills on a prescription.
![image](https://github.com/user-attachments/assets/8c0e6a29-5984-4025-9a86-78ad5daed5b1)

and so...
<img width="153" alt="Screen Shot 2024-07-19 at 8 18 43 AM" src="https://github.com/user-attachments/assets/372c99e9-7e68-4586-ab85-86547ef9b6d6">
