### PR TITLE
Force users to select an account if they're logged in via their SSO

### DIFF
--- a/packages/sdk/src/auth.ts
+++ b/packages/sdk/src/auth.ts
@@ -95,7 +95,8 @@ export class AuthManager {
         ...(organizationId || this.organization
           ? { organization: organizationId || this.organization }
           : {}),
-        ...(invitation ? { invitation } : {})
+        ...(invitation ? { invitation } : {}),
+        prompt: 'select_account'
       },
       ...(appState ? { appState } : {})
     };


### PR DESCRIPTION
Users run into issues when theyre already logged in via their auth provider, because they are logged into an account _not_ associated with Photon (i.e. they're on their personal Outlook, but need to select their work Micorosft 365). The solution right now is they have to go to that account, logout and then return to Photon.

This change forces them to select which account they use, even if only one account is active.