### PR TITLE
codegen the patient app

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
 node_modules
 dist
 apps/app/src/gql
+__generated__

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -22,5 +22,8 @@ jobs:
       - name: Install Dependencies
         run: npm ci
 
+      - name: Codegen
+        run: npx run-many --target=codegen --all
+
       - name: Run Prettier
         run: npx prettier --check .

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ storybook-static/
 build-storybook.log
 
 .nx/cache/
+__generated__

--- a/.prettierignore
+++ b/.prettierignore
@@ -6,3 +6,4 @@
 
 # gql codegen
 /apps/app/src/gql
+__generated__

--- a/apps/patient/codegen.ts
+++ b/apps/patient/codegen.ts
@@ -1,0 +1,16 @@
+import type { CodegenConfig } from '@graphql-codegen/cli';
+
+const config: CodegenConfig = {
+  schema: 'http://patient-api.boson.health/graphql',
+  documents: ['**/*.ts'],
+  config: {
+    maybeValue: 'T | undefined'
+  },
+  ignoreNoDocuments: true, // for better experience with the watcher
+  generates: {
+    'src/__generated__/graphql.ts': {
+      plugins: ['typescript', 'typescript-operations', 'typescript-graphql-request']
+    }
+  }
+};
+export default config;

--- a/apps/patient/codegen.ts
+++ b/apps/patient/codegen.ts
@@ -2,6 +2,7 @@ import type { CodegenConfig } from '@graphql-codegen/cli';
 
 const config: CodegenConfig = {
   schema: 'http://patient-api.boson.health/graphql',
+  // schema: 'http://patient-api.tau.health:8080/graphql',
   documents: ['**/*.ts'],
   config: {
     maybeValue: 'T | undefined'

--- a/apps/patient/codegen.ts
+++ b/apps/patient/codegen.ts
@@ -1,8 +1,7 @@
 import type { CodegenConfig } from '@graphql-codegen/cli';
 
 const config: CodegenConfig = {
-  schema: 'http://patient-api.boson.health/graphql',
-  // schema: 'http://patient-api.tau.health:8080/graphql',
+  schema: `${process.env.GQL_SCHEMA_URL ?? 'http://patient-api.boson.health'}/graphql`,
   documents: ['**/*.ts'],
   config: {
     maybeValue: 'T | undefined'

--- a/apps/patient/package.json
+++ b/apps/patient/package.json
@@ -3,7 +3,6 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@photonhealth/sdk": "*",
     "chakra-react-select": "^4.6.0",
     "dayjs": "^1.11.7",
     "eslint-config-prettier": "^9.1.0",

--- a/apps/patient/project.json
+++ b/apps/patient/project.json
@@ -5,13 +5,20 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "application",
   "targets": {
+    "codegen": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "apps/patient",
+        "command": "npx graphql-codegen"
+      }
+    },
     "start": {
       "executor": "nx:run-commands",
       "options": {
         "cwd": "apps/patient",
         "command": "env-cmd -f .env.boson react-app-rewired start"
       },
-      "dependsOn": ["^build"]
+      "dependsOn": ["^build", "codegen"]
     },
     "start:tau": {
       "executor": "nx:run-commands",
@@ -28,7 +35,7 @@
         "command": "env-cmd -f .env.boson react-app-rewired build",
         "outputs": "dist/apps/patient"
       },
-      "dependsOn": ["^build"]
+      "dependsOn": ["^build", "codegen"]
     },
     "build:neutron": {
       "executor": "nx:run-commands",
@@ -37,7 +44,7 @@
         "command": "env-cmd -f .env.neutron react-app-rewired build",
         "outputs": "dist/apps/patient"
       },
-      "dependsOn": ["^build"]
+      "dependsOn": ["^build", "codegen"]
     },
     "build:photon": {
       "executor": "nx:run-commands",
@@ -46,7 +53,7 @@
         "command": "env-cmd -f .env.photon react-app-rewired build",
         "outputs": "dist/apps/patient"
       },
-      "dependsOn": ["^build"]
+      "dependsOn": ["^build", "codegen"]
     },
     "test": {
       "executor": "nx:run-commands",
@@ -60,21 +67,24 @@
       "options": {
         "cwd": "apps/patient",
         "command": "npx eslint . --ext .tsx,.ts --quiet"
-      }
+      },
+      "dependsOn": ["codegen"]
     },
     "lint:fix": {
       "executor": "nx:run-commands",
       "options": {
         "cwd": "apps/patient",
         "command": "npx eslint . --ext .tsx,.ts --fix && npx prettier --write src/**/*.{ts,tsx}"
-      }
+      },
+      "dependsOn": ["codegen"]
     },
     "tsc": {
       "executor": "nx:run-commands",
       "options": {
         "cwd": "apps/patient",
         "command": "npx tsc --noEmit"
-      }
+      },
+      "dependsOn": ["codegen"]
     }
   }
 }

--- a/apps/patient/project.json
+++ b/apps/patient/project.json
@@ -12,6 +12,13 @@
         "command": "npx graphql-codegen"
       }
     },
+    "codegen:watch": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "apps/patient",
+        "command": "npx graphql-codegen --watch"
+      }
+    },
     "start": {
       "executor": "nx:run-commands",
       "options": {

--- a/apps/patient/project.json
+++ b/apps/patient/project.json
@@ -19,6 +19,13 @@
         "command": "npx graphql-codegen --watch"
       }
     },
+    "codegen:tau": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "apps/patient",
+        "command": "GQL_SCHEMA_URL='http://patient-api.tau.health:8080' npx graphql-codegen --watch"
+      }
+    },
     "start": {
       "executor": "nx:run-commands",
       "options": {
@@ -33,7 +40,7 @@
         "cwd": "apps/patient",
         "command": "env-cmd -f .env.tau react-app-rewired start"
       },
-      "dependsOn": ["^build"]
+      "dependsOn": ["^build", "codegen:tau"]
     },
     "build:boson": {
       "executor": "nx:run-commands",

--- a/apps/patient/src/api/internal.ts
+++ b/apps/patient/src/api/internal.ts
@@ -1,15 +1,4 @@
-import { types } from 'packages/sdk/dist/lib';
-
 import { graphQLClient } from '../configs/graphqlClient';
-import {
-  GET_ORDER,
-  GET_PHARMACIES,
-  MARK_ORDER_AS_PICKED_UP,
-  REROUTE_ORDER,
-  SET_ORDER_PHARMACY,
-  SET_PREFERRED_PHARMACY
-} from '../graphql';
-import { Order } from '../utils/models';
 
 export const AUTH_HEADER_ERRORS = ['EMPTY_AUTHORIZATION_HEADER', 'INVALID_AUTHORIZATION_HEADER'];
 
@@ -19,9 +8,7 @@ export const AUTH_HEADER_ERRORS = ['EMPTY_AUTHORIZATION_HEADER', 'INVALID_AUTHOR
 
 export const getOrder = async (orderId: string) => {
   // Not wrapped in try/catch so error handling can be done in Main
-  const response: { order: Order } = await graphQLClient.request(GET_ORDER, {
-    id: orderId
-  });
+  const response = await graphQLClient.order({ id: orderId });
   if (response.order) {
     return response.order;
   } else {
@@ -50,20 +37,17 @@ export const getPharmacies = async ({
 }) => {
   try {
     const now = new Date();
-    const response: { pharmaciesByLocation: types.Pharmacy[] } = await graphQLClient.request(
-      GET_PHARMACIES,
-      {
-        location: {
-          radius: 100,
-          ...searchParams
-        },
-        limit,
-        offset,
-        openAt: isOpenNow ? now : undefined,
-        is24hr,
-        name
-      }
-    );
+    const response = await graphQLClient.GetPharmaciesByLocation({
+      location: {
+        radius: 100,
+        ...searchParams
+      },
+      limit,
+      offset,
+      openAt: isOpenNow ? now : undefined,
+      is24hr,
+      name
+    });
 
     if (response?.pharmaciesByLocation?.length > 0) {
       return response.pharmaciesByLocation;
@@ -83,10 +67,9 @@ export const getPharmacies = async ({
 
 export const markOrderAsPickedUp = async (orderId: string) => {
   try {
-    const response: { markOrderAsPickedUp: boolean } = await graphQLClient.request(
-      MARK_ORDER_AS_PICKED_UP,
-      { markOrderAsPickedUpId: orderId }
-    );
+    const response = await graphQLClient.MarkOrderAsPickedUp({
+      markOrderAsPickedUpId: orderId
+    });
     if (response?.markOrderAsPickedUp) {
       return true;
     } else {
@@ -101,7 +84,7 @@ export const markOrderAsPickedUp = async (orderId: string) => {
 
 export const rerouteOrder = async (orderId: string, pharmacyId: string) => {
   try {
-    const response: { rerouteOrder: boolean } = await graphQLClient.request(REROUTE_ORDER, {
+    const response = await graphQLClient.RerouteOrder({
       orderId,
       pharmacyId
     });
@@ -125,16 +108,13 @@ export const setOrderPharmacy = async (
   readyByTime?: string
 ) => {
   try {
-    const response: { setOrderPharmacy: boolean } = await graphQLClient.request(
-      SET_ORDER_PHARMACY,
-      {
-        pharmacyId,
-        orderId,
-        readyBy,
-        readyByDay,
-        readyByTime
-      }
-    );
+    const response = await graphQLClient.SetOrderPharmacy({
+      pharmacyId,
+      orderId,
+      readyBy,
+      readyByDay,
+      readyByTime
+    });
 
     if (response?.setOrderPharmacy) {
       return true;
@@ -150,13 +130,10 @@ export const setOrderPharmacy = async (
 
 export const setPreferredPharmacy = async (patientId: string, pharmacyId: string) => {
   try {
-    const response: { setPreferredPharmacy: boolean } = await graphQLClient.request(
-      SET_PREFERRED_PHARMACY,
-      {
-        patientId,
-        pharmacyId
-      }
-    );
+    const response = await graphQLClient.SetPreferredPharmacy({
+      patientId,
+      pharmacyId
+    });
 
     if (response?.setPreferredPharmacy) {
       return true;

--- a/apps/patient/src/components/HorizontalStatusStepper.tsx
+++ b/apps/patient/src/components/HorizontalStatusStepper.tsx
@@ -25,9 +25,7 @@ export const HorizontalStatusStepper = ({ status, fulfillmentType }: Props) => {
   return (
     <HStack w="full" justify="space-evenly">
       {getStates(fulfillmentType).map((state, i) => {
-        const text = t[fulfillmentType][
-          state as keyof (typeof t)[typeof fulfillmentType]
-        ] as (typeof t)[typeof fulfillmentType]['SENT'];
+        const text = t[fulfillmentType][state]!;
         return (
           <VStack key={state} w="full">
             <Box

--- a/apps/patient/src/components/PharmacyInfo.tsx
+++ b/apps/patient/src/components/PharmacyInfo.tsx
@@ -3,8 +3,7 @@ import { Box, HStack, Tag, TagLabel, TagLeftIcon, Text, VStack, Image } from '@c
 import { FiStar } from 'react-icons/fi';
 import dayjs from 'dayjs';
 import customParseFormat from 'dayjs/plugin/customParseFormat';
-import { types } from '@photonhealth/sdk';
-import { EnrichedPharmacy } from '../utils/models';
+import { Address, EnrichedPharmacy } from '../utils/models';
 import { text as t } from '../utils/text';
 
 import { formatAddress } from '../utils/general';
@@ -57,7 +56,7 @@ const Hours = ({ is24Hr, isOpen, isClosingSoon, opens, closes }: HoursProps) => 
 
 interface DistanceAddressProps {
   distance?: number;
-  address?: types.Address | null;
+  address?: Address | null;
   fontSize?: string;
 }
 

--- a/apps/patient/src/components/PharmacyInfo.tsx
+++ b/apps/patient/src/components/PharmacyInfo.tsx
@@ -4,7 +4,7 @@ import { FiStar } from 'react-icons/fi';
 import dayjs from 'dayjs';
 import customParseFormat from 'dayjs/plugin/customParseFormat';
 import { types } from '@photonhealth/sdk';
-import { Pharmacy as EnrichedPharmacy } from '../utils/models';
+import { EnrichedPharmacy } from '../utils/models';
 import { text as t } from '../utils/text';
 
 import { formatAddress } from '../utils/general';

--- a/apps/patient/src/components/ReadyText.tsx
+++ b/apps/patient/src/components/ReadyText.tsx
@@ -8,7 +8,7 @@ dayjs.extend(isTomorrow);
 
 interface ReadyTextProps {
   readyBy?: string;
-  readyByTime?: string;
+  readyByTime?: Date;
   isDeliveryPharmacy?: boolean;
   fulfillment?: Maybe<OrderFulfillment>;
 }
@@ -83,7 +83,7 @@ const PharmacyEstimatedReadyAt = ({ pharmacyEstimatedReadyAt }: PharmacyEstimate
 
 interface PatientDesiredReadyByProps {
   readyBy: string;
-  readyByTime: string;
+  readyByTime: Date;
 }
 const PatientDesiredReadyBy = ({ readyBy, readyByTime }: PatientDesiredReadyByProps) => {
   const readyByTimeDayJs = dayjs(readyByTime);

--- a/apps/patient/src/components/ReadyText.tsx
+++ b/apps/patient/src/components/ReadyText.tsx
@@ -1,7 +1,8 @@
 import dayjs from 'dayjs';
 import { Text } from '@chakra-ui/react';
-import { OrderFulfillment, Maybe } from 'packages/sdk/dist/types';
 import isTomorrow from 'dayjs/plugin/isTomorrow';
+import { Maybe } from '../__generated__/graphql';
+import { OrderFulfillment } from '../utils/models';
 
 dayjs.extend(isTomorrow);
 

--- a/apps/patient/src/components/StatusStepper.tsx
+++ b/apps/patient/src/components/StatusStepper.tsx
@@ -59,9 +59,7 @@ export const StatusStepper = ({ status, fulfillmentType, patientAddress }: Props
           >
             {getStates(fulfillmentType).map((state, id) => {
               // Types are a bit screwy here
-              const text = t[fulfillmentType][
-                state as keyof (typeof t)[typeof fulfillmentType]
-              ] as (typeof t)[typeof fulfillmentType]['SENT'];
+              const text = t[fulfillmentType][state]!;
               const title = text.status;
               const description = `${text.description(isMultiRx)}${
                 isDelivery && (state === 'SHIPPED' || state === 'READY') ? patientAddress : ''

--- a/apps/patient/src/configs/graphqlClient.ts
+++ b/apps/patient/src/configs/graphqlClient.ts
@@ -1,11 +1,72 @@
 import { GraphQLClient } from 'graphql-request';
 import { getSdk } from '../__generated__/graphql';
 
-const client = new GraphQLClient((process.env as any).REACT_APP_GRAPHQL_API_ENDPOINT, {
-  jsonSerializer: {
-    parse: JSON.parse,
-    stringify: JSON.stringify
+import { GraphQLDateTime } from 'graphql-scalars';
+
+// https://gist.github.com/tomfa/849adb5b7037b9b23ba59bf0d73c801b
+const RFC_3339_REGEX =
+  /^(\d{4}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9]|60))(\.\d{1,})?(([Z])|([+|-]([01][0-9]|2[0-3]):[0-5][0-9]))$/;
+
+const isDateTimeString = (value: string) => RFC_3339_REGEX.test(value);
+
+const parse = (value: unknown): unknown => {
+  if (value === null) {
+    return value;
   }
+  if (typeof value === 'string') {
+    if (isDateTimeString(value)) {
+      return GraphQLDateTime.parseValue(value);
+    }
+  }
+  if (typeof value === 'object') {
+    if (Array.isArray(value)) {
+      return value.map(parse);
+    }
+    return Object.fromEntries(
+      Object.entries(value).map(([k, v]) => {
+        return [k, parse(v)];
+      })
+    );
+  }
+
+  return value;
+};
+
+const stringify = (value: unknown): unknown => {
+  if (value === null) {
+    return value;
+  }
+  if (value instanceof Date) {
+    return GraphQLDateTime.serialize(value);
+  }
+  if (typeof value === 'object') {
+    if (Array.isArray(value)) {
+      return value.map(stringify);
+    }
+    return Object.fromEntries(
+      Object.entries(value).map(([k, v]) => {
+        return [k, stringify(v)];
+      })
+    );
+  }
+
+  return value;
+};
+
+export const gqlSerializer = {
+  parse: <T = any>(jsonStr: string): T => {
+    const jsonValue = JSON.parse(jsonStr);
+    return parse(jsonValue) as T;
+  },
+
+  stringify: <T = unknown>(obj: T): string => {
+    const objWithoutDate = stringify(obj);
+    return JSON.stringify(objWithoutDate);
+  }
+};
+
+const client = new GraphQLClient((process.env as any).REACT_APP_GRAPHQL_API_ENDPOINT, {
+  jsonSerializer: gqlSerializer
 });
 
 export const graphQLClient = getSdk(client);

--- a/apps/patient/src/configs/graphqlClient.ts
+++ b/apps/patient/src/configs/graphqlClient.ts
@@ -1,17 +1,17 @@
 import { GraphQLClient } from 'graphql-request';
+import { getSdk } from '../__generated__/graphql';
 
-export const graphQLClient = new GraphQLClient(
-  (process.env as any).REACT_APP_GRAPHQL_API_ENDPOINT,
-  {
-    jsonSerializer: {
-      parse: JSON.parse,
-      stringify: JSON.stringify
-    }
+const client = new GraphQLClient((process.env as any).REACT_APP_GRAPHQL_API_ENDPOINT, {
+  jsonSerializer: {
+    parse: JSON.parse,
+    stringify: JSON.stringify
   }
-);
+});
+
+export const graphQLClient = getSdk(client);
 
 export const setAuthHeader = (token: string) => {
-  graphQLClient.setHeaders({
+  client.setHeaders({
     'x-photon-auth': token
   });
 };

--- a/apps/patient/src/data/demoOrder.ts
+++ b/apps/patient/src/data/demoOrder.ts
@@ -1,62 +1,43 @@
-import { Fill } from 'packages/sdk/dist/types';
-import { FillState } from 'packages/sdk/src/types';
+import { OrderState } from '../__generated__/graphql';
 import { Order } from '../utils/models';
 
 // TODO(mrochlin) need to fix this
 export const demoOrder: Order = {
+  __typename: 'Order',
+  readyBy: undefined,
+  readyByTime: undefined,
+  isReroutable: false,
   fills: [
     {
       id: 'fil_01H91JWEAPK8ZHF0H35JE59RQY',
       prescription: {
         daysSupply: 10,
-        dispenseQuantity: '100 ML',
+        dispenseUnit: 'ML',
+        dispenseQuantity: '100 ML' as unknown as number, // Make it format nicely for demo
         expirationDate: '2024-08-29T00:00:00.000Z',
         fillsAllowed: 1,
         id: 'rx_01H91JW889FRF34ger7QC5V3PYBNWD0'
       },
       treatment: {
         id: 'med_01GZH4K86J1ZF85C43rf061G1DTGYZ',
-        name: 'amoxicillin 400 MG in 5 mL Oral Suspension',
-        codes: {
-          __typename: undefined,
-          HCPCS: undefined,
-          SKU: undefined,
-          packageNDC: undefined,
-          productNDC: undefined,
-          rxcui: undefined
-        }
-      },
-      quantity: '100 ML',
-      strength: '10 mg/10mL',
-      order: { id: 'ord_FGHDFYT4523465346' } as Order,
-      requestedAt: '2023',
-      state: FillState.New
-    } as unknown as Fill,
+        name: 'amoxicillin 400 MG in 5 mL Oral Suspension'
+      }
+    },
     {
       id: 'fil_01sH91JWEAPK8ZHF0H35sfwe3JE59RQY',
       prescription: {
         daysSupply: 2,
-        dispenseQuantity: '2 tablets',
+        dispenseUnit: 'tablets',
+        dispenseQuantity: '2 tablets' as unknown as number,
         expirationDate: '2024-08-29T00:00:00.000Z',
         fillsAllowed: 1,
         id: 'rx_01H9154tgJW889FRF7QC5V3PYBNWD0'
       },
       treatment: {
         id: 'med_01GZH4K86J1ZF85C061G14fe4DTGYZ',
-        name: 'dexamethasone 6 MG Oral Tablet',
-        codes: {
-          __typename: undefined,
-          HCPCS: undefined,
-          SKU: undefined,
-          packageNDC: undefined,
-          productNDC: undefined,
-          rxcui: undefined
-        }
-      },
-      strength: '10 mg/10mL',
-      requestedAt: '2023',
-      state: FillState.New
-    } as unknown as Fill
+        name: 'dexamethasone 6 MG Oral Tablet'
+      }
+    }
   ],
   address: {
     city: 'Brooklyn',
@@ -75,9 +56,8 @@ export const demoOrder: Order = {
       full: 'Jessie Demo'
     }
   },
-  fulfillment: null,
+  fulfillment: undefined,
   id: 'ord_FGHDFYT4523465346',
-  pharmacy: null,
-  state: 'ROUTING',
-  createdAt: '2023'
-} as unknown as Order;
+  pharmacy: undefined,
+  state: OrderState.Routing
+};

--- a/apps/patient/src/data/demoPharmacies.ts
+++ b/apps/patient/src/data/demoPharmacies.ts
@@ -1,4 +1,6 @@
-export const demoPharmacies = [
+import { EnrichedPharmacy } from '../utils/models';
+
+export const demoPharmacies: EnrichedPharmacy[] = [
   {
     id: 'asdfsafas889767546f',
     address: {
@@ -9,7 +11,6 @@ export const demoPharmacies = [
       street1: '121 Kent Ave'
     },
     name: 'Central Pharmacy',
-    info: 'preferred',
     distance: 0.2,
     isOpen: true,
     closes: 'Closes 4:30PM',
@@ -26,7 +27,6 @@ export const demoPharmacies = [
       street1: '559 Driggs Ave'
     },
     name: 'Northside Pharmacy',
-    info: 'preferred',
     distance: 0.4,
     isOpen: false,
     closes: 'Closes 7PM',
@@ -43,7 +43,6 @@ export const demoPharmacies = [
       street1: '250 Bedford Ave'
     },
     name: `Walgreens Pharmacy`,
-    info: 'preferred',
     distance: 0.5,
     isOpen: true,
     closes: '',
@@ -60,7 +59,6 @@ export const demoPharmacies = [
       street1: '27 N 6th St'
     },
     name: `CVS Pharmacy`,
-    info: 'preferred',
     distance: 0.8,
     isOpen: true,
     closes: 'Closes 6PM',
@@ -77,7 +75,6 @@ export const demoPharmacies = [
       street1: '250 Bedford Ave'
     },
     name: `Duane Reade Pharmacy`,
-    info: 'preferred',
     distance: 1.0,
     isOpen: true,
     closes: '',
@@ -94,7 +91,6 @@ export const demoPharmacies = [
       street1: '205 N 9th St'
     },
     name: `Organic Planet Pharmacy`,
-    info: 'preferred',
     distance: 1.1,
     isOpen: true,
     closes: 'Closes 4:30PM',
@@ -111,7 +107,6 @@ export const demoPharmacies = [
       street1: '556 Grand St'
     },
     name: `United Pharmacy`,
-    info: 'preferred',
     distance: 1.1,
     isOpen: true,
     closes: 'Closes 4:30PM',
@@ -128,7 +123,6 @@ export const demoPharmacies = [
       street1: '255 S 2nd St'
     },
     name: `Santa Maria Pharmacy`,
-    info: 'preferred',
     distance: 1.4,
     isOpen: false,
     closes: 'Closes 4:30PM',
@@ -145,7 +139,6 @@ export const demoPharmacies = [
       street1: '258 Bedford Ave'
     },
     name: `Walgreens Pharmacy`,
-    info: 'preferred',
     distance: 1.5,
     isOpen: true,
     closes: '',
@@ -162,7 +155,6 @@ export const demoPharmacies = [
       street1: '682 Grand St'
     },
     name: `Sisto Pharmacy`,
-    info: 'preferred',
     distance: 2.1,
     isOpen: true,
     closes: 'Closes 4:30PM',

--- a/apps/patient/src/graphql/queries.ts
+++ b/apps/patient/src/graphql/queries.ts
@@ -1,4 +1,3 @@
-// import { gql } from 'graphql-request';
 import gql from 'graphql-tag';
 
 export const GET_ORDER = gql`

--- a/apps/patient/src/graphql/queries.ts
+++ b/apps/patient/src/graphql/queries.ts
@@ -1,4 +1,5 @@
-import { gql } from 'graphql-request';
+// import { gql } from 'graphql-request';
+import gql from 'graphql-tag';
 
 export const GET_ORDER = gql`
   query order($id: ID!, $openAt: DateTime) {
@@ -8,6 +9,7 @@ export const GET_ORDER = gql`
       isReroutable
       readyBy
       readyByTime
+      readyByDay
       address {
         street1
         street2
@@ -95,6 +97,7 @@ export const GET_ORDER = gql`
           id
           daysSupply
           dispenseQuantity
+          dispenseUnit
           expirationDate
           fillsAllowed
         }

--- a/apps/patient/src/utils/general.ts
+++ b/apps/patient/src/utils/general.ts
@@ -1,4 +1,3 @@
-import { types } from '@photonhealth/sdk';
 import dayjs, { Dayjs } from 'dayjs';
 import isBetween from 'dayjs/plugin/isBetween';
 import isToday from 'dayjs/plugin/isToday';
@@ -8,8 +7,14 @@ import utc from 'dayjs/plugin/utc';
 import costcoLogo from '../assets/costco_logo_small.png';
 import walgreensLogo from '../assets/walgreens_small.png';
 import { COMMON_COURIER_PHARMACY_IDS } from '../data/courierPharmacys';
-import { EnrichedPharmacy, Fill, OrderFulfillment, Pharmacy } from '../utils/models';
+import { Address, EnrichedPharmacy, Fill, OrderFulfillment, Pharmacy } from '../utils/models';
 import { ExtendedFulfillmentType } from './models';
+import {
+  FulfillmentType,
+  PharmacyCloseEvent,
+  PharmacyEvent,
+  PharmacyOpenEvent
+} from '../__generated__/graphql';
 
 dayjs.extend(utc);
 dayjs.extend(timezone);
@@ -24,7 +29,7 @@ export const titleCase = (str: string) =>
     .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
     .join(' ');
 
-export const formatAddress = (address: types.Address) => {
+export const formatAddress = (address: Address) => {
   const { city, postalCode, state, street1, street2 } = address;
   return `${titleCase(street1)}${street2 ? `, ${titleCase(street2)}` : ''}, ${titleCase(
     city
@@ -55,8 +60,9 @@ export const getFulfillmentType = (
 
   // Next, try query param if it's set
   const fulfillmentTypes: ExtendedFulfillmentType[] = [
-    ...Object.values(types.FulfillmentType),
-    'COURIER' as ExtendedFulfillmentType
+    'COURIER',
+    FulfillmentType.MailOrder,
+    FulfillmentType.PickUp
   ];
   const foundType = fulfillmentTypes.find((val) => val === param);
   if (foundType) {
@@ -64,7 +70,7 @@ export const getFulfillmentType = (
   }
 
   // Fallback to pickup
-  return types.FulfillmentType.PickUp;
+  return FulfillmentType.PickUp;
 };
 
 /**
@@ -99,11 +105,11 @@ export const countFillsAndRemoveDuplicates = (fills: (Fill | FillWithCount)[]): 
   return Array.from(distinctFills.values());
 };
 
-function isOpenEvent(event: types.PharmacyEvent): event is types.PharmacyOpenEvent {
+function isOpenEvent(event: PharmacyEvent): event is PharmacyOpenEvent {
   return event.type === 'open';
 }
 
-function isCloseEvent(event: types.PharmacyEvent): event is types.PharmacyCloseEvent {
+function isCloseEvent(event: PharmacyEvent): event is PharmacyCloseEvent {
   return event.type === 'close';
 }
 

--- a/apps/patient/src/utils/general.ts
+++ b/apps/patient/src/utils/general.ts
@@ -80,17 +80,14 @@ export const getFulfillmentType = (
 export type FillWithCount = Fill & { count: number };
 export const countFillsAndRemoveDuplicates = (fills: (Fill | FillWithCount)[]): FillWithCount[] => {
   // First, count the occurrences of each treatment.id
-  const counts = fills.reduce(
-    (acc, fill) => {
-      const id = fill.treatment.id;
-      if (!(id in acc)) {
-        acc[id] = 0;
-      }
-      acc[id] += 'count' in fill ? fill.count : 1;
-      return acc;
-    },
-    {} as Record<string, number>
-  );
+  const counts = fills.reduce((acc, fill) => {
+    const id = fill.treatment.id;
+    if (!(id in acc)) {
+      acc[id] = 0;
+    }
+    acc[id] += 'count' in fill ? fill.count : 1;
+    return acc;
+  }, {} as Record<string, number>);
 
   // Then, create a map of distinct fills with updated counts
   const distinctFills = fills.reduce((acc: Map<string, FillWithCount>, fill) => {

--- a/apps/patient/src/utils/models.ts
+++ b/apps/patient/src/utils/models.ts
@@ -1,30 +1,26 @@
-import { types } from '@photonhealth/sdk';
+import {
+  GetPharmaciesByLocationQuery,
+  OrderQuery,
+  Address as GQLAddress,
+  FulfillmentType
+} from '../__generated__/graphql';
 
-export interface Order extends types.Order {
-  organization: {
-    id: string;
-    name: string;
-  };
-  readyBy?: string;
-  readyByDay?: string;
-  readyByTime?: string;
-  isReroutable?: boolean;
-  pharmacyEstimatedReadyAt?: Date;
-}
+type NotMaybe<T> = Exclude<T, null | undefined>;
+export type Order = NotMaybe<OrderQuery['order']>;
+export type Fill = Order['fills'][number];
 
-export interface Pharmacy extends types.Pharmacy {
-  id: string;
-  address?: types.Address | null;
-  name: string;
-  info?: string | undefined;
-  distance?: number | undefined;
-  isOpen?: boolean;
+export type Pharmacy = NotMaybe<GetPharmaciesByLocationQuery['pharmaciesByLocation'][number]>;
+
+export type OrderFulfillment = NotMaybe<Order['fulfillment']>;
+
+export type EnrichedPharmacy = Pharmacy & {
+  logo?: string | null;
+  showReadyIn30Min?: boolean;
   is24Hr?: boolean;
   isClosingSoon?: boolean;
-  showReadyIn30Min?: boolean;
-  closes?: string;
-  opens?: string;
-  logo?: string | null;
-}
+  opens?: string | undefined;
+  closes?: string | undefined;
+};
+export type ExtendedFulfillmentType = FulfillmentType | 'COURIER';
 
-export type ExtendedFulfillmentType = types.FulfillmentType | 'COURIER';
+export type Address = GQLAddress;

--- a/apps/patient/src/utils/text.tsx
+++ b/apps/patient/src/utils/text.tsx
@@ -1,5 +1,7 @@
 import { Link } from '@chakra-ui/react';
-import React from 'react';
+import { FulfillmentState } from 'packages/sdk/src/types';
+import React, { ReactNode } from 'react';
+import { ExtendedFulfillmentType } from './models';
 
 export const text = {
   closed: 'Closed',
@@ -201,7 +203,17 @@ export function PhoneLink({ children }: { children?: React.ReactNode }): React.R
   );
 }
 
-export const orderStateMapping = {
+export const orderStateMapping: {
+  [FT in ExtendedFulfillmentType]: Partial<{
+    [State in FulfillmentState]: {
+      heading: string;
+      subheading: string | ((isPlural: boolean) => string);
+      status: string;
+      description: (pl: boolean) => string;
+      cta: (pl: boolean) => string;
+    };
+  }> & { error: { title: string; description: ReactNode } };
+} = {
   PICK_UP: {
     SENT: {
       heading: text.orderWasPlaced,

--- a/apps/patient/src/views/Main.tsx
+++ b/apps/patient/src/views/Main.tsx
@@ -16,7 +16,7 @@ import { FillWithCount, countFillsAndRemoveDuplicates } from '../utils/general';
 import { Order } from '../utils/models';
 
 import { getSettings } from '@client/settings';
-import { types } from '@photonhealth/sdk';
+import { OrderState } from '../__generated__/graphql';
 import { AUTH_HEADER_ERRORS } from '../api/internal';
 import { setAuthHeader } from '../configs/graphqlClient';
 import theme from '../configs/theme';
@@ -76,7 +76,7 @@ export const Main = () => {
       datadogRum.setGlobalContextProperty('orderId', orderId);
       datadogRum.setUser({ patientId: order.patient.id });
 
-      if (order.state === types.OrderState.Canceled) {
+      if (order.state === OrderState.Canceled) {
         navigate('/canceled', { replace: true });
         return;
       }

--- a/apps/patient/src/views/Main.tsx
+++ b/apps/patient/src/views/Main.tsx
@@ -92,7 +92,7 @@ export const Main = () => {
   const fetchOrder = useCallback(async () => {
     if (isDemo) return demoOrder;
     try {
-      const result: Order = await getOrder(orderId!);
+      const result = await getOrder(orderId!);
       if (result) {
         handleOrderResponse(result);
       }

--- a/apps/patient/src/views/Pharmacy.tsx
+++ b/apps/patient/src/views/Pharmacy.tsx
@@ -15,7 +15,6 @@ import {
 import { FiCheck, FiMapPin } from 'react-icons/fi';
 import { Helmet } from 'react-helmet';
 import queryString from 'query-string';
-import { types } from '@photonhealth/sdk';
 import * as TOAST_CONFIG from '../configs/toast';
 import { formatAddress, preparePharmacy } from '../utils/general';
 import { ExtendedFulfillmentType } from '../utils/models';
@@ -43,6 +42,7 @@ import capsuleZipcodeLookup from '../data/capsuleZipcodes.json';
 import { Pharmacy as EnrichedPharmacy } from '../utils/models';
 import { isGLP } from '../utils/isGLP';
 import ReactGA from 'react-ga4';
+import { FulfillmentType } from '../__generated__/graphql';
 
 const GET_PHARMACIES_COUNT = 5; // Number of pharmacies to fetch at a time
 
@@ -499,8 +499,8 @@ export const Pharmacy = () => {
         : await setOrderPharmacy(
             order.id,
             selectedId,
-            order.readyBy,
-            order.readyByDay,
+            order.readyBy ?? undefined,
+            order.readyByDay ?? undefined,
             order.readyByTime
           );
 
@@ -513,7 +513,7 @@ export const Pharmacy = () => {
             // Fudge it so that we can show the pharmacy card on initial load of the
             // status view for all types. On my christmas list for 2024 is better
             // fulfillment types on pharmacies.
-            let type: ExtendedFulfillmentType = types.FulfillmentType.PickUp;
+            let type: ExtendedFulfillmentType = FulfillmentType.PickUp;
             let selectedPharmacy = null;
             if (selectedId in capsulePharmacyIdLookup) {
               type = 'COURIER';
@@ -522,13 +522,13 @@ export const Pharmacy = () => {
               type = 'COURIER';
               selectedPharmacy = { id: selectedId, name: 'Alto Pharmacy' };
             } else if (selectedId === process.env.REACT_APP_AMAZON_PHARMACY_ID) {
-              type = types.FulfillmentType.MailOrder;
+              type = FulfillmentType.MailOrder;
               selectedPharmacy = { id: selectedId, name: 'Amazon Pharmacy' };
             } else if (selectedId === process.env.REACT_APP_COSTCO_PHARMACY_ID) {
-              type = types.FulfillmentType.MailOrder;
+              type = FulfillmentType.MailOrder;
               selectedPharmacy = { id: selectedId, name: 'Costco Pharmacy' };
             } else {
-              type = types.FulfillmentType.PickUp;
+              type = FulfillmentType.PickUp;
               selectedPharmacy = allPharmacies.find((p) => p.id === selectedId);
             }
 

--- a/apps/patient/src/views/Status.tsx
+++ b/apps/patient/src/views/Status.tsx
@@ -7,15 +7,15 @@ import { Helmet } from 'react-helmet';
 import { FiCheck, FiNavigation, FiRefreshCcw } from 'react-icons/fi';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { markOrderAsPickedUp, triggerDemoNotification } from '../api';
-import { DemoCtaModal, PharmacyInfo, PoweredBy, PHARMACY_BRANDING } from '../components';
+import { DemoCtaModal, PHARMACY_BRANDING, PharmacyInfo, PoweredBy } from '../components';
 import { FAQ } from '../components/FAQ';
+import { HorizontalStatusStepper } from '../components/HorizontalStatusStepper';
 import { PrescriptionsList } from '../components/PrescriptionsList';
+import { ReadyText } from '../components/ReadyText';
 import * as TOAST_CONFIG from '../configs/toast';
 import { formatAddress, getFulfillmentType, preparePharmacy } from '../utils/general';
 import { orderStateMapping as m, text as t } from '../utils/text';
 import { useOrderContext } from './Main';
-import { HorizontalStatusStepper } from '../components/HorizontalStatusStepper';
-import { ReadyText } from '../components/ReadyText';
 
 export const Status = () => {
   const navigate = useNavigate();

--- a/apps/patient/src/views/Status.tsx
+++ b/apps/patient/src/views/Status.tsx
@@ -1,6 +1,5 @@
 import { Box, Button, Container, Heading, Link, Text, VStack, useToast } from '@chakra-ui/react';
 import { getSettings } from '@client/settings';
-import { types } from '@photonhealth/sdk';
 import queryString from 'query-string';
 import { useEffect, useState } from 'react';
 import { Helmet } from 'react-helmet';
@@ -16,6 +15,7 @@ import * as TOAST_CONFIG from '../configs/toast';
 import { formatAddress, getFulfillmentType, preparePharmacy } from '../utils/general';
 import { orderStateMapping as m, text as t } from '../utils/text';
 import { useOrderContext } from './Main';
+import { FulfillmentType } from '../__generated__/graphql';
 
 export const Status = () => {
   const navigate = useNavigate();
@@ -31,7 +31,7 @@ export const Status = () => {
   const showReceivedButtonStates = ['RECEIVED', 'READY'];
   const [showReceivedButton, setShowReceivedButton] = useState<boolean>(
     showReceivedButtonStates.includes(order?.fulfillment?.state ?? '') &&
-      order?.fulfillment?.type !== types.FulfillmentType.MailOrder
+      order?.fulfillment?.type !== FulfillmentType.MailOrder
   );
   const [showDemoCtaModal, setShowDemoCtaModal] = useState<boolean>(false);
 
@@ -129,7 +129,7 @@ export const Status = () => {
           fulfillment: {
             ...order.fulfillment,
             state: 'RECEIVED',
-            type: 'PICK_UP' as types.FulfillmentType
+            type: FulfillmentType.PickUp
           }
         });
 
@@ -149,7 +149,7 @@ export const Status = () => {
             fulfillment: {
               ...order.fulfillment,
               state: 'READY',
-              type: 'PICK_UP' as types.FulfillmentType
+              type: FulfillmentType.PickUp
             }
           });
 
@@ -222,7 +222,7 @@ export const Status = () => {
                   : copy.subheading}
               </Text>
             </Box>
-            {fulfillmentType === types.FulfillmentType.MailOrder && fulfillment?.trackingNumber ? (
+            {fulfillmentType === FulfillmentType.MailOrder && fulfillment?.trackingNumber ? (
               <Box alignSelf="start">
                 <Text display="inline" color="gray.600">
                   {t.tracking}

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "graphiql": "^2.4.1",
         "graphql": ">=16.0.0 <16.7.0",
         "graphql-request": "^5.2.0",
+        "graphql-scalars": "^1.23.0",
         "graphql-tag": "^2.12.6",
         "jwt-decode": "^3.1.2",
         "libphonenumber-js": "^1.10.24",
@@ -22091,6 +22092,20 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/graphql-scalars": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/graphql-scalars/-/graphql-scalars-1.23.0.tgz",
+      "integrity": "sha512-YTRNcwitkn8CqYcleKOx9IvedA8JIERn8BRq21nlKgOr4NEcTaWEG0sT+H92eF3ALTFbPgsqfft4cw+MGgv0Gg==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
       }
     },
     "node_modules/graphql-tag": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -82,6 +82,7 @@
         "@babel/preset-react": "^7.14.5",
         "@graphql-codegen/cli": "^5.0.0",
         "@graphql-codegen/client-preset": "^4.1.0",
+        "@graphql-codegen/typescript-graphql-request": "^6.2.0",
         "@nrwl/cypress": "^15.6.3",
         "@nrwl/eslint-plugin-nx": "^15.6.3",
         "@nrwl/jest": "15.6.3",
@@ -6198,6 +6199,168 @@
       "peerDependencies": {
         "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
       }
+    },
+    "node_modules/@graphql-codegen/typescript-graphql-request": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/typescript-graphql-request/-/typescript-graphql-request-6.2.0.tgz",
+      "integrity": "sha512-nkp5tr4PrC/+2QkQqi+IB+bc7AavUnUvXPW8MC93HZRvwfMGy6m2Oo7b9JCPZ3vhNpqT2VDWOn/zIZXKz6zJAw==",
+      "dev": true,
+      "dependencies": {
+        "@graphql-codegen/plugin-helpers": "^3.0.0",
+        "@graphql-codegen/visitor-plugin-common": "2.13.1",
+        "auto-bind": "~4.0.0",
+        "tslib": "~2.6.0"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0",
+        "graphql-request": "^6.0.0",
+        "graphql-tag": "^2.0.0"
+      }
+    },
+    "node_modules/@graphql-codegen/typescript-graphql-request/node_modules/@graphql-codegen/plugin-helpers": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/plugin-helpers/-/plugin-helpers-3.1.2.tgz",
+      "integrity": "sha512-emOQiHyIliVOIjKVKdsI5MXj312zmRDwmHpyUTZMjfpvxq/UVAHUJIVdVf+lnjjrI+LXBTgMlTWTgHQfmICxjg==",
+      "dev": true,
+      "dependencies": {
+        "@graphql-tools/utils": "^9.0.0",
+        "change-case-all": "1.0.15",
+        "common-tags": "1.8.2",
+        "import-from": "4.0.0",
+        "lodash": "~4.17.0",
+        "tslib": "~2.4.0"
+      },
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@graphql-codegen/typescript-graphql-request/node_modules/@graphql-codegen/plugin-helpers/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
+    },
+    "node_modules/@graphql-codegen/typescript-graphql-request/node_modules/@graphql-codegen/visitor-plugin-common": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-2.13.1.tgz",
+      "integrity": "sha512-mD9ufZhDGhyrSaWQGrU1Q1c5f01TeWtSWy/cDwXYjJcHIj1Y/DG2x0tOflEfCvh5WcnmHNIw4lzDsg1W7iFJEg==",
+      "dev": true,
+      "dependencies": {
+        "@graphql-codegen/plugin-helpers": "^2.7.2",
+        "@graphql-tools/optimize": "^1.3.0",
+        "@graphql-tools/relay-operation-optimizer": "^6.5.0",
+        "@graphql-tools/utils": "^8.8.0",
+        "auto-bind": "~4.0.0",
+        "change-case-all": "1.0.14",
+        "dependency-graph": "^0.11.0",
+        "graphql-tag": "^2.11.0",
+        "parse-filepath": "^1.0.2",
+        "tslib": "~2.4.0"
+      },
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@graphql-codegen/typescript-graphql-request/node_modules/@graphql-codegen/visitor-plugin-common/node_modules/@graphql-codegen/plugin-helpers": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/plugin-helpers/-/plugin-helpers-2.7.2.tgz",
+      "integrity": "sha512-kln2AZ12uii6U59OQXdjLk5nOlh1pHis1R98cDZGFnfaiAbX9V3fxcZ1MMJkB7qFUymTALzyjZoXXdyVmPMfRg==",
+      "dev": true,
+      "dependencies": {
+        "@graphql-tools/utils": "^8.8.0",
+        "change-case-all": "1.0.14",
+        "common-tags": "1.8.2",
+        "import-from": "4.0.0",
+        "lodash": "~4.17.0",
+        "tslib": "~2.4.0"
+      },
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@graphql-codegen/typescript-graphql-request/node_modules/@graphql-codegen/visitor-plugin-common/node_modules/@graphql-tools/utils": {
+      "version": "8.13.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.13.1.tgz",
+      "integrity": "sha512-qIh9yYpdUFmctVqovwMdheVNJqFh+DQNWIhX87FJStfXYnmweBUDATok9fWPleKeFwxnW8IapKmY8m8toJEkAw==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-codegen/typescript-graphql-request/node_modules/@graphql-codegen/visitor-plugin-common/node_modules/change-case-all": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/change-case-all/-/change-case-all-1.0.14.tgz",
+      "integrity": "sha512-CWVm2uT7dmSHdO/z1CXT/n47mWonyypzBbuCy5tN7uMg22BsfkhwT6oHmFCAk+gL1LOOxhdbB9SZz3J1KTY3gA==",
+      "dev": true,
+      "dependencies": {
+        "change-case": "^4.1.2",
+        "is-lower-case": "^2.0.2",
+        "is-upper-case": "^2.0.2",
+        "lower-case": "^2.0.2",
+        "lower-case-first": "^2.0.2",
+        "sponge-case": "^1.0.1",
+        "swap-case": "^2.0.2",
+        "title-case": "^3.0.3",
+        "upper-case": "^2.0.2",
+        "upper-case-first": "^2.0.2"
+      }
+    },
+    "node_modules/@graphql-codegen/typescript-graphql-request/node_modules/@graphql-codegen/visitor-plugin-common/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
+    },
+    "node_modules/@graphql-codegen/typescript-graphql-request/node_modules/@graphql-tools/optimize": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/optimize/-/optimize-1.4.0.tgz",
+      "integrity": "sha512-dJs/2XvZp+wgHH8T5J2TqptT9/6uVzIYvA6uFACha+ufvdMBedkfR4b4GbT8jAKLRARiqRTxy3dctnwkTM2tdw==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-codegen/typescript-graphql-request/node_modules/@graphql-tools/relay-operation-optimizer": {
+      "version": "6.5.18",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/relay-operation-optimizer/-/relay-operation-optimizer-6.5.18.tgz",
+      "integrity": "sha512-mc5VPyTeV+LwiM+DNvoDQfPqwQYhPV/cl5jOBjTgSniyaq8/86aODfMkrE2OduhQ5E00hqrkuL2Fdrgk0w1QJg==",
+      "dev": true,
+      "dependencies": {
+        "@ardatan/relay-compiler": "12.0.0",
+        "@graphql-tools/utils": "^9.2.1",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-codegen/typescript-graphql-request/node_modules/@graphql-tools/utils": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.2.1.tgz",
+      "integrity": "sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A==",
+      "dev": true,
+      "dependencies": {
+        "@graphql-typed-document-node/core": "^3.1.1",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-codegen/typescript-graphql-request/node_modules/tslib": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+      "dev": true
     },
     "node_modules/@graphql-codegen/typescript-operations": {
       "version": "4.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -165,7 +165,6 @@
     "apps/patient": {
       "version": "0.1.0",
       "dependencies": {
-        "@photonhealth/sdk": "*",
         "chakra-react-select": "^4.6.0",
         "dayjs": "^1.11.7",
         "eslint-config-prettier": "^9.1.0",
@@ -40360,7 +40359,7 @@
     },
     "packages/elements": {
       "name": "@photonhealth/elements",
-      "version": "0.11.0-rc.1",
+      "version": "0.12.1",
       "license": "ISC",
       "dependencies": {
         "@photonhealth/components": "*",

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "scripts": {
     "app:local": "concurrently \"npx graphql-codegen --watch --config='apps/app/codegen.ts'\" \"npx nx run app:start\"",
     "app:tau": "concurrently \"npx graphql-codegen --watch --config='apps/app/codegen.ts'\" \"npx nx run app:start:tau\"",
-    "patient": "npx nx run patient:start",
-    "patient:tau": "npx nx run patient:start:tau",
+    "patient:tau": "concurrently \"npx nx run patient:codegen:watch\" \"npx nx run patient:start:tau\"",
+    "patient": "concurrently \"npx nx run patient:codegen:watch\" \"npx nx run patient:start\"",
     "lint": "npx nx run-many --target=lint",
     "lint:fix": "npx nx run-many --target=lint:fix"
   },

--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
     "graphiql": "^2.4.1",
     "graphql": ">=16.0.0 <16.7.0",
     "graphql-request": "^5.2.0",
+    "graphql-scalars": "^1.23.0",
     "graphql-tag": "^2.12.6",
     "jwt-decode": "^3.1.2",
     "libphonenumber-js": "^1.10.24",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@babel/preset-react": "^7.14.5",
     "@graphql-codegen/cli": "^5.0.0",
     "@graphql-codegen/client-preset": "^4.1.0",
+    "@graphql-codegen/typescript-graphql-request": "^6.2.0",
     "@nrwl/cypress": "^15.6.3",
     "@nrwl/eslint-plugin-nx": "^15.6.3",
     "@nrwl/jest": "15.6.3",


### PR DESCRIPTION
Add codegen to the patient app.

- We're always using `patient-api` for the patient app so its easy to point at
- The codegen will hot-reload if you run `npm run patient` but you can also run `nx run patient:codegen:watch` (or just `nx run patient:codegen` if you don't want to watch
- For now, this keeps the `graphql-request` library as the client. This provides no caching or anything, so we should eventually revisit that
- We currently co-locate all our queries and mutations. This makes some stuff easy (i.e. the types are consistent across pages) but other stuff hard. For a simple app like the patient app, I think the current approach is fine. But as the app gets more complex we might want to move to Apollo or Relay
- By generating our own types, this PR also removes the dependency on the sdk's package because we weren't actually using it