### PR TITLE
Enable local delivery Amazon Pharmacy test for sesame

### DIFF
--- a/apps/patient/src/components/BrandedPharmacyCard.tsx
+++ b/apps/patient/src/components/BrandedPharmacyCard.tsx
@@ -63,6 +63,7 @@ export const BrandedPharmacyCard = ({ pharmacyId, selected, handleSelect }: Prop
           pharmacy={pharmacy}
           tagline={brand.description}
           availableInYourArea={brand.name === 'Capsule Pharmacy'}
+          freeDelivery={brand.name === 'Amazon Pharmacy'}
           boldPharmacyName={false}
         />
       </CardBody>

--- a/apps/patient/src/components/PharmacyInfo.tsx
+++ b/apps/patient/src/components/PharmacyInfo.tsx
@@ -82,6 +82,7 @@ interface PharmacyInfoProps {
   preferred?: boolean;
   showDetails?: boolean;
   availableInYourArea?: boolean;
+  freeDelivery?: boolean;
   boldPharmacyName?: boolean;
   isStatus?: boolean;
   selected?: boolean;
@@ -93,6 +94,7 @@ export const PharmacyInfo = ({
   preferred = false,
   showDetails = true,
   availableInYourArea = false,
+  freeDelivery = false,
   boldPharmacyName = true,
   isStatus = false
 }: PharmacyInfoProps) => {
@@ -103,12 +105,16 @@ export const PharmacyInfo = ({
   const showPreferredTag = preferred;
   const showReadyIn30MinTag = pharmacy?.showReadyIn30Min && !isStatus;
   const showAvailableInYourAreaTag = availableInYourArea;
+  const showFreeDeliveryTag = freeDelivery;
   const whiteLabelDeliveryPharmacy =
     pharmacy.name === 'Capsule Pharmacy' && location.pathname === '/pharmacy';
 
   return (
     <VStack align="start" w="full" spacing={1}>
-      {showPreferredTag || showReadyIn30MinTag || showAvailableInYourAreaTag ? (
+      {showPreferredTag ||
+      showReadyIn30MinTag ||
+      showAvailableInYourAreaTag ||
+      showFreeDeliveryTag ? (
         <HStack spacing={2} m={0} p={0}>
           {showPreferredTag ? (
             <Tag size="sm" colorScheme="blue">
@@ -124,6 +130,11 @@ export const PharmacyInfo = ({
           {showAvailableInYourAreaTag ? (
             <Tag size="sm" bgColor="green.100" color="green.600" mb={1}>
               <TagLabel fontWeight="bold">Available in your area</TagLabel>
+            </Tag>
+          ) : null}
+          {showFreeDeliveryTag ? (
+            <Tag size="sm" bgColor="green.100" color="green.600" mb={1}>
+              <TagLabel fontWeight="bold">Free Delivery</TagLabel>
             </Tag>
           ) : null}
         </HStack>

--- a/apps/patient/src/views/Pharmacy.tsx
+++ b/apps/patient/src/views/Pharmacy.tsx
@@ -103,26 +103,6 @@ export const Pharmacy = () => {
 
   const isMultiRx = flattenedFills.length > 1;
 
-  const enableMailOrder = !isDemo && orgSettings.mailOrderNavigate;
-
-  // capsule
-  const isCapsuleTerritory =
-    order?.address?.postalCode != null && order.address.postalCode in capsuleZipcodeLookup;
-  const enableCourier = !isDemo && isCapsuleTerritory && orgSettings.enableCourierNavigate;
-  const capsulePharmacyId = order?.address?.postalCode
-    ? capsuleZipcodeLookup[order.address.postalCode as keyof typeof capsuleZipcodeLookup]
-        ?.pharmacyId
-    : null;
-
-  const enableTopRankedCostco = !isDemo && orgSettings.topRankedCostco;
-  const enableTopRankedWalgreens = !isDemo && orgSettings.topRankedWalgreens;
-  const containsGLP = flattenedFills.some((fill) => isGLP(fill.treatment.name));
-
-  const heading = isReroute ? t.changePharmacy : t.selectAPharmacy;
-  const subheading = isReroute
-    ? t.sendToNew(isMultiRx, order.pharmacy!.name)
-    : t.sendToSelected(isMultiRx);
-
   // Pharmacy results
   const [topRankedPharmacies, setTopRankedPharmacies] = useState<EnrichedPharmacy[]>([]);
   const [pharmacyResults, setPharmacyResults] = useState<EnrichedPharmacy[]>([]);
@@ -138,6 +118,33 @@ export const Pharmacy = () => {
     }
     return combined.map(preparePharmacy);
   }, [isDemo, pharmacyResults, topRankedPharmacies]);
+
+  // capsule
+  const isCapsuleTerritory =
+    order?.address?.postalCode != null && order.address.postalCode in capsuleZipcodeLookup;
+  const enableCourier = !isDemo && isCapsuleTerritory && orgSettings.enableCourierNavigate;
+  const capsulePharmacyId = order?.address?.postalCode
+    ? capsuleZipcodeLookup[order.address.postalCode as keyof typeof capsuleZipcodeLookup]
+        ?.pharmacyId
+    : null;
+
+  // mail order
+  const hasTopRankedCostco = topRankedPharmacies.some((p) => p.name === 'Costco Pharmacy');
+  const enableMailOrder =
+    !isDemo &&
+    !hasTopRankedCostco && // this means org is Sesame, we don't want to show Amazon and top ranked Costco at the same time
+    orgSettings.mailOrderNavigate;
+
+  // top ranked pharmacies
+  const enableTopRankedCostco = !isDemo && orgSettings.topRankedCostco;
+  const enableTopRankedWalgreens = !isDemo && orgSettings.topRankedWalgreens;
+  const containsGLP = flattenedFills.some((fill) => isGLP(fill.treatment.name));
+
+  // headings
+  const heading = isReroute ? t.changePharmacy : t.selectAPharmacy;
+  const subheading = isReroute
+    ? t.sendToNew(isMultiRx, order.pharmacy!.name)
+    : t.sendToSelected(isMultiRx);
 
   const showToastWarning = () =>
     toast({

--- a/package-lock.json
+++ b/package-lock.json
@@ -40197,7 +40197,7 @@
     },
     "packages/elements": {
       "name": "@photonhealth/elements",
-      "version": "0.10.2",
+      "version": "0.10.9",
       "license": "ISC",
       "dependencies": {
         "@photonhealth/components": "*",

--- a/packages/settings/src/lib/neutron.ts
+++ b/packages/settings/src/lib/neutron.ts
@@ -226,7 +226,9 @@ const organizationSettings: {
     accentColor: '#5224C7',
     topRankedCostco: true,
     mailOrder: true,
-    mailOrderProviders: [FOOTHILLS_PHARMACY_ID]
+    mailOrderProviders: [FOOTHILLS_PHARMACY_ID],
+    mailOrderNavigate: true,
+    mailOrderNavigateProviders: [AMAZON_PHARMACY_ID]
   },
   // Oshi Health
   org_yOgsgGMBVUZIBcwp: {

--- a/packages/settings/src/lib/neutron.ts
+++ b/packages/settings/src/lib/neutron.ts
@@ -80,6 +80,8 @@ const organizationSettings: {
       FOOTHILLS_PHARMACY_ID
     ],
     topRankedWalgreens: true,
+    mailOrderNavigate: true,
+    mailOrderNavigateProviders: [AMAZON_PHARMACY_ID],
     enableCourierNavigate: true
   },
   // NewCo (demo's)

--- a/packages/settings/src/lib/photon.ts
+++ b/packages/settings/src/lib/photon.ts
@@ -268,7 +268,9 @@ const organizationSettings: {
   org_zc1RzzmSwd8eE94U: {
     logo: 'sesame_logo.jpg',
     accentColor: '#5224C7',
-    topRankedCostco: true
+    topRankedCostco: true,
+    mailOrderNavigate: true,
+    mailOrderNavigateProviders: [AMAZON_PHARMACY_ID]
   },
   // DrTelx
   org_6DKb7celAunAoLzb: {


### PR DESCRIPTION
We're running a similar delivery test to our recent Courier tests. This will also be for Sesame, but Amazon Pharmacy this time. Also note, this is mutually exclusive to the top ranked Costco option we are surfacing for Sesame GLP's.

Here's what the option looks like...

![image (39)](https://github.com/user-attachments/assets/b0b3b64a-e06c-4a10-8594-a44c1fb9db3c)
