### PR TITLE
Set top ranked pharmacy search radius to 15mi

### DIFF
--- a/apps/patient/src/api/internal.ts
+++ b/apps/patient/src/api/internal.ts
@@ -54,7 +54,7 @@ export const getPharmacies = async ({
       GET_PHARMACIES,
       {
         location: {
-          radius: searchParams.radius ?? 100,
+          radius: 100,
           ...searchParams
         },
         limit,

--- a/apps/patient/src/api/internal.ts
+++ b/apps/patient/src/api/internal.ts
@@ -40,6 +40,7 @@ export const getPharmacies = async ({
   searchParams: {
     latitude: number;
     longitude: number;
+    radius?: number;
   };
   limit: number;
   offset: number;
@@ -53,7 +54,7 @@ export const getPharmacies = async ({
       GET_PHARMACIES,
       {
         location: {
-          radius: 100,
+          radius: searchParams.radius ?? 100,
           ...searchParams
         },
         limit,

--- a/apps/patient/src/views/Pharmacy.tsx
+++ b/apps/patient/src/views/Pharmacy.tsx
@@ -648,7 +648,7 @@ export const Pharmacy = () => {
       <Container pb={showFooter ? 28 : 8}>
         {location ? (
           <VStack spacing={6} align="stretch" pt={4}>
-            {!enableCourier || enableMailOrder ? (
+            {enableCourier || enableMailOrder ? (
               <BrandedOptions
                 options={[
                   ...(enableCourier && order?.address?.postalCode && capsulePharmacyId

--- a/apps/patient/src/views/Pharmacy.tsx
+++ b/apps/patient/src/views/Pharmacy.tsx
@@ -648,7 +648,7 @@ export const Pharmacy = () => {
       <Container pb={showFooter ? 28 : 8}>
         {location ? (
           <VStack spacing={6} align="stretch" pt={4}>
-            {enableCourier || enableMailOrder ? (
+            {!enableCourier || enableMailOrder ? (
               <BrandedOptions
                 options={[
                   ...(enableCourier && order?.address?.postalCode && capsulePharmacyId

--- a/apps/patient/src/views/Pharmacy.tsx
+++ b/apps/patient/src/views/Pharmacy.tsx
@@ -245,7 +245,7 @@ export const Pharmacy = () => {
       }
       try {
         const topRankedCostco: EnrichedPharmacy[] = await getPharmacies({
-          searchParams: { latitude, longitude },
+          searchParams: { latitude, longitude, radius: 15 },
           limit: 1,
           offset: 0,
           isOpenNow: enableOpenNow,
@@ -281,7 +281,7 @@ export const Pharmacy = () => {
 
       try {
         const topRankedWags: EnrichedPharmacy[] = await getPharmacies({
-          searchParams: { latitude, longitude },
+          searchParams: { latitude, longitude, radius: 15 },
           limit: 1,
           offset: 0,
           isOpenNow: enableOpenNow,


### PR DESCRIPTION
Right now we are returning costcos that are real far away (see below) for top ranked pharmacies like Costco we should limit the radius in search.

![image (40)](https://github.com/user-attachments/assets/98d259ba-4279-466f-9aee-0041be9ce443)
