### PR TITLE
fixing spacing in the treatments tab

### DIFF
--- a/apps/app/src/views/components/SplitLayout.tsx
+++ b/apps/app/src/views/components/SplitLayout.tsx
@@ -18,7 +18,6 @@ export const SplitLayout = (props: any) => {
         width={isMobileAndTablet ? '100%' : 'full'}
         alignSelf={isMobileAndTablet ? 'center' : 'flex-start'}
         mt={2}
-        px={isMobileAndTablet ? 4 : 0}
       >
         {children[0]}
       </Box>

--- a/apps/app/src/views/components/SplitLayout.tsx
+++ b/apps/app/src/views/components/SplitLayout.tsx
@@ -10,14 +10,14 @@ export const SplitLayout = (props: any) => {
     <Stack
       flexDir={isMobileAndTablet ? 'column' : 'row'}
       gap={5}
-      width="95vw"
+      width="100%"
       maxW="1400"
       justify="center"
     >
       <Box
-        width={isMobileAndTablet ? '100vw' : 'full'}
+        width={isMobileAndTablet ? '100%' : 'full'}
         alignSelf={isMobileAndTablet ? 'center' : 'flex-start'}
-        pt={2}
+        mt={2}
         px={isMobileAndTablet ? 4 : 0}
       >
         {children[0]}
@@ -29,6 +29,7 @@ export const SplitLayout = (props: any) => {
           shadow="md"
           minW="400px"
           alignSelf={isMobileAndTablet ? 'center' : 'flex-start'}
+          mt={2}
           p={6}
         >
           {children[1]}

--- a/apps/app/src/views/routes/Settings/views/TreatmentTab.tsx
+++ b/apps/app/src/views/routes/Settings/views/TreatmentTab.tsx
@@ -2,6 +2,7 @@ import { useMutation } from '@apollo/client';
 import {
   Alert,
   AlertIcon,
+  Box,
   Modal,
   ModalBody,
   ModalCloseButton,
@@ -192,9 +193,13 @@ export const TreatmentTab = ({
           </ModalBody>
         </ModalContent>
       </Modal>
-      <Text width="full" fontWeight="medium" fontSize="lg">
-        Manage {organization ? `${organization.name}'s ` : ''}Catalog
-      </Text>
+
+      <Box width="full">
+        <Text width="full" fontWeight="medium" fontSize="l">
+          Manage {organization ? `${organization.name}'s ` : ''}Catalog
+        </Text>
+      </Box>
+
       {error && (
         <Alert status="error" rounded="lg">
           <AlertIcon />

--- a/apps/app/src/views/routes/Settings/views/TreatmentTab.tsx
+++ b/apps/app/src/views/routes/Settings/views/TreatmentTab.tsx
@@ -2,7 +2,6 @@ import { useMutation } from '@apollo/client';
 import {
   Alert,
   AlertIcon,
-  Box,
   Modal,
   ModalBody,
   ModalCloseButton,
@@ -194,11 +193,9 @@ export const TreatmentTab = ({
         </ModalContent>
       </Modal>
 
-      <Box width="full">
-        <Text width="full" fontWeight="medium" fontSize="l">
-          Manage {organization ? `${organization.name}'s ` : ''}Catalog
-        </Text>
-      </Box>
+      <Text width="full" fontWeight="medium" fontSize="l">
+        Manage {organization ? `${organization.name}'s ` : ''}Catalog
+      </Text>
 
       {error && (
         <Alert status="error" rounded="lg">

--- a/apps/app/src/views/routes/Settings/views/TreatmentTab.tsx
+++ b/apps/app/src/views/routes/Settings/views/TreatmentTab.tsx
@@ -192,11 +192,9 @@ export const TreatmentTab = ({
           </ModalBody>
         </ModalContent>
       </Modal>
-
       <Text width="full" fontWeight="medium" fontSize="l">
         Manage {organization ? `${organization.name}'s ` : ''}Catalog
       </Text>
-
       {error && (
         <Alert status="error" rounded="lg">
           <AlertIcon />

--- a/apps/app/src/views/routes/Settings/views/TreatmentTab.tsx
+++ b/apps/app/src/views/routes/Settings/views/TreatmentTab.tsx
@@ -192,7 +192,7 @@ export const TreatmentTab = ({
           </ModalBody>
         </ModalContent>
       </Modal>
-      <Text width="full" fontWeight="medium" fontSize="l">
+      <Text width="full" fontWeight="medium" fontSize="lg">
         Manage {organization ? `${organization.name}'s ` : ''}Catalog
       </Text>
       {error && (


### PR DESCRIPTION
as per [this](https://www.notion.so/photons/Update-templates-catalog-layout-d7b8c3feb46e49148bf2a4eb422cc121) ticket, there are some spacing issues in the catalogs section.

the overflow issue has been resolved by switching from `vw` units to `100%`. `vw` will always be the view width, which sometimes can be too big - we instead want it to fill the parent container, which is what changing to `100%` does.

additionally, there was some annoying vertical discrepancy between the split contents due to differences in handling the first child vs the second. i've standardized it so they both have the same amount of margin.

##  BEFORE

### DESKTOP
<img width="1387" alt="treatments_before_desktop" src="https://github.com/user-attachments/assets/7decd34a-d146-439f-b264-08ffe47023f8">

**issues:** 

1. the vertical alignment of the table and the `add treatment` section on the right
2. the overflow of the table

### MOBILE
<img width="443" alt="treatments_before_mobile" src="https://github.com/user-attachments/assets/3cb8e93e-f584-40c8-b430-2167786caaeb">

## AFTER

### DESKTOP 
<img width="1342" alt="treatments_after_desktop" src="https://github.com/user-attachments/assets/1899ab9d-e3a1-4a1a-a200-fcfb1816a748">

**solutions:** 

1. the alignment of the table and `add treatment section` is uniform
2. the overflow of the table has been resolved

### MOBILE
<img width="456" alt="treatments_after_mobile" src="https://github.com/user-attachments/assets/c28f230b-7834-439d-a21e-1abdc2647447">

