### PR TITLE
Disable Amazon Pharmacy test

### DIFF
--- a/packages/settings/src/lib/photon.ts
+++ b/packages/settings/src/lib/photon.ts
@@ -269,8 +269,6 @@ const organizationSettings: {
     logo: 'sesame_logo.jpg',
     accentColor: '#5224C7',
     topRankedCostco: true,
-    mailOrderNavigate: true,
-    mailOrderNavigateProviders: [AMAZON_PHARMACY_ID]
   },
   // DrTelx
   org_6DKb7celAunAoLzb: {

--- a/packages/settings/src/lib/photon.ts
+++ b/packages/settings/src/lib/photon.ts
@@ -268,7 +268,7 @@ const organizationSettings: {
   org_zc1RzzmSwd8eE94U: {
     logo: 'sesame_logo.jpg',
     accentColor: '#5224C7',
-    topRankedCostco: true,
+    topRankedCostco: true
   },
   // DrTelx
   org_6DKb7celAunAoLzb: {


### PR DESCRIPTION
Removing amazon pharmacy as a mail order option for sesame within the patient app since we concluded our test.