### PR TITLE
Limit med search to 3 or more chars in search string

### DIFF
--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@photonhealth/elements",
-  "version": "0.11.0-rc.3",
+  "version": "0.11.0-rc.4",
   "description": "",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/elements/src/photon-medication-search/photon-medication-search-component.tsx
+++ b/packages/elements/src/photon-medication-search/photon-medication-search-component.tsx
@@ -257,10 +257,11 @@ const Component = (props: ComponentProps) => {
   const tryLoadTreatmentOptions = async (searchTerm: string) => {
     setLoadingTreatmentOptions(true);
 
-    const treatmentOptions = searchTerm
-      ? await loadTreatmentOptions(client!.sdk.apolloClinical, searchTerm)
-      : // Set treatment options to empty array if search term is empty
-        [];
+    const treatmentOptions =
+      searchTerm?.length >= 3 // 3 min chars for smaller responses
+        ? await loadTreatmentOptions(client!.sdk.apolloClinical, searchTerm)
+        : // Set treatment options to empty array if search term is empty
+          [];
     const filteredData = getFilteredData(props, props.searchText, treatmentOptions);
     setOptions(filteredData);
 


### PR DESCRIPTION
Search can tend to take a bit when you're only searching for "s". Limiting to 3 or more worked well for our prototypes. Responses are about to get larger with us returning generic as well when searching branded.