### PR TITLE
Add catalog params to photon-prescribe-workflow

### DIFF
--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@photonhealth/elements",
-  "version": "0.12.7",
+  "version": "0.12.8",
   "description": "",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/elements/src/photon-multirx-form/components/AddPrescriptionCard.tsx
+++ b/packages/elements/src/photon-multirx-form/components/AddPrescriptionCard.tsx
@@ -48,6 +48,8 @@ export const AddPrescriptionCard = (props: {
   weightUnit?: string;
   prefillNotes?: string;
   enableCombineAndDuplicate?: boolean;
+  catalogId?: string;
+  allowOffCatalogSearch?: boolean;
 }) => {
   const client = usePhoton();
   const [medDialogOpen, setMedDialogOpen] = createSignal(false);
@@ -56,7 +58,6 @@ export const AddPrescriptionCard = (props: {
   const [openDoseCalculator, setOpenDoseCalculator] = createSignal(false);
   const [, recentOrdersActions] = useRecentOrders();
   const [searchText, setSearchText] = createSignal<string>('');
-
   let ref: any;
 
   onMount(() => {
@@ -210,6 +211,8 @@ export const AddPrescriptionCard = (props: {
         >
           <photon-medication-search
             label="Search for Treatment"
+            catalog-id={props.catalogId}
+            allow-off-catalog-search={props.allowOffCatalogSearch}
             selected={props.store.treatment?.value ?? undefined}
             invalid={props.store.treatment?.error ?? false}
             help-text={props.store.treatment?.error}

--- a/packages/elements/src/photon-multirx-form/photon-prescribe-workflow-component.tsx
+++ b/packages/elements/src/photon-multirx-form/photon-prescribe-workflow-component.tsx
@@ -42,6 +42,8 @@ const Component = (props: PrescribeProps) => {
         formStore={store}
         formActions={actions}
         externalOrderId={props.externalOrderId}
+        catalogId={props.catalogId}
+        allowOffCatalogSearch={props.allowOffCatalogSearch}
       />
     </RecentOrders>
   );
@@ -72,7 +74,9 @@ customElement(
     triggerSubmit: false,
     setTriggerSubmit: undefined,
     toastBuffer: 0,
-    externalOrderId: undefined
+    externalOrderId: undefined,
+    catalogId: undefined,
+    allowOffCatalogSearch: true
   },
   Component
 );

--- a/packages/elements/src/photon-multirx-form/photon-prescribe-workflow.tsx
+++ b/packages/elements/src/photon-multirx-form/photon-prescribe-workflow.tsx
@@ -72,6 +72,8 @@ export type PrescribeProps = {
   formStore?: any;
   formActions?: any;
   externalOrderId?: string;
+  catalogId?: string;
+  allowOffCatalogSearch?: boolean;
 };
 
 export function PrescribeWorkflow(props: PrescribeProps) {
@@ -453,6 +455,8 @@ export function PrescribeWorkflow(props: PrescribeProps) {
                       weightUnit={props.weightUnit}
                       prefillNotes={prefillNotes}
                       enableCombineAndDuplicate={props.enableCombineAndDuplicate}
+                      catalogId={props.catalogId}
+                      allowOffCatalogSearch={props.allowOffCatalogSearch}
                     />
                   </div>
                 </Show>

--- a/packages/elements/src/stores/catalog.ts
+++ b/packages/elements/src/stores/catalog.ts
@@ -9,7 +9,7 @@ const CATALOG_FIELDS = gql`
     id
   }
 `;
-const CatalogtFieldsMap = { CatalogFields: CATALOG_FIELDS };
+const CatalogFieldsMap = { CatalogFields: CATALOG_FIELDS };
 
 const CATALOG_TREATMENTS_FIELDS = gql`
   fragment CatalogTreatmentsFields on Catalog {
@@ -70,7 +70,7 @@ const createCatalogStore = () => {
       isLoading: true
     });
     const { data, errors } = await client.clinical.catalog.getCatalogs({
-      fragment: CatalogtFieldsMap
+      fragment: CatalogFieldsMap
     });
     setStore('catalogs', {
       ...store.catalogs,

--- a/packages/elements/src/stores/catalog.ts
+++ b/packages/elements/src/stores/catalog.ts
@@ -4,6 +4,13 @@ import { GraphQLError } from 'graphql';
 import gql from 'graphql-tag';
 import { createStore } from 'solid-js/store';
 
+const CATALOG_FIELDS = gql`
+  fragment CatalogFields on Catalog {
+    id
+  }
+`;
+const CatalogtFieldsMap = { CatalogFields: CATALOG_FIELDS };
+
 const CATALOG_TREATMENTS_FIELDS = gql`
   fragment CatalogTreatmentsFields on Catalog {
     id
@@ -39,9 +46,19 @@ const createCatalogStore = () => {
       errors: readonly GraphQLError[];
       isLoading: boolean;
     };
+    catalog: {
+      data?: Catalog;
+      errors: readonly GraphQLError[];
+      isLoading: boolean;
+    };
   }>({
     catalogs: {
       data: [],
+      errors: [],
+      isLoading: false
+    },
+    catalog: {
+      data: undefined,
       errors: [],
       isLoading: false
     }
@@ -53,7 +70,7 @@ const createCatalogStore = () => {
       isLoading: true
     });
     const { data, errors } = await client.clinical.catalog.getCatalogs({
-      fragment: CatalogTreatmentFieldsMap
+      fragment: CatalogtFieldsMap
     });
     setStore('catalogs', {
       ...store.catalogs,
@@ -63,10 +80,28 @@ const createCatalogStore = () => {
     });
   };
 
+  const getCatalog = async (client: PhotonClient, id: string) => {
+    setStore('catalog', {
+      ...store.catalog,
+      isLoading: true
+    });
+    const { data, errors } = await client.clinical.catalog.getCatalog({
+      id,
+      fragment: CatalogTreatmentFieldsMap
+    });
+    setStore('catalog', {
+      ...store.catalog,
+      isLoading: false,
+      data: data.catalog,
+      errors: errors
+    });
+  };
+
   return {
     store,
     actions: {
-      getCatalogs
+      getCatalogs,
+      getCatalog
     }
   };
 };


### PR DESCRIPTION
Two additional params are added:

`catalog-id`
This allows constraining a caller to a specific catalog

`allow-off-catalog-search`
This gives control to allowing or blocking searching for items _not_ on the catalog

These will be used in mail order configurations, so a customer can programmatically constrain the meds allowed to be prescribed.