### PR TITLE
Discount card test follow-up

### DIFF
--- a/apps/patient/src/components/Coupons.tsx
+++ b/apps/patient/src/components/Coupons.tsx
@@ -27,11 +27,10 @@ export const Coupons = () => {
   return (
     <VStack w="full" alignItems="stretch" spacing={4}>
       <Heading as="h4" size="md">
-        {discountCards.length > 1 ? 'Coupons' : 'Coupon'}
+        Coupon
       </Heading>
-      {discountCards.map((card) => (
-        <Coupon key={card.id} coupon={card} />
-      ))}
+      {/* Show one coupon only */}
+      <Coupon coupon={discountCards[0]} />
     </VStack>
   );
 };

--- a/apps/patient/src/views/Pharmacy.tsx
+++ b/apps/patient/src/views/Pharmacy.tsx
@@ -14,7 +14,7 @@ import {
 } from '@chakra-ui/react';
 import { getSettings } from '@client/settings';
 import queryString from 'query-string';
-import { useCallback, useEffect, useMemo, useState, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import ReactGA from 'react-ga4';
 import { Helmet } from 'react-helmet';
 import { FiCheck, FiMapPin } from 'react-icons/fi';
@@ -674,19 +674,17 @@ export const Pharmacy = () => {
     }
   };
 
-  const actionTriggeredRef = useRef(false);
-
+  // TODO: remove after we start storing prices (<1wk)
   useEffect(() => {
     // wait until pharmacies are loaded to determine if showing cash price
-    if (!loadingPharmacies && showSearchToggle && !actionTriggeredRef.current) {
+    if (!loadingPharmacies && showSearchToggle && sortBy === 'price') {
       datadogRum.addAction('cash_price_displayed', {
         orderId: order.id,
         organization: order.organization.name,
         timestamp: new Date().toISOString()
       });
-      actionTriggeredRef.current = true;
     }
-  }, [loadingPharmacies, showSearchToggle, order]);
+  }, [loadingPharmacies, showSearchToggle, order, sortBy]);
 
   useEffect(() => {
     datadogRum.addAction('pharmacy_list_toggle_selection', {


### PR DESCRIPTION
- restrict frontend to only show 1 coupon - saw one order with this, i believe it was reroute to the same pharmacy
- hide toggle for multirx - backend was limiting this already by returning no pharmacies
- don't show prices for glp1 - this was an original requirement that i missed
- don't register `cash_price_displayed` action unless toggled to price search - need this change now that we're not defaulting to cash price search