### PR TITLE
persist url search params when session expires

### DIFF
--- a/apps/app/src/views/components/Auth.tsx
+++ b/apps/app/src/views/components/Auth.tsx
@@ -30,7 +30,10 @@ export const Auth = (props: AuthProps) => {
     );
 
   return (
-    <Button colorScheme="blue" onClick={() => login({ appState: { returnTo } })}>
+    <Button
+      colorScheme="blue"
+      onClick={() => login({ appState: { returnTo: window.location.origin + returnTo } })}
+    >
       Log in
     </Button>
   );

--- a/apps/app/src/views/components/Auth.tsx
+++ b/apps/app/src/views/components/Auth.tsx
@@ -30,10 +30,7 @@ export const Auth = (props: AuthProps) => {
     );
 
   return (
-    <Button
-      colorScheme="blue"
-      onClick={() => login({ appState: { returnTo: window.location.origin + returnTo } })}
-    >
+    <Button colorScheme="blue" onClick={() => login({ appState: { returnTo } })}>
       Log in
     </Button>
   );

--- a/apps/app/src/views/routes/Login.tsx
+++ b/apps/app/src/views/routes/Login.tsx
@@ -41,7 +41,7 @@ export const Login = () => {
     return <Navigate to="/" replace />;
   }
 
-  const from = `${(location.state?.from?.pathname || '/') + (location.state?.from?.search || '')}`;
+  const from = `${(location.pathname || '/') + (location.search || '')}`;
 
   return (
     <Container maxW="md" py={{ base: '12', md: '24' }}>

--- a/apps/app/src/views/routes/Login.tsx
+++ b/apps/app/src/views/routes/Login.tsx
@@ -41,8 +41,6 @@ export const Login = () => {
     return <Navigate to="/" replace />;
   }
 
-  const from = `${(location.pathname || '/') + (location.search || '')}`;
-
   return (
     <Container maxW="md" py={{ base: '12', md: '24' }}>
       <Stack spacing="8">
@@ -79,7 +77,7 @@ export const Login = () => {
           </Stack>
         </Stack>
         <Stack spacing="4">
-          <Auth returnTo={from} />
+          <Auth returnTo={location.state?.returnTo} />
         </Stack>
       </Stack>
     </Container>

--- a/apps/app/src/views/routes/Main.tsx
+++ b/apps/app/src/views/routes/Main.tsx
@@ -82,17 +82,15 @@ export const Main = () => {
   }
 
   if (!isAuthenticated && !isLoading) {
-    const pathname = query.get('pathname');
+    const pathname = location.pathname;
     const queryString = query.toString() ? `?${query.toString()}` : '';
 
     return (
       <Navigate
         to={`/login${queryString}`}
         state={{
-          from: {
-            ...location,
-            ...(pathname ? { pathname } : {})
-          }
+          from: { location },
+          returnTo: `${pathname}${queryString}`
         }}
         replace
       />

--- a/packages/react/src/provider.tsx
+++ b/packages/react/src/provider.tsx
@@ -736,13 +736,6 @@ export const PhotonProvider = (opts: {
   const handleRedirect = useCallback(
     async (url?: string) => {
       try {
-        // eslint-disable-next-line no-debugger
-        debugger;
-        console.log('\n       url: ', url);
-
-        // eslint-disable-next-line no-debugger
-        debugger;
-
         await client.authentication.handleRedirect(url);
       } catch (e) {
         const message = (e as Error).message;

--- a/packages/react/src/provider.tsx
+++ b/packages/react/src/provider.tsx
@@ -714,7 +714,7 @@ export const PhotonProvider = (opts: {
       if (client.authentication.hasAuthParams()) {
         try {
           // @ts-ignore
-          const { appState } = await client.authentication.handleRedirect();
+          const { appState } = await client.authentication.handleRedirect(state?.returnTo);
           onRedirectCallback(appState);
         } catch (e) {
           const message = (e as Error).message;
@@ -736,6 +736,13 @@ export const PhotonProvider = (opts: {
   const handleRedirect = useCallback(
     async (url?: string) => {
       try {
+        // eslint-disable-next-line no-debugger
+        debugger;
+        console.log('\n       url: ', url);
+
+        // eslint-disable-next-line no-debugger
+        debugger;
+
         await client.authentication.handleRedirect(url);
       } catch (e) {
         const message = (e as Error).message;

--- a/packages/sdk/src/auth.ts
+++ b/packages/sdk/src/auth.ts
@@ -154,7 +154,7 @@ export class AuthManager {
       const redirectOpts: RedirectLoginOptions = {
         ...opts,
         appState: {
-          returnTo: window.location.pathname + window.location.search
+          returnTo: `${window.location.pathname}${window.location.search}`
         }
       };
       await this.authentication.loginWithRedirect(redirectOpts);

--- a/packages/sdk/src/auth.ts
+++ b/packages/sdk/src/auth.ts
@@ -151,7 +151,13 @@ export class AuthManager {
       }
     }
     if (!token) {
-      await this.authentication.loginWithRedirect(opts);
+      const redirectOpts: RedirectLoginOptions = {
+        ...opts,
+        appState: {
+          returnTo: window.location.pathname + window.location.search
+        }
+      };
+      await this.authentication.loginWithRedirect(redirectOpts);
       if (throwIfFailure) {
         throw new Error(); // Needed just because this needs to resolve to something
       } else {


### PR DESCRIPTION
for this ticket: https://www.notion.so/photons/URL-params-not-persisted-on-redirect-1288bfbbf4ec8055b43bf981aa95df6e


session expires while url contains search params: user gets returned to url with search params after logging back in
user goes to the login page: user is direct to `/prescriptions` after login
user is logged out and tries to access url with search params: user is directed to that url with search params after login
session expires while patient is at `/patients`: user is returned to `/patients` after logging back in