### PR TITLE
Disallow routing to the same pharmacy

### DIFF
--- a/apps/patient/src/components/PharmacyCard.tsx
+++ b/apps/patient/src/components/PharmacyCard.tsx
@@ -19,7 +19,7 @@ interface PharmacyCardProps {
   selectable?: boolean;
   showDetails?: boolean;
   showPrice?: boolean;
-  currentPharmacy?: boolean;
+  isCurrentPharmacy?: boolean;
 }
 
 export const PharmacyCard = memo(function PharmacyCard({
@@ -32,22 +32,22 @@ export const PharmacyCard = memo(function PharmacyCard({
   selectable = false,
   showDetails = true,
   showPrice = false,
-  currentPharmacy = false
+  isCurrentPharmacy = false
 }: PharmacyCardProps) {
   if (!pharmacy) return null;
 
   return (
     <Card
-      bgColor={currentPharmacy ? 'gray.200' : 'white'}
+      bgColor={isCurrentPharmacy ? 'gray.200' : 'white'}
       borderWidth={selected ? '2px' : '1px'}
-      borderColor={selected && onSelect ? 'brand.500' : currentPharmacy ? 'gray.300' : 'gray.100'}
-      shadow={currentPharmacy ? 'none' : undefined}
+      borderColor={selected && onSelect ? 'brand.500' : isCurrentPharmacy ? 'gray.300' : 'gray.100'}
+      shadow={isCurrentPharmacy ? 'none' : undefined}
       borderRadius="lg"
       onClick={() => onSelect && onSelect()}
       mx={{ base: -3, md: undefined }}
       cursor={selectable ? 'pointer' : undefined}
-      pointerEvents={currentPharmacy ? 'none' : undefined}
-      opacity={currentPharmacy ? 0.7 : undefined}
+      pointerEvents={isCurrentPharmacy ? 'none' : undefined}
+      opacity={isCurrentPharmacy ? 0.7 : undefined}
     >
       <CardBody p={3}>
         <PharmacyInfo
@@ -57,7 +57,7 @@ export const PharmacyCard = memo(function PharmacyCard({
           showPrice={showPrice}
           boldPharmacyName={false}
           selected={selected}
-          currentPharmacy={currentPharmacy}
+          isCurrentPharmacy={isCurrentPharmacy}
         />
       </CardBody>
       {showDetails ? (

--- a/apps/patient/src/components/PharmacyCard.tsx
+++ b/apps/patient/src/components/PharmacyCard.tsx
@@ -19,6 +19,7 @@ interface PharmacyCardProps {
   selectable?: boolean;
   showDetails?: boolean;
   showPrice?: boolean;
+  currentPharmacy?: boolean;
 }
 
 export const PharmacyCard = memo(function PharmacyCard({
@@ -30,19 +31,23 @@ export const PharmacyCard = memo(function PharmacyCard({
   onSetPreferred,
   selectable = false,
   showDetails = true,
-  showPrice = false
+  showPrice = false,
+  currentPharmacy = false
 }: PharmacyCardProps) {
   if (!pharmacy) return null;
 
   return (
     <Card
-      bgColor="white"
-      border="2px solid"
-      borderColor={selected && onSelect ? 'brand.500' : 'white'}
+      bgColor={currentPharmacy ? 'gray.200' : 'white'}
+      borderWidth={selected ? '2px' : '1px'}
+      borderColor={selected && onSelect ? 'brand.500' : currentPharmacy ? 'gray.300' : 'gray.100'}
+      shadow={currentPharmacy ? 'none' : undefined}
       borderRadius="lg"
       onClick={() => onSelect && onSelect()}
       mx={{ base: -3, md: undefined }}
       cursor={selectable ? 'pointer' : undefined}
+      pointerEvents={currentPharmacy ? 'none' : undefined}
+      opacity={currentPharmacy ? 0.7 : undefined}
     >
       <CardBody p={3}>
         <PharmacyInfo
@@ -52,6 +57,7 @@ export const PharmacyCard = memo(function PharmacyCard({
           showPrice={showPrice}
           boldPharmacyName={false}
           selected={selected}
+          currentPharmacy={currentPharmacy}
         />
       </CardBody>
       {showDetails ? (

--- a/apps/patient/src/components/PharmacyInfo.tsx
+++ b/apps/patient/src/components/PharmacyInfo.tsx
@@ -212,6 +212,7 @@ interface PharmacyInfoProps {
   isStatus?: boolean;
   selected?: boolean;
   showHours?: boolean;
+  currentPharmacy?: boolean;
 }
 
 export const PharmacyInfo = ({
@@ -224,7 +225,8 @@ export const PharmacyInfo = ({
   freeDelivery = false,
   boldPharmacyName = true,
   isStatus = false,
-  showHours = false
+  showHours = false,
+  currentPharmacy = false
 }: PharmacyInfoProps) => {
   if (!pharmacy) return null;
 
@@ -312,6 +314,19 @@ export const PharmacyInfo = ({
             showHours={showHours}
           />
         </VStack>
+      ) : null}
+      {currentPharmacy ? (
+        <Tag
+          size="md"
+          bgColor="red.50"
+          color="red.600"
+          borderColor="red.200"
+          borderRadius="full"
+          borderWidth="1px"
+          mb={1}
+        >
+          <TagLabel fontWeight="bold">Current Pharmacy</TagLabel>
+        </Tag>
       ) : null}
     </VStack>
   );

--- a/apps/patient/src/components/PharmacyInfo.tsx
+++ b/apps/patient/src/components/PharmacyInfo.tsx
@@ -212,7 +212,7 @@ interface PharmacyInfoProps {
   isStatus?: boolean;
   selected?: boolean;
   showHours?: boolean;
-  currentPharmacy?: boolean;
+  isCurrentPharmacy?: boolean;
 }
 
 export const PharmacyInfo = ({
@@ -226,7 +226,7 @@ export const PharmacyInfo = ({
   boldPharmacyName = true,
   isStatus = false,
   showHours = false,
-  currentPharmacy = false
+  isCurrentPharmacy = false
 }: PharmacyInfoProps) => {
   if (!pharmacy) return null;
 
@@ -315,7 +315,7 @@ export const PharmacyInfo = ({
           />
         </VStack>
       ) : null}
-      {currentPharmacy ? (
+      {isCurrentPharmacy ? (
         <Tag
           size="md"
           bgColor="red.50"

--- a/apps/patient/src/components/PickupOptions.tsx
+++ b/apps/patient/src/components/PickupOptions.tsx
@@ -171,7 +171,7 @@ export const PickupOptions = ({
               onSetPreferred={() => handleSetPreferred(pharmacy.id)}
               selectable={true}
               showPrice
-              currentPharmacy={pharmacy.id === currentPharmacyId}
+              isCurrentPharmacy={pharmacy.id === currentPharmacyId}
             />
           </SlideFade>
         ))}

--- a/apps/patient/src/components/PickupOptions.tsx
+++ b/apps/patient/src/components/PickupOptions.tsx
@@ -75,6 +75,7 @@ interface PickupOptionsProps {
   setEnableOpenNow: (isOpen: boolean) => void;
   setEnable24Hr: (is24Hr: boolean) => void;
   location: string;
+  currentPharmacyId?: string;
 }
 
 export const PickupOptions = ({
@@ -92,7 +93,8 @@ export const PickupOptions = ({
   enableOpenNow,
   enable24Hr,
   setEnableOpenNow,
-  setEnable24Hr
+  setEnable24Hr,
+  currentPharmacyId
 }: PickupOptionsProps) => {
   return (
     <VStack spacing={3} align="span" w="full">
@@ -169,6 +171,7 @@ export const PickupOptions = ({
               onSetPreferred={() => handleSetPreferred(pharmacy.id)}
               selectable={true}
               showPrice
+              currentPharmacy={pharmacy.id === currentPharmacyId}
             />
           </SlideFade>
         ))}

--- a/apps/patient/src/views/Pharmacy.tsx
+++ b/apps/patient/src/views/Pharmacy.tsx
@@ -812,6 +812,7 @@ export const Pharmacy = () => {
               enable24Hr={enable24Hr}
               setEnableOpenNow={setEnableOpenNow}
               setEnable24Hr={setEnable24Hr}
+              currentPharmacyId={order.pharmacy?.id}
             />
           </VStack>
         ) : null}


### PR DESCRIPTION
[Eng ticket](https://www.notion.so/photons/Disallow-rerouting-to-the-same-pharmacy-892bce0804624bf8a33d50627d4fe7d1)

Allowing routing to the same pharmacy creates unnecessary ops costs, this disables that.

Example:

<img width="319" alt="image" src="https://github.com/user-attachments/assets/84b3aa3f-b9cd-4ee8-a553-ca5fc4528494">
