### PR TITLE
Display default info for mail order pharmacy, move tracking link into the pharmcy info section

### DIFF
--- a/apps/patient/src/components/PharmacyInfo.tsx
+++ b/apps/patient/src/components/PharmacyInfo.tsx
@@ -3,6 +3,7 @@ import {
   HStack,
   IconButton,
   Image,
+  Link,
   Spacer,
   Tag,
   TagLabel,
@@ -14,12 +15,13 @@ import dayjs from 'dayjs';
 import customParseFormat from 'dayjs/plugin/customParseFormat';
 import { FiStar } from 'react-icons/fi';
 import { useLocation } from 'react-router-dom';
-import { Address, EnrichedPharmacy } from '../utils/models';
+import { Address, EnrichedPharmacy, OrderFulfillment } from '../utils/models';
 import { text as t } from '../utils/text';
 
 import { useMemo, useState } from 'react';
 import { IoChevronDownOutline, IoChevronUpOutline } from 'react-icons/io5';
 import { formatAddress, titleCase } from '../utils/general';
+import { getFulfillmentTrackingLink } from '../utils/fulfillmentsHelpers';
 
 dayjs.extend(customParseFormat);
 
@@ -213,6 +215,7 @@ interface PharmacyInfoProps {
   selected?: boolean;
   showHours?: boolean;
   isCurrentPharmacy?: boolean;
+  orderFulfillment?: OrderFulfillment;
 }
 
 export const PharmacyInfo = ({
@@ -226,7 +229,8 @@ export const PharmacyInfo = ({
   boldPharmacyName = true,
   isStatus = false,
   showHours = false,
-  isCurrentPharmacy = false
+  isCurrentPharmacy = false,
+  orderFulfillment
 }: PharmacyInfoProps) => {
   if (!pharmacy) return null;
 
@@ -238,6 +242,9 @@ export const PharmacyInfo = ({
   const showFreeDeliveryTag = freeDelivery;
   const whiteLabelDeliveryPharmacy =
     pharmacy.name === 'Capsule Pharmacy' && location.pathname === '/pharmacy';
+
+  const trackingLink = orderFulfillment && getFulfillmentTrackingLink(orderFulfillment);
+
   return (
     <VStack align="start" w="full">
       {showPreferredTag ||
@@ -328,6 +335,22 @@ export const PharmacyInfo = ({
           <TagLabel fontWeight="bold">Current Pharmacy</TagLabel>
         </Tag>
       ) : null}
+      {trackingLink && (
+        <HStack spacing={0}>
+          <Text>Tracking #:</Text>
+          <Link
+            href={trackingLink}
+            display="inline"
+            color="link"
+            fontWeight="medium"
+            target="_blank"
+            data-dd-privacy="mask"
+            ms={2}
+          >
+            {orderFulfillment.carrier} {orderFulfillment.trackingNumber}
+          </Link>
+        </HStack>
+      )}
     </VStack>
   );
 };

--- a/apps/patient/src/views/Pharmacy.tsx
+++ b/apps/patient/src/views/Pharmacy.tsx
@@ -142,7 +142,7 @@ export const Pharmacy = () => {
       // demo pharmacies already are prepared
       return combined;
     }
-    return combined.map(preparePharmacy);
+    return combined.map((combinedItem) => preparePharmacy(combinedItem));
   }, [isDemo, pharmacyResults, topRankedPharmacies]);
 
   // capsule

--- a/apps/patient/src/views/StatusV2.tsx
+++ b/apps/patient/src/views/StatusV2.tsx
@@ -217,13 +217,13 @@ export const StatusV2 = () => {
 
         <Container>
           <VStack spacing={6}>
-            <VStack w="full" alignItems="stretch" spacing={4}>
-              <Heading as="h4" size="md">
-                Pharmacy
-              </Heading>
-              <Card>
-                <VStack w="full" spacing={0}>
-                  {displayPharmacy && (
+            {displayPharmacy && (
+              <VStack w="full" alignItems="stretch" spacing={4}>
+                <Heading as="h4" size="md">
+                  Pharmacy
+                </Heading>
+                <Card>
+                  <VStack w="full" spacing={0}>
                     <PharmacyInfo
                       pharmacy={displayPharmacy}
                       showDetails={!isDeliveryPharmacy}
@@ -231,14 +231,14 @@ export const StatusV2 = () => {
                       orderFulfillment={fulfillment}
                       isStatus
                     />
-                  )}
-                  <VStack spacing={2} w="full">
-                    {displayPharmacy && !isDeliveryPharmacy && navigateButton}
-                    {!isDeliveryPharmacy && displayPharmacy && canReroute && rerouteButton}
+                    <VStack spacing={2} w="full">
+                      {displayPharmacy && !isDeliveryPharmacy && navigateButton}
+                      {!isDeliveryPharmacy && displayPharmacy && canReroute && rerouteButton}
+                    </VStack>
                   </VStack>
-                </VStack>
-              </Card>
-            </VStack>
+                </Card>
+              </VStack>
+            )}
 
             <OrderSummary
               fulfillments={fulfillments}


### PR DESCRIPTION
We currently don't have any default behavior for mail order pharmacies that don't have any information in the `PHARMACY_BRANDING` constant. 

## Before
<img width="544" alt="Screenshot 2024-12-04 at 10 31 02 AM" src="https://github.com/user-attachments/assets/de4bf1cd-3c53-4b9c-896b-301c94390672">


## After
<img width="476" alt="Screenshot 2024-12-04 at 12 11 13 PM" src="https://github.com/user-attachments/assets/4014888f-82d4-4d90-9c1f-05e3a50640bc">
<img width="408" alt="Screenshot 2024-12-04 at 12 26 35 PM" src="https://github.com/user-attachments/assets/3e023bb0-1fa1-43cb-9812-c1cbae753722">
<img width="411" alt="Screenshot 2024-12-04 at 12 11 23 PM" src="https://github.com/user-attachments/assets/c2c15c53-8263-41b3-9fca-bd426f92cc0e">

