### PR TITLE
Fix Race Condition between getting a patient and creating an order

### DIFF
--- a/packages/elements/index.html
+++ b/packages/elements/index.html
@@ -18,7 +18,6 @@
     >
       <div style="padding: 15px">
         <photon-prescribe-workflow
-          patient-id="pat_01GQ0XFBHSH3YXN936A2D2SD7Y"
           enable-order="true"
           enable-send-to-patient="true"
           enable-local-pickup="true"

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@photonhealth/elements",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "description": "",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/elements/src/photon-multirx-form/photon-prescribe-workflow.tsx
+++ b/packages/elements/src/photon-multirx-form/photon-prescribe-workflow.tsx
@@ -348,7 +348,7 @@ export function PrescribeWorkflow(props: PrescribeProps) {
           effectiveDate: draft.effectiveDate,
           instructions: draft.instructions,
           notes: draft.notes,
-          patientId: props.formStore.patient?.value.id,
+          patientId: props?.patientId || props.formStore.patient?.value.id,
           // +1 here because we're using the refillsInput
           fillsAllowed: draft.refillsInput ? draft.refillsInput + 1 : 1,
           treatmentId: draft.treatment.id,
@@ -422,7 +422,7 @@ export function PrescribeWorkflow(props: PrescribeProps) {
           const { data: orderData, errors } = await orderMutation({
             variables: {
               ...(props.externalOrderId ? { externalId: props.externalOrderId } : {}),
-              patientId: props.formStore.patient?.value.id,
+              patientId: props?.patientId || props.formStore.patient?.value.id,
               pharmacyId: props?.pharmacyId || props.formStore.pharmacy?.value || '',
               fulfillmentType: props.formStore.fulfillmentType?.value || '',
               address: formattedAddress(),

--- a/packages/elements/src/photon-multirx-form/photon-prescribe-workflow.tsx
+++ b/packages/elements/src/photon-multirx-form/photon-prescribe-workflow.tsx
@@ -348,7 +348,7 @@ export function PrescribeWorkflow(props: PrescribeProps) {
           effectiveDate: draft.effectiveDate,
           instructions: draft.instructions,
           notes: draft.notes,
-          patientId: props?.patientId || props.formStore.patient?.value.id,
+          patientId: props?.patientId ?? props.formStore.patient?.value.id,
           // +1 here because we're using the refillsInput
           fillsAllowed: draft.refillsInput ? draft.refillsInput + 1 : 1,
           treatmentId: draft.treatment.id,
@@ -422,8 +422,8 @@ export function PrescribeWorkflow(props: PrescribeProps) {
           const { data: orderData, errors } = await orderMutation({
             variables: {
               ...(props.externalOrderId ? { externalId: props.externalOrderId } : {}),
-              patientId: props?.patientId || props.formStore.patient?.value.id,
-              pharmacyId: props?.pharmacyId || props.formStore.pharmacy?.value || '',
+              patientId: props?.patientId ?? props.formStore.patient?.value.id,
+              pharmacyId: props?.pharmacyId ?? (props.formStore.pharmacy?.value || ''),
               fulfillmentType: props.formStore.fulfillmentType?.value || '',
               address: formattedAddress(),
               fills: prescriptionData?.createPrescriptions.map((x) => ({ prescriptionId: x.id }))


### PR DESCRIPTION
[Example situation](https://app.datadoghq.com/logs?query=env%3Aphoton%20-%40identity.claims.http%5C%3A%2F%2Fphoton.health%2Forg_id%3Aorg_Oxc0CSPfdiyWW3VM%20source%3Alambda%20-service%3A%28events%20OR%20admin%20OR%20state-machine-executors%29%20functionname%3A%28create_prescriptions%20OR%20get_patient%29&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice%2Cfunctionname&fromUser=true&graphType=flamegraph&messageDisplay=inline&refresh_mode=paused&sort=time&storage=hot&stream_sort=desc&viz=stream&from_ts=1733818056335&to_ts=1733818058552&live=false) showing that there is a second difference between the get_patient request and the create_order request.

This resulted in the cached patient from a previous order being erroneously set to the new order.