### PR TITLE
Add provider and date to duplicate order modal

### DIFF
--- a/packages/components/src/systems/RecentOrders/RecentOrders.tsx
+++ b/packages/components/src/systems/RecentOrders/RecentOrders.tsx
@@ -36,6 +36,12 @@ const GetPatientOrdersQuery = gql`
             dispenseUnit
             fillsAllowed
             instructions
+            writtenAt
+            prescriber {
+              name {
+                full
+              }
+            }
           }
         }
       }
@@ -51,7 +57,7 @@ type GetPatientOrdersVars = {
 type Treatment = Pick<FullFill['treatment'], 'name'>;
 type Prescription = Pick<
   FullPrescription,
-  'dispenseQuantity' | 'dispenseUnit' | 'fillsAllowed' | 'instructions'
+  'dispenseQuantity' | 'dispenseUnit' | 'fillsAllowed' | 'instructions' | 'writtenAt' | 'prescriber'
 >;
 type Fill = {
   treatment: Treatment;

--- a/packages/components/src/systems/RecentOrders/RecentOrdersDuplicateDialog.tsx
+++ b/packages/components/src/systems/RecentOrders/RecentOrdersDuplicateDialog.tsx
@@ -54,6 +54,10 @@ export default function RecentOrdersDuplicateDialog() {
               instructions: state?.duplicateFill?.prescription?.instructions
             })}
           </Text>
+          <Text size="sm" color="gray">
+            Written by {state?.duplicateFill?.prescription?.prescriber?.name?.full} on{' '}
+            {new Date(state?.duplicateFill?.prescription?.writtenAt).toLocaleDateString()}
+          </Text>
         </div>
 
         <div class="flex flex-col items-stretch gap-4">


### PR DESCRIPTION
[Ref this ticket](https://www.notion.so/photons/Investigate-Duplicate-Orders-Potentially-Update-Logic-1528bfbbf4ec80b69129ea041681e9f6?pvs=4)

I’ve confirmed that the duplicate modal is displaying between different providers with the same organization.
My thinking is to add the provider name and date to the modal to make it very clear that it was prescribed perhaps by someone else and when.


Before:
<img width="286" alt="Screen Shot 2024-12-19 at 4 08 24 PM" src="https://github.com/user-attachments/assets/975ec210-a34e-428c-add1-7b2bcadec0a5" />

After: 
<img width="336" alt="Screen Shot 2024-12-19 at 4 26 26 PM" src="https://github.com/user-attachments/assets/5e5c245b-e4a6-4fb2-b08d-859f945c7b6f" />
