### PR TITLE
Fix Dosing Calculator Alignment in Add Prescription Card

### DIFF
--- a/packages/elements/src/photon-multirx-form/components/AddPrescriptionCard.tsx
+++ b/packages/elements/src/photon-multirx-form/components/AddPrescriptionCard.tsx
@@ -399,7 +399,7 @@ export const AddPrescriptionCard = (props: {
                   style={{
                     // ya, it ain't pretty, but it works. just need it for a lil bit longer
                     height: '40px',
-                    'margin-top': '34px'
+                    'margin-top': '32px'
                   }}
                 >
                   <Icon name="calculator" size="sm" />


### PR DESCRIPTION
## Before 
<img width="533" alt="Screenshot 2025-01-14 at 5 12 34 PM" src="https://github.com/user-attachments/assets/59069a8f-90ef-4be1-9450-04e912ae6d3a" />


## After
<img width="537" alt="Screenshot 2025-01-14 at 5 05 15 PM" src="https://github.com/user-attachments/assets/de948c38-8c89-4817-bc1b-3900cf1304fd" />

