### PR TITLE
possibly fixing issue with optional dependency

### DIFF
--- a/packages/sdk/project.json
+++ b/packages/sdk/project.json
@@ -11,6 +11,9 @@
         "cwd": "packages/sdk",
         "commands": [
           "rimraf dist",
+          "rimraf node_modules",
+          "rimraf package-lock.json",
+          "npm install",
           "tsc --emitDeclarationOnly --outDir dist",
           "vite build",
           "cp src/types.ts dist/types.ts"


### PR DESCRIPTION
publishing a new version of elements is failing due to the legitimate issue discussed here https://github.com/npm/cli/issues/4828

for the error message check these logs https://github.com/Photon-Health/client/actions/runs/13295335704/job/37125969289#step:7:80

this PR modifies the failing step in the way the error says to get past this error