### PR TITLE
Fix stale patient data being sent with new orders

### DIFF
--- a/packages/elements/index.html
+++ b/packages/elements/index.html
@@ -5,6 +5,26 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Photon Components</title>
     <script src="./src/index.ts" type="module"></script>
+
+    <script>
+      window.addEventListener('photon-order-created', (e) => {
+        console.log(e);
+        const parent = document.getElementById('parent');
+        const one = document.getElementById('one');
+        one.remove();
+
+        const two = document.createElement('photon-prescribe-workflow');
+        two.id = 'two';
+        two.patientId = 'pat_01J8T7B7WF4YSSQX526MR0S0RM';
+        two.pharmacyId = 'phr_01GA9HPXAF9BC9PC8XM25Q836N';
+        two.templateIds = 'tmp_01HF7H3J7J37458TEMT6R8JW84';
+        two.enableOrder = true;
+        two.hideTemplates = true;
+        setTimeout(() => {
+          parent.appendChild(two);
+        }, 1000);
+      });
+    </script>
   </head>
   <body style="margin: 0px">
     <photon-client
@@ -16,16 +36,13 @@
       uri="https://api.boson.health/graphql"
       auto-login="true"
     >
-      <div style="padding: 15px">
+      <div style="padding: 15px" id="parent">
         <photon-prescribe-workflow
           enable-order="true"
-          enable-send-to-patient="true"
-          enable-local-pickup="true"
-          enable-med-history="true"
-          enable-new-medication-search="true"
-          mail-order-ids="phr_01GA9HPVBVJ0E65P819FD881N0,phr_01GCA54GVKA06C905DETQ9SY98"
-          additional-notes="Some additional notes to add to the message."
-          weight="23"
+          hide-templates="true"
+          pharmacy-id="phr_01GA9HPXAF9BC9PC8XM25Q836N"
+          template-ids="tmp_01J6DBEHZX11BPMY38G9PWASMH"
+          id="one"
         ></photon-prescribe-workflow>
       </div>
     </photon-client>

--- a/packages/elements/index.html
+++ b/packages/elements/index.html
@@ -15,7 +15,7 @@
 
         const two = document.createElement('photon-prescribe-workflow');
         two.id = 'two';
-        two.patientId = 'pat_01J8T7B7WF4YSSQX526MR0S0RM';
+        two.patientId = 'pat_01JGQ28XABSJGGJ7DRGZDB95X4';
         two.pharmacyId = 'phr_01GA9HPXAF9BC9PC8XM25Q836N';
         two.templateIds = 'tmp_01HF7H3J7J37458TEMT6R8JW84';
         two.enableOrder = true;
@@ -38,6 +38,7 @@
     >
       <div style="padding: 15px" id="parent">
         <photon-prescribe-workflow
+          patient-id="pat_01JBHGD32EDTC0RAHC5CY39K85"
           enable-order="true"
           hide-templates="true"
           pharmacy-id="phr_01GA9HPXAF9BC9PC8XM25Q836N"

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@photonhealth/elements",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "description": "",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@photonhealth/elements",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/elements/src/photon-multirx-form/components/PatientCard.tsx
+++ b/packages/elements/src/photon-multirx-form/components/PatientCard.tsx
@@ -84,7 +84,8 @@ export const PatientCard = (props: {
   });
 
   const currentPatientId = createMemo(
-    () => (props.store.patient?.value?.id as string) || props?.patientId
+    // prefer the passed-in patientId if it exists
+    () => props?.patientId || (props.store.patient?.value?.id as string)
   );
 
   // Listen for changes to the patient

--- a/packages/elements/src/photon-multirx-form/photon-prescribe-workflow.tsx
+++ b/packages/elements/src/photon-multirx-form/photon-prescribe-workflow.tsx
@@ -488,6 +488,14 @@ export function PrescribeWorkflow(props: PrescribeProps) {
 
   let prescriptionRef: HTMLDivElement | undefined;
 
+  const hasCorrectPatientData = createMemo(() => {
+    return (
+      !props.patientId ||
+      props.patientId === props.formStore.patient?.value?.id ||
+      props.patientId === props.formStore.patient?.value?.externalId
+    );
+  });
+
   return (
     <div ref={ref}>
       <style>{tailwind}</style>
@@ -580,8 +588,13 @@ export function PrescribeWorkflow(props: PrescribeProps) {
               />
               <Show
                 when={
-                  props.formStore.patient?.value?.address ||
-                  (props.formStore.patient?.value?.id && !props.enableOrder)
+                  // if patientId is passed in, we need to ensure it matches the patient id in our store
+                  // so we are not referencing stale data
+                  hasCorrectPatientData() &&
+                  // if orders are enabled, we need a patient's address
+                  (props.formStore.patient?.value?.address ||
+                    // if orders are disabled, we need only a patient id
+                    (props.formStore.patient?.value?.id && !props.enableOrder))
                 }
               >
                 <Show when={props.enableCombineAndDuplicate}>


### PR DESCRIPTION
https://photonhealth.slack.com/archives/C03TRQ4NLE5/p1739919711496799

Stale customer data can be sent in orders while the new patient information is being fetched. Previous attempts [here](https://github.com/Photon-Health/client/pull/1518/files) and here with [the action reset](https://github.com/Photon-Health/client/pull/1528/files).

This also seems to fix an issue we've been seeing[ in our data](https://www.notion.so/photons/We-get-warnings-Fill-s-for-one-or-more-prescriptions-do-not-belong-to-patient-pat_-provided-on-t-19f8bfbbf4ec80aabdcceb79e69238d3?pvs=4):
<img width="481" alt="Screenshot 2025-02-21 at 3 08 47 PM" src="https://github.com/user-attachments/assets/b4de322d-49d1-497d-b15a-aa171c701e9b" />
