### PR TITLE
showing branded options if `amazonPharmacyEndOfPharmacyTestSegment` experiment is active

### DIFF
--- a/apps/patient/src/views/Pharmacy.tsx
+++ b/apps/patient/src/views/Pharmacy.tsx
@@ -862,7 +862,7 @@ export const Pharmacy = () => {
       <Container pb={showFooter ? 32 : 8}>
         {location ? (
           <VStack spacing={6} align="stretch" pt={4}>
-            {enableCourier || enableMailOrder ? (
+            {enableCourier || enableMailOrder || amazonPharmacyEndOfPharmacyTestSegment ? (
               <BrandedOptions
                 options={brandedOptions}
                 location={location}


### PR DESCRIPTION
people who should have the experiment active are not seeing amazon as an option, i suspect this is why