### PR TITLE
PatientMedHistory shows prescription details

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 <a alt="photon logo" href="https://nx.dev" target="_blank" rel="noreferrer"><img src="https://uploads-ssl.webflow.com/636c1da7b9e42c43e229900c/636c1da7b9e42caa79299017_header-logo.svg" width="100"></a>
 
-## Getting started
+## Local Development
+
+### Get started
 
 Install it all
 
@@ -16,17 +18,33 @@ In the root of this folder, look for your target in `apps/` or `packages/` and r
 npx nx run [project][:target][:configuration] [_..]
 ```
 
-For example, run a target for a app:
+For example, run an `app` target:
 
 ```
 npx nx run app:start
 ```
 
-or
+or, run an `elements` target:
 
 ```
-npx nx run elements:upload-s3:dist
+npx nx run elements:lint:only-errors
 ```
+
+### Run clinical app
+
+See [app README](apps/app/README.md)
+
+### Run patient app
+
+See [app README](apps/patient/README.md)
+
+### Run components storybook
+
+See [components README](packages/components/README.md)
+
+### Run embeddable components
+
+See [elements README](packages/elements/README.md)
 
 ## Remote caching
 

--- a/apps/app/README.md
+++ b/apps/app/README.md
@@ -1,39 +1,54 @@
 # Photon Clinical App
 
-## Scripts
+## Local Development
 
-### `npm start`
+### Run against Boson services
 
-Runs the app in the development mode.\
-Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
+> Runs against remote Boson environment services
 
-The page will reload if you make edits.\
-You will also see any lint errors in the console.
+`npx nx run app:start`
 
-### `npm test`
 
-Launches the test runner in the interactive watch mode.\
-See the section about [running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.
+### Run against local "Tau" services
 
-### `npm test -- -u`
+> Must be running [tau services](https://github.com/Photon-Health/services) locally
 
-Update test snapshots
+`npx nx run app:start:tau`
 
-### `npm test -- --coverage`
+### Tests
 
-Generate test coverage report
+`npx nx run app:test`
 
-### `npm run lint`
 
-Run ESLint manually, `:fix` will automatically make any possible fixes.
+Update test snapshots:
 
-### `npm run format`
+`npx nx run app:test -- -u`
 
-Format files via Prettier.
 
-### `npm run build`
+Generate test coverage report:
 
-Builds the app for production to the `build` folder.\
+`npx nx run app:test -- --coverage`
+
+### Linting
+
+Run ESLint manually:
+
+`npx nx run app:lint`
+
+Automatically fix ESLint issues:
+
+`npx nx run app:lint:fix` 
+
+
+### Build
+
+`npx nx run app:build:boson`
+
+`npx nx run app:build:neutron`
+
+`npx nx run app:build:photon`
+
+Builds the app for each environment into the `build` folder.\
 It correctly bundles React in production mode and optimizes the build for the best performance.
 
 The build is minified and the filenames include the hashes.

--- a/packages/components/.storybook/main.js
+++ b/packages/components/.storybook/main.js
@@ -1,9 +1,15 @@
 const { mergeConfig } = require('vite');
+const path = require('path');
 
 module.exports = {
   async viteFinal(config, { configType }) {
     return mergeConfig(config, {
-      define: { 'process.env': {} }
+      define: { 'process.env': {} },
+      resolve: {
+        alias: {
+          '@photonhealth/sdk': path.resolve(__dirname, '../../../packages/sdk')
+        }
+      }
     });
   },
   stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|ts|tsx)'],

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -1,15 +1,27 @@
 # Components
 
-## Storybook
+## Local Development
 
-Run Storybook and then have a look at "particles" at `localhost:6006`
+### particles
 
-```
+Run Storybook to see the `particles` at `localhost:6006`:
+
+```shell
 npm run storybook
+
+# or via nx
+npx nx run components:storybook
 ```
 
-Run the local app to see many of the "systems" in action at `localhost:3000`.
+### systems
 
-```
+Run the local app to see the `systems` in action at `localhost:3000`:
+
+```shell
 npm run start
+
+# or via nx
+npx nx run components:start
 ```
+
+Modify [dev/App.tsx](dev/App.tsx) to change the `systems`

--- a/packages/components/dev/App.tsx
+++ b/packages/components/dev/App.tsx
@@ -16,6 +16,8 @@ import AddressForm from '../src/systems/AddressForm';
 
 const draftPrescriptions: DraftPrescription[] = [
   {
+    name: 'Metropolol Draft',
+    isPrivate: false,
     id: '1',
     effectiveDate: '2021-01-01',
     treatment: {
@@ -41,6 +43,8 @@ const draftPrescriptions: DraftPrescription[] = [
     catalogId: 'catalogId'
   },
   {
+    name: 'Metropolol Draft 2',
+    isPrivate: false,
     id: '2',
     effectiveDate: '2021-01-01',
     treatment: {
@@ -117,7 +121,7 @@ const App = () => {
 
         <div class="mb-10">
           <h2>Patient Med History</h2>
-          <PatientMedHistory patientId="pat_01GQ0XFBHSH3YXN936A2D2SD7Y" />
+          <PatientMedHistory patientId="pat_01GQ0XFBHSH3YXN936A2D2SD7Y" enableLinks={false} />
         </div>
 
         <div class="mb-10">
@@ -125,11 +129,13 @@ const App = () => {
           <DraftPrescriptions
             draftPrescriptions={draftPrescriptions}
             setDraftPrescriptions={setDraftPrescriptions}
+            screeningAlerts={[]}
           />
           <h2>Fetching Draft Presciptions</h2>
           <DraftPrescriptions
             draftPrescriptions={draftPrescriptionsFromTemplates()}
             setDraftPrescriptions={setDraftPrescriptions}
+            screeningAlerts={[]}
             templateIds={[
               'tmp_01H5JXWKYFMYT70RND1CGQCFKZ',
               'tmp_01H5JB37PPK9F64RE3QQ52WD7M',

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -29,6 +29,7 @@ import triggerToast from './utils/toastTriggers';
 import generateString from './utils/generateString';
 import { createQuery } from './utils/createQuery';
 import formatDate from './utils/formatDate';
+import { formatPrescriptionDetails } from './utils/formatPrescriptionDetail';
 
 import type { DraftPrescription, TemplateOverrides } from './systems/DraftPrescriptions';
 import { SignatureAttestationModal } from './systems/SignatureAttestation';
@@ -63,7 +64,8 @@ export {
   generateString,
   triggerToast,
   usePhotonClient,
-  useRecentOrders
+  useRecentOrders,
+  formatPrescriptionDetails
 };
 
 // Export types

--- a/packages/components/src/systems/PatientMedHistory/PatientMedHistoryTable.stories.tsx
+++ b/packages/components/src/systems/PatientMedHistory/PatientMedHistoryTable.stories.tsx
@@ -23,7 +23,9 @@ const testData: PatientTreatmentHistoryElement[] = [
   {
     active: false,
     prescription: createTestPrescription({ instructions: 'very long instructions '.repeat(10) }),
-    treatment: createTestTreatment({ name: 'treatment name 2' })
+    treatment: createTestTreatment({
+      name: 'treatment name 2 is very long and might get truncated on a small screen'
+    })
   }
 ];
 

--- a/packages/components/src/systems/PatientMedHistory/PatientMedHistoryTable.stories.tsx
+++ b/packages/components/src/systems/PatientMedHistory/PatientMedHistoryTable.stories.tsx
@@ -1,0 +1,46 @@
+import type { Meta, StoryObj } from '@storybook/html';
+import type { ComponentProps } from 'solid-js';
+import { PatientTreatmentHistoryElement } from './index';
+import PatientMedHistoryTable from './PatientMedHistoryTable';
+import { createTestPrescription, createTestTreatment } from '../../utils/storybookUtils';
+
+type Story = StoryObj<typeof PatientMedHistoryTable>;
+
+export const Default: Story = {
+  args: {
+    enableLinks: false,
+    medHistory: [],
+    baseURL: 'test-base-url.com/'
+  }
+};
+
+const testData: PatientTreatmentHistoryElement[] = [
+  {
+    active: false,
+    prescription: createTestPrescription({ dispenseQuantity: 30, dispenseUnit: 'unit' }),
+    treatment: createTestTreatment({ name: 'treatment name 1' })
+  },
+  {
+    active: false,
+    prescription: createTestPrescription({ instructions: 'very long instructions '.repeat(10) }),
+    treatment: createTestTreatment({ name: 'treatment name 2' })
+  }
+];
+
+export default {
+  title: 'Patient Medication History Table',
+  tags: ['autodocs'],
+  render: (props) => {
+    return (
+      <div>
+        <PatientMedHistoryTable
+          enableLinks={props.enableLinks}
+          medHistory={testData}
+          baseURL={'test-base-url.com/'}
+          chronological={true}
+          onChronologicalChange={() => {}}
+        ></PatientMedHistoryTable>
+      </div>
+    );
+  }
+} as Meta<ComponentProps<typeof PatientMedHistoryTable>>;

--- a/packages/components/src/systems/PatientMedHistory/PatientMedHistoryTable.tsx
+++ b/packages/components/src/systems/PatientMedHistory/PatientMedHistoryTable.tsx
@@ -1,0 +1,130 @@
+import { createSignal, For, Show } from 'solid-js';
+import { formatDate, formatPrescriptionDetails, generateString, Icon, Table, Text } from '../../';
+import { PatientTreatmentHistoryElement } from './index';
+
+const LoadingRowFallback = (props: { enableLinks: boolean }) => (
+  <Table.Row>
+    <Table.Cell>
+      <Text sampleLoadingText={generateString(10, 25)} loading />
+    </Table.Cell>
+    <Table.Cell>
+      <Text sampleLoadingText={generateString(2, 8)} loading />
+    </Table.Cell>
+    <Show when={props.enableLinks}>
+      <Table.Cell>
+        <Text sampleLoadingText={generateString(4, 8)} loading />
+      </Table.Cell>
+    </Show>
+  </Table.Row>
+);
+
+export type PatientMedHistoryTableProps = {
+  enableLinks: boolean;
+  medHistory?: PatientTreatmentHistoryElement[] | undefined;
+  baseURL: string;
+  onChronologicalChange: () => void;
+  chronological: boolean;
+};
+
+export default function PatientMedHistoryTable(props: PatientMedHistoryTableProps) {
+  const [expandedRows, setExpandedRows] = createSignal<Set<string>>(new Set());
+
+  const toggleExpand = (medId: string) => {
+    console.log('toggleExpand', medId);
+    setExpandedRows((prev) => {
+      const newSet = new Set(prev);
+      if (newSet.has(medId)) {
+        newSet.delete(medId);
+      } else {
+        newSet.add(medId);
+      }
+      return newSet;
+    });
+  };
+
+  return (
+    <Table>
+      <Table.Header>
+        <Table.Col width="16rem">Medication</Table.Col>
+        <Table.Col>
+          <span class="cursor-pointer flex" onClick={() => props.onChronologicalChange}>
+            Written
+            <div class="ml-1">
+              <Show when={props.chronological}>
+                <Icon name="chevronDown" size="sm" />
+              </Show>
+              <Show when={!props.chronological}>
+                <Icon name="chevronUp" size="sm" />
+              </Show>
+            </div>
+          </span>
+        </Table.Col>
+        <Show when={props.enableLinks}>
+          <Table.Col>Source</Table.Col>
+        </Show>
+      </Table.Header>
+      <Table.Body>
+        <Show
+          when={props.medHistory}
+          fallback={
+            <>
+              <LoadingRowFallback enableLinks={props.enableLinks} />
+              <LoadingRowFallback enableLinks={props.enableLinks} />
+              <LoadingRowFallback enableLinks={props.enableLinks} />
+            </>
+          }
+        >
+          <For each={props.medHistory}>
+            {(med) => (
+              <Table.Row>
+                <Table.Cell width="16rem">
+                  <div class="flex items-stretch h-full">
+                    <div class="flex-col flex-1 min-w-0">
+                      <div class="whitespace-nowrap text-ellipsis overflow-hidden">
+                        {med.treatment?.name}
+                      </div>
+                      <div class="text-gray-500">
+                        <div
+                          class={`${
+                            expandedRows().has(med.treatment?.id) ? '' : 'whitespace-nowrap'
+                          } text-ellipsis overflow-hidden`}
+                        >
+                          {formatPrescriptionDetails(med.prescription)}
+                        </div>
+                      </div>
+                    </div>
+                    <button
+                      onClick={() => toggleExpand(med.treatment?.id)}
+                      class="text-blue-500 hover:text-blue-700 text-sm ml-2 self-stretch flex items-center"
+                    >
+                      <Icon
+                        name={expandedRows().has(med.treatment?.id) ? 'minus' : 'plus'}
+                        size="sm"
+                      />
+                    </button>
+                  </div>
+                </Table.Cell>
+                <Table.Cell>{formatDate(med.prescription?.writtenAt) || 'N/A'}</Table.Cell>
+                <Show when={props.enableLinks}>
+                  <Table.Cell>
+                    {med.prescription?.id ? (
+                      <a
+                        class="text-blue-500 underline"
+                        target="_blank"
+                        href={`${props.baseURL}${med.prescription?.id}`}
+                      >
+                        Link
+                      </a>
+                    ) : (
+                      'External'
+                    )}
+                  </Table.Cell>
+                </Show>
+              </Table.Row>
+            )}
+          </For>
+        </Show>
+      </Table.Body>
+    </Table>
+  );
+}

--- a/packages/components/src/systems/PatientMedHistory/PatientMedHistoryTable.tsx
+++ b/packages/components/src/systems/PatientMedHistory/PatientMedHistoryTable.tsx
@@ -30,7 +30,6 @@ export default function PatientMedHistoryTable(props: PatientMedHistoryTableProp
   const [expandedRows, setExpandedRows] = createSignal<Set<string>>(new Set());
 
   const toggleExpand = (medId: string) => {
-    console.log('toggleExpand', medId);
     setExpandedRows((prev) => {
       const newSet = new Set(prev);
       if (newSet.has(medId)) {
@@ -80,13 +79,17 @@ export default function PatientMedHistoryTable(props: PatientMedHistoryTableProp
                 <Table.Cell width="16rem">
                   <div class="flex items-stretch h-full">
                     <div class="flex-col flex-1 min-w-0">
-                      <div class="whitespace-nowrap text-ellipsis overflow-hidden">
-                        {med.treatment?.name}
+                      <div
+                        class={`${
+                          expandedRows().has(med.treatment.id) ? '' : 'whitespace-nowrap'
+                        } text-ellipsis overflow-hidden`}
+                      >
+                        {med.treatment.name}
                       </div>
                       <div class="text-gray-500">
                         <div
                           class={`${
-                            expandedRows().has(med.treatment?.id) ? '' : 'whitespace-nowrap'
+                            expandedRows().has(med.treatment.id) ? '' : 'whitespace-nowrap'
                           } text-ellipsis overflow-hidden`}
                         >
                           {formatPrescriptionDetails(med.prescription)}

--- a/packages/components/src/systems/PatientMedHistory/PatientMedHistoryTable.tsx
+++ b/packages/components/src/systems/PatientMedHistory/PatientMedHistoryTable.tsx
@@ -79,12 +79,14 @@ export default function PatientMedHistoryTable(props: PatientMedHistoryTableProp
                 <Table.Cell width="16rem">
                   <div class="flex items-stretch h-full">
                     <div
-                      class={`flex-col flex-1 min-w-0 text-ellipsis overflow-hidden ${
+                      class={`flex-col flex-1 min-w-0 ${
                         expandedRows().has(med.treatment.id) ? '' : 'whitespace-nowrap'
                       }`}
                     >
-                      <div>{med.treatment.name}</div>
-                      <div class="text-gray-500">{formatPrescriptionDetails(med.prescription)}</div>
+                      <div class="text-ellipsis overflow-hidden">{med.treatment.name}</div>
+                      <div class="text-gray-500 text-ellipsis overflow-hidden">
+                        {formatPrescriptionDetails(med.prescription)}
+                      </div>
                     </div>
                     <button
                       type="button"

--- a/packages/components/src/systems/PatientMedHistory/PatientMedHistoryTable.tsx
+++ b/packages/components/src/systems/PatientMedHistory/PatientMedHistoryTable.tsx
@@ -78,31 +78,29 @@ export default function PatientMedHistoryTable(props: PatientMedHistoryTableProp
               <Table.Row>
                 <Table.Cell width="16rem">
                   <div class="flex items-stretch h-full">
-                    <div class="flex-col flex-1 min-w-0">
-                      <div
-                        class={`${
-                          expandedRows().has(med.treatment.id) ? '' : 'whitespace-nowrap'
-                        } text-ellipsis overflow-hidden`}
-                      >
-                        {med.treatment.name}
-                      </div>
-                      <div class="text-gray-500">
-                        <div
-                          class={`${
-                            expandedRows().has(med.treatment.id) ? '' : 'whitespace-nowrap'
-                          } text-ellipsis overflow-hidden`}
-                        >
-                          {formatPrescriptionDetails(med.prescription)}
-                        </div>
-                      </div>
+                    <div
+                      class={`flex-col flex-1 min-w-0 text-ellipsis overflow-hidden ${
+                        expandedRows().has(med.treatment.id) ? '' : 'whitespace-nowrap'
+                      }`}
+                    >
+                      <div>{med.treatment.name}</div>
+                      <div class="text-gray-500">{formatPrescriptionDetails(med.prescription)}</div>
                     </div>
                     <button
+                      type="button"
                       onClick={() => toggleExpand(med.treatment?.id)}
                       class="text-blue-500 hover:text-blue-700 text-sm ml-2 self-stretch flex items-center"
+                      aria-expanded={expandedRows().has(med.treatment?.id)}
+                      aria-label={
+                        expandedRows().has(med.treatment?.id)
+                          ? 'Collapse medication details'
+                          : 'Expand medication details'
+                      }
                     >
                       <Icon
                         name={expandedRows().has(med.treatment?.id) ? 'minus' : 'plus'}
                         size="sm"
+                        aria-hidden="true"
                       />
                     </button>
                   </div>

--- a/packages/components/src/systems/PatientMedHistory/index.tsx
+++ b/packages/components/src/systems/PatientMedHistory/index.tsx
@@ -1,16 +1,17 @@
-import { createSignal, createEffect, Show, For, createMemo } from 'solid-js';
+import { createEffect, createMemo, createSignal, For, Show } from 'solid-js';
 import gql from 'graphql-tag';
 import { usePhotonClient } from '../SDKProvider';
 import { Prescription, Treatment } from '@photonhealth/sdk/dist/types';
 import {
-  Icon,
-  Card,
   Button,
-  Text,
-  Table,
-  generateString,
+  Card,
   createQuery,
   formatDate,
+  formatPrescriptionDetails,
+  generateString,
+  Icon,
+  Table,
+  Text,
   triggerToast
 } from '../../';
 import { ApolloCache } from '@apollo/client';
@@ -24,6 +25,10 @@ const GET_PATIENT_MED_HISTORY = gql`
         prescription {
           id
           writtenAt
+          instructions
+          dispenseQuantity
+          dispenseUnit
+          daysSupply
         }
         treatment {
           id
@@ -237,7 +242,14 @@ export default function PatientMedHistory(props: PatientMedHistoryProps) {
               <For each={medHistory()}>
                 {(med) => (
                   <Table.Row>
-                    <Table.Cell width="16rem">{med.treatment?.name}</Table.Cell>
+                    <Table.Cell width="16rem">
+                      <div>{med.treatment?.name}</div>
+                      <div>
+                        <p class="text-ellipsis overflow-hidden text-gray-500">
+                          {formatPrescriptionDetails(med.prescription)}
+                        </p>
+                      </div>
+                    </Table.Cell>
                     <Table.Cell>{formatDate(med.prescription?.writtenAt) || 'N/A'}</Table.Cell>
                     <Show when={props.enableLinks}>
                       <Table.Cell>

--- a/packages/components/src/systems/PatientMedHistory/index.tsx
+++ b/packages/components/src/systems/PatientMedHistory/index.tsx
@@ -1,20 +1,10 @@
-import { createEffect, createMemo, createSignal, For, Show } from 'solid-js';
+import { createEffect, createMemo, createSignal, Show } from 'solid-js';
 import gql from 'graphql-tag';
 import { usePhotonClient } from '../SDKProvider';
 import { Prescription, Treatment } from '@photonhealth/sdk/dist/types';
-import {
-  Button,
-  Card,
-  createQuery,
-  formatDate,
-  formatPrescriptionDetails,
-  generateString,
-  Icon,
-  Table,
-  Text,
-  triggerToast
-} from '../../';
+import { Button, Card, createQuery, Text, triggerToast } from '../../';
 import { ApolloCache } from '@apollo/client';
+import PatientMedHistoryTable from './PatientMedHistoryTable';
 
 const GET_PATIENT_MED_HISTORY = gql`
   query GetPatient($id: ID!) {
@@ -55,23 +45,7 @@ type PatientMedHistoryProps = {
   hideAddMedicationDialog?: () => void;
 };
 
-const LoadingRowFallback = (props: { enableLinks: boolean }) => (
-  <Table.Row>
-    <Table.Cell>
-      <Text sampleLoadingText={generateString(10, 25)} loading />
-    </Table.Cell>
-    <Table.Cell>
-      <Text sampleLoadingText={generateString(2, 8)} loading />
-    </Table.Cell>
-    <Show when={props.enableLinks}>
-      <Table.Cell>
-        <Text sampleLoadingText={generateString(4, 8)} loading />
-      </Table.Cell>
-    </Show>
-  </Table.Row>
-);
-
-type PatientTreatmentHistoryElement = {
+export type PatientTreatmentHistoryElement = {
   active: boolean;
   comment?: string;
   treatment: Treatment;
@@ -208,70 +182,13 @@ export default function PatientMedHistory(props: PatientMedHistoryProps) {
       </div>
 
       <div class="max-h-80 overflow-y-auto">
-        <Table>
-          <Table.Header>
-            <Table.Col width="16rem">Medication</Table.Col>
-            <Table.Col>
-              <span class="cursor-pointer flex" onClick={() => setChronological(!chronological())}>
-                Written
-                <div class="ml-1">
-                  <Show when={chronological()}>
-                    <Icon name="chevronDown" size="sm" />
-                  </Show>
-                  <Show when={!chronological()}>
-                    <Icon name="chevronUp" size="sm" />
-                  </Show>
-                </div>
-              </span>
-            </Table.Col>
-            <Show when={props.enableLinks}>
-              <Table.Col>Source</Table.Col>
-            </Show>
-          </Table.Header>
-          <Table.Body>
-            <Show
-              when={medHistory()}
-              fallback={
-                <>
-                  <LoadingRowFallback enableLinks={props.enableLinks} />
-                  <LoadingRowFallback enableLinks={props.enableLinks} />
-                  <LoadingRowFallback enableLinks={props.enableLinks} />
-                </>
-              }
-            >
-              <For each={medHistory()}>
-                {(med) => (
-                  <Table.Row>
-                    <Table.Cell width="16rem">
-                      <div>{med.treatment?.name}</div>
-                      <div>
-                        <p class="text-ellipsis overflow-hidden text-gray-500">
-                          {formatPrescriptionDetails(med.prescription)}
-                        </p>
-                      </div>
-                    </Table.Cell>
-                    <Table.Cell>{formatDate(med.prescription?.writtenAt) || 'N/A'}</Table.Cell>
-                    <Show when={props.enableLinks}>
-                      <Table.Cell>
-                        {med.prescription?.id ? (
-                          <a
-                            class="text-blue-500 underline"
-                            target="_blank"
-                            href={`${baseURL()}${med.prescription?.id}`}
-                          >
-                            Link
-                          </a>
-                        ) : (
-                          'External'
-                        )}
-                      </Table.Cell>
-                    </Show>
-                  </Table.Row>
-                )}
-              </For>
-            </Show>
-          </Table.Body>
-        </Table>
+        <PatientMedHistoryTable
+          enableLinks={props.enableLinks}
+          baseURL={baseURL()}
+          medHistory={medHistory()}
+          chronological={chronological()}
+          onChronologicalChange={() => setChronological(!chronological())}
+        />
       </div>
     </Card>
   );

--- a/packages/components/src/utils/formatPrescriptionDetail.test.ts
+++ b/packages/components/src/utils/formatPrescriptionDetail.test.ts
@@ -1,0 +1,33 @@
+import { formatPrescriptionDetails } from './formatPrescriptionDetail';
+
+test('formats all prescription details', () => {
+  const actual = formatPrescriptionDetails({
+    daysSupply: 444,
+    instructions: 'test-instructions',
+    dispenseQuantity: 111,
+    dispenseUnit: 'Each',
+    fillsAllowed: 555
+  });
+
+  expect(actual).toEqual(
+    'QTY: 111 Each | Days Supply: 444 | Refills: 554 | Sig: test-instructions'
+  );
+});
+
+test('formats missing prescription', () => {
+  const actual = formatPrescriptionDetails(undefined);
+
+  expect(actual).toEqual('QTY: N/A | Days Supply: N/A | Refills: N/A | Sig: N/A');
+});
+
+test('formats partial prescription details', () => {
+  const actual = formatPrescriptionDetails({
+    daysSupply: undefined,
+    instructions: '',
+    dispenseQuantity: 0,
+    dispenseUnit: '',
+    fillsAllowed: 0
+  });
+
+  expect(actual).toEqual('QTY: 0 | Days Supply: N/A | Refills: 0 | Sig: N/A');
+});

--- a/packages/components/src/utils/formatPrescriptionDetail.ts
+++ b/packages/components/src/utils/formatPrescriptionDetail.ts
@@ -1,0 +1,37 @@
+import { Prescription } from '@photonhealth/sdk/dist/types';
+
+type PrescriptionDetails = Pick<
+  Prescription,
+  'dispenseQuantity' | 'dispenseUnit' | 'daysSupply' | 'instructions' | 'fillsAllowed'
+>;
+
+export function formatPrescriptionDetails(prescription?: PrescriptionDetails) {
+  let dispenseQuantity = 'N/A';
+  let dispenseUnit = '';
+  let daysSupply = 'N/A';
+  let refills = 'N/A';
+  let instructions = 'N/A';
+
+  if (prescription) {
+    dispenseQuantity = prescription.dispenseQuantity.toString();
+    if (prescription.dispenseQuantity > 0) {
+      dispenseUnit = ` ${prescription.dispenseUnit}`;
+    }
+
+    if (prescription.daysSupply) {
+      daysSupply = prescription.daysSupply.toString();
+    }
+
+    if (prescription.fillsAllowed) {
+      refills = (prescription.fillsAllowed - 1).toString();
+    } else {
+      refills = '0';
+    }
+
+    if (prescription.instructions) {
+      instructions = prescription.instructions;
+    }
+  }
+
+  return `QTY: ${dispenseQuantity}${dispenseUnit} | Days Supply: ${daysSupply} | Refills: ${refills} | Sig: ${instructions}`;
+}

--- a/packages/components/src/utils/storybookUtils.ts
+++ b/packages/components/src/utils/storybookUtils.ts
@@ -1,0 +1,93 @@
+import {
+  Fill,
+  FillState,
+  Order,
+  OrderState,
+  Patient,
+  Prescription,
+  PrescriptionState,
+  SexType,
+  Treatment
+} from '@photonhealth/sdk/src/types';
+
+export function createTestPatient(): Patient {
+  return {
+    dateOfBirth: '2020-12-31',
+    id: 'test-patient-id-1',
+    name: {
+      first: 'test-patient-first-name',
+      full: 'test-patient-full-name',
+      last: 'test-patient-last-name'
+    },
+    phone: '123-456-7890',
+    sex: SexType.Unknown
+  };
+}
+
+function createTestOrder(): Order {
+  return {
+    createdAt: undefined,
+    fills: [],
+    id: '',
+    patient: createTestPatient(),
+    state: OrderState.Completed
+  };
+}
+
+export function createTestPrescriber() {
+  return {
+    email: undefined,
+    id: '',
+    name: {
+      first: 'test-provider-first-name',
+      full: '',
+      last: 'test-provider-last-name'
+    },
+    organizations: [],
+    phone: undefined
+  };
+}
+
+export function createTestPrescription(options: Partial<Prescription> = {}): Prescription {
+  const testFill: Fill = {
+    id: '',
+    order: createTestOrder(),
+    requestedAt: undefined,
+    state: FillState.Sent,
+    treatment: createTestTreatment()
+  };
+  return {
+    dispenseQuantity: 0,
+    effectiveDate: undefined,
+    expirationDate: undefined,
+    fills: [testFill],
+    fillsAllowed: 0,
+    fillsRemaining: 0,
+    id: '',
+    instructions: '',
+    patient: createTestPatient(),
+    prescriber: createTestPrescriber(),
+    state: PrescriptionState.Expired,
+    treatment: createTestTreatment(),
+    writtenAt: undefined,
+    dispenseUnit: 'Each',
+    ...options
+  };
+}
+
+let treatmentIdCounter = 1; // Counter to ensure unique IDs
+export function createTestTreatment(options: Partial<Treatment> = {}) {
+  return {
+    id: `med_${treatmentIdCounter++}`,
+    description: 'test-treatment-description-1',
+    name: 'test-treatment-name-1',
+    codes: {
+      HCPCS: 'test-HCPCS',
+      SKU: 'test-SKU',
+      packageNDC: 'test-packageNDC',
+      productNDC: 'test-productNDC',
+      rxcui: 'test-rxcui'
+    },
+    ...options
+  };
+}

--- a/packages/components/tsconfig.json
+++ b/packages/components/tsconfig.json
@@ -13,6 +13,6 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true
   },
-  "include": ["src", "types"],
+  "include": ["src", "types", "dev"],
   "exclude": ["node_modules", "tmp", "dist"]
 }

--- a/packages/elements/README.md
+++ b/packages/elements/README.md
@@ -2,7 +2,19 @@
 
 Photon's collection of customizable and reusable components to help clients integrate seamlessly with our system. Elements can be used to add prescribing functionality into any web-based clinical tool.
 
-## Documentation
+## Local Development
+
+To run at http://localhost:3000:
+
+```shell
+npx nx run elements:start
+```
+
+To modify the embedded component, edit attributes of element `photon-prescribe-workflow` inside [index.html](index.html)
+
+To view available attributes/options, see [photon-prescribe-workflow-component.tsx](src/photon-multirx-form/photon-prescribe-workflow-component.tsx) or [official docs](https://docs.photon.health/docs/elements#prescribe-element)
+
+## Usage
 
 ### Installation
 
@@ -10,7 +22,7 @@ Photon's collection of customizable and reusable components to help clients inte
 npm i @photonhealth/elements
 ```
 
-### Usage
+### Example
 
 ```javascript
 import('@photonhealth/elements').catch((err) => {});

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@photonhealth/elements",
-  "version": "0.14.4",
+  "version": "0.14.5",
   "description": "",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
* MedHistory shows a line of text with prescription data:
  * quantity
  * days supply
  * refills remaining
  * instruction (i.e. "sig")
* toggle button allows expansion. 
  * need this because there isn't a lot of space to show all the prescription details, especially the longer instructions field
* Improve READMEs for local development
  * main README links to sub-READMEs
  * replaced broken `npm start` commands with `npx nx` commands

Prescriptions with the same medication.treatment expand/collapse together (see end of demo video). Not sure if this actually happens outside test data environment or if it needs to be fixed.

https://github.com/user-attachments/assets/10d9f903-6f84-4975-81eb-0a03651fae1b



related milestone: https://www.notion.so/photons/Med-History-Details-in-Embedded-Flow-1908bfbbf4ec80b8b6c9e14c1d2f4612?pvs=4