### PR TITLE
Allow wildcards in the subdomain of whitelisted ulrs, validation fix

### DIFF
--- a/apps/app/src/views/routes/Settings/components/client-credentials/SPAClientEditForm.tsx
+++ b/apps/app/src/views/routes/Settings/components/client-credentials/SPAClientEditForm.tsx
@@ -31,10 +31,17 @@ const spaClientValidationSchema = yup.object({
     .test('urls', 'Must be valid comma separated URLs with no query parameters', (value) => {
       if (!value) return true;
       const urls = value.split(',').map((url) => url.trim());
-      return urls.every((url) => {
-        if (!url) return true;
+      return urls.every((item) => {
+        if (!item) return true;
+        let url = item;
+        // if the Url has a wildcard in the subdomain
+        if (url.includes('://*.')) {
+          url = url.replace('://*.', '://WILDCARD.');
+        }
+
         try {
           const urlObject = new URL(url);
+          if (!urlObject.protocol || !urlObject.hostname) return false;
           if (urlObject.searchParams.size > 0) return false;
           return true;
         } catch {


### PR DESCRIPTION
We need to enable customers to use wildcards in the subdomain of the URLs that they're whitelisting

## Before

https://github.com/user-attachments/assets/a47451d5-8eb1-4186-b999-6d432a85d732



## After

https://github.com/user-attachments/assets/96aa9b70-4350-4c62-864a-39baaf8d2729


<img width="576" alt="Screenshot 2025-03-18 at 2 05 11 PM" src="https://github.com/user-attachments/assets/cff46adb-0495-4bd5-9c53-d4367bc829ab" />

