### PR TITLE
Add 1 click refill button to med history

### DIFF
--- a/apps/app/src/views/routes/PrescriptionForm.tsx
+++ b/apps/app/src/views/routes/PrescriptionForm.tsx
@@ -119,6 +119,7 @@ export const PrescriptionForm = () => {
           enable-order={orgSettings?.enableRxAndOrder ?? true}
           enable-med-history={orgSettings?.enableMedHistory ?? false}
           enable-med-history-links={true}
+          enable-med-history-refill-button={true}
           enable-local-pickup={orgSettings?.pickUp ?? false}
           enable-send-to-patient={orgSettings?.sendToPatient ?? false}
           enable-combine-and-duplicate={orgSettings?.enableCombineAndDuplicate ?? false}

--- a/packages/components/dev/App.tsx
+++ b/packages/components/dev/App.tsx
@@ -121,11 +121,15 @@ const App = () => {
 
         <div class="mb-10">
           <h2>Patient Med History</h2>
-          <PatientMedHistory patientId="pat_01JEVF5DWQAQFHTVYK9ABG65JZ" enableLinks={false} />
+          <PatientMedHistory
+            patientId="pat_01JEVF5DWQAQFHTVYK9ABG65JZ"
+            enableLinks={false}
+            enableRefillButton={true}
+          />
         </div>
 
         <div class="mb-10">
-          <h2>Draft Presciptions</h2>
+          <h2>Draft Prescriptions</h2>
           <DraftPrescriptions
             draftPrescriptions={draftPrescriptions}
             setDraftPrescriptions={setDraftPrescriptions}

--- a/packages/components/src/particles/Card/index.tsx
+++ b/packages/components/src/particles/Card/index.tsx
@@ -6,10 +6,11 @@ export interface CardProps extends JSX.HTMLAttributes<HTMLDivElement> {
   selected?: boolean;
   variant?: 'white' | 'gray';
   addChildrenDivider?: boolean;
+  autoPadding?: boolean;
 }
 
 function Card(preProps: CardProps) {
-  const props = mergeProps({ variant: 'white' }, preProps);
+  const props = mergeProps({ variant: 'white', autoPadding: true }, preProps);
 
   const cardClasses = createMemo(() =>
     clsx('border rounded-lg ', {
@@ -25,7 +26,9 @@ function Card(preProps: CardProps) {
     <div class={cardClasses()}>
       {/* addChildrenDivider adds a horizontal line between each child element */}
       <For each={Array.isArray(props.children) ? props.children : [props.children]}>
-        {(child) => <div class="px-4 py-3 sm:px-6 sm:py-4">{child}</div>}
+        {(child) => (
+          <div class={clsx({ 'px-4 py-3 sm:px-6 sm:py-4': props.autoPadding })}>{child}</div>
+        )}
       </For>
     </div>
   );

--- a/packages/components/src/particles/FlyoutMenu/FlyoutMenu.stories.tsx
+++ b/packages/components/src/particles/FlyoutMenu/FlyoutMenu.stories.tsx
@@ -1,0 +1,61 @@
+import type { Meta, StoryObj } from '@storybook/html';
+import { ComponentProps, For } from 'solid-js';
+import { FlyoutMenu } from './';
+import Table from '../Table';
+
+type FlyoutMenuStory = StoryObj<ComponentProps<typeof FlyoutMenu>>;
+
+const meta: Meta<ComponentProps<typeof FlyoutMenu>> = {
+  title: 'FlyoutMenu',
+  // @ts-ignore
+  component: FlyoutMenu,
+  argTypes: {},
+  tags: ['autodocs']
+};
+
+export default meta;
+
+export const Default: FlyoutMenuStory = {
+  args: {
+    options: [
+      { label: 'anchor 1', icon: 'inbox', link: '/' },
+      { label: 'button 1', onClick: () => alert('Hello from button 1') }
+    ]
+  }
+};
+
+export const WithinTable: FlyoutMenuStory = {
+  args: {
+    options: [
+      { label: 'anchor 1', icon: 'cog', link: '/' },
+      { label: 'button 1', onClick: () => alert('Hello from button 1') }
+    ]
+  },
+  // @ts-ignore
+  render: (args) => {
+    return (
+      <div>
+        <Table>
+          <Table.Header>
+            <Table.Col>Header 1</Table.Col>
+            <Table.Col>Header 2</Table.Col>
+          </Table.Header>
+          <Table.Body>
+            <Table.Row>
+              <Table.Cell>Row 1 Cell 1</Table.Cell>
+              <Table.Cell>
+                <FlyoutMenu options={args.options} />
+              </Table.Cell>
+            </Table.Row>
+            <Table.Row>
+              <Table.Cell>Row 2 Cell 1</Table.Cell>
+              <Table.Cell>
+                <FlyoutMenu options={args.options} />
+              </Table.Cell>
+            </Table.Row>
+          </Table.Body>
+        </Table>
+      </div>
+    );
+  }
+};

--- a/packages/components/src/particles/FlyoutMenu/FlyoutMenu.tsx
+++ b/packages/components/src/particles/FlyoutMenu/FlyoutMenu.tsx
@@ -1,0 +1,139 @@
+import { Portal } from 'solid-js/web';
+import { Component, createSignal, For, onCleanup, onMount, Show } from 'solid-js';
+import type { JSX } from 'solid-js';
+import Icon, { IconName } from '../Icon';
+import createTransition from '../../utils/createTransition';
+import { Transition } from 'solid-transition-group';
+
+export type FlyoutOption = {
+  label: string;
+  icon?: IconName;
+  link?: string;
+  onClick?: () => void;
+};
+
+interface FlyoutProps {
+  options: FlyoutOption[];
+}
+
+export const FlyoutMenu = (props: FlyoutProps) => {
+  const [open, setOpen] = createSignal(false);
+  let buttonRef: HTMLButtonElement | undefined;
+  let menuRef: HTMLDivElement | undefined;
+
+  const handleClickOutside = (event: MouseEvent) => {
+    if (
+      menuRef &&
+      buttonRef &&
+      !menuRef.contains(event.target as Node) &&
+      !buttonRef.contains(event.target as Node)
+    ) {
+      setOpen(false);
+    }
+  };
+
+  onMount(() => {
+    document.addEventListener('mousedown', handleClickOutside);
+  });
+
+  onCleanup(() => {
+    document.removeEventListener('mousedown', handleClickOutside);
+  });
+
+  return (
+    <div class="relative">
+      <button
+        ref={buttonRef}
+        type="button"
+        class="inline-flex items-center gap-x-1 text-sm/6 font-semibold rounded-lg p-2  hover:text-gray-700 hover:bg-gray-50"
+        aria-label="More options"
+        aria-expanded={open()}
+        aria-haspopup="menu"
+        aria-controls="flyout-menu"
+        onClick={() => {
+          setOpen(!open());
+        }}
+      >
+        <Icon name="ellipsisVertical" size="md" class="text-current" />
+      </button>
+      <Portal>
+        <FlyoutTransition>
+          <Show when={open() && !!buttonRef}>
+            <div
+              ref={menuRef}
+              id="flyout-menu"
+              role="menu"
+              class="fixed z-50 "
+              style={{
+                top: (buttonRef as HTMLButtonElement).getBoundingClientRect().bottom + 5 + 'px',
+                right:
+                  window.innerWidth -
+                  (buttonRef as HTMLButtonElement).getBoundingClientRect().right +
+                  'px'
+              }}
+            >
+              <div class="max-w-sm flex-auto rounded-md bg-white p-0 text-sm/6 shadow-lg ring-1 ring-gray-900/5">
+                <For each={props.options}>
+                  {(option) => (
+                    <div class="text-gray-900 hover:text-gray-500 text-end">
+                      <Show when={!option.onClick}>
+                        <a href={option.link}>{getOptionContent(option)}</a>
+                      </Show>
+                      <Show when={option.onClick}>
+                        <button onClick={option.onClick}>{getOptionContent(option)}</button>
+                      </Show>
+                    </div>
+                  )}
+                </For>
+              </div>
+            </div>
+          </Show>
+        </FlyoutTransition>
+      </Portal>
+    </div>
+  );
+};
+
+const getOptionContent = (option: FlyoutOption) => {
+  return (
+    <div class="flex items-center p-2">
+      <Show when={option.icon}>
+        <Icon name={option.icon} size="sm" />
+      </Show>
+      <span>{option.label}</span>
+    </div>
+  );
+};
+
+interface FlyoutTransitionProps {
+  children: JSX.Element;
+}
+
+const FlyoutTransition: Component<FlyoutTransitionProps> = (props) => {
+  return (
+    <Transition
+      onEnter={createTransition(
+        [
+          { opacity: 0, transform: 'translateY(4px)' },
+          { opacity: 1, transform: 'translateY(0)' }
+        ],
+        {
+          duration: 200,
+          easing: 'ease-out'
+        }
+      )}
+      onExit={createTransition(
+        [
+          { opacity: 1, transform: 'translateY(0)' },
+          { opacity: 0, transform: 'translateY(4px)' }
+        ],
+        {
+          duration: 150,
+          easing: 'ease-in'
+        }
+      )}
+    >
+      {props.children}
+    </Transition>
+  );
+};

--- a/packages/components/src/particles/FlyoutMenu/index.ts
+++ b/packages/components/src/particles/FlyoutMenu/index.ts
@@ -1,0 +1,1 @@
+export * from './FlyoutMenu';

--- a/packages/components/src/particles/IconButton/index.tsx
+++ b/packages/components/src/particles/IconButton/index.tsx
@@ -1,0 +1,29 @@
+import { Component, mergeProps } from 'solid-js';
+import { Icon } from '../../index';
+import Tooltip from '../Tooltip';
+import { IconName, IconSize } from '../Icon';
+
+interface IconButtonProps {
+  onClick: () => void;
+  iconName: IconName;
+  iconSize?: IconSize;
+  label: string;
+  disabled?: boolean;
+}
+
+export const IconButton: Component<IconButtonProps> = (props) => {
+  const merged = mergeProps({ size: 'md' }, props);
+  const button = (
+    <button
+      class="text-gray-700 hover:text-gray-900 hover:bg-blue-50 rounded-md p-2 disabled:opacity-50 disabled:hover:bg-transparent disabled:hover:text-gray-700 disabled:cursor-not-allowed"
+      type="button"
+      aria-label={props.label}
+      onClick={() => props.onClick()}
+      disabled={props.disabled}
+    >
+      <Icon name={props.iconName} size={merged.iconSize} />
+    </button>
+  );
+
+  return <>{props.disabled ? button : <Tooltip text={props.label}>{button}</Tooltip>}</>;
+};

--- a/packages/components/src/systems/DraftPrescriptions/index.tsx
+++ b/packages/components/src/systems/DraftPrescriptions/index.tsx
@@ -1,6 +1,14 @@
 import { Catalog, PrescriptionTemplate } from '@photonhealth/sdk/dist/types';
 import gql from 'graphql-tag';
-import { createSignal, For, JSXElement, mergeProps, onMount, Show } from 'solid-js';
+import {
+  createEffect,
+  createMemo,
+  createSignal,
+  For,
+  JSXElement,
+  mergeProps,
+  Show
+} from 'solid-js';
 import Banner from '../../particles/Banner';
 import Card from '../../particles/Card';
 import Icon from '../../particles/Icon';
@@ -118,6 +126,11 @@ export default function DraftPrescriptions(props: DraftPrescriptionsProps) {
   const [isLoading, setIsLoading] = createSignal<boolean>(true);
   const client = usePhotonClient();
 
+  const allDraftPrescriptionIds = createMemo(() => [
+    ...merged.templateIds,
+    ...merged.prescriptionIds
+  ]);
+
   async function fetchDrafts() {
     setIsLoading(true);
     const draftPrescriptions: DraftPrescription[] = [];
@@ -193,8 +206,8 @@ export default function DraftPrescriptions(props: DraftPrescriptionsProps) {
     setIsLoading(false);
   }
 
-  onMount(() => {
-    if (merged.templateIds.length > 0 || merged.prescriptionIds.length > 0) {
+  createEffect(() => {
+    if (allDraftPrescriptionIds().length > 0) {
       fetchDrafts();
     } else {
       setIsLoading(false);
@@ -205,7 +218,7 @@ export default function DraftPrescriptions(props: DraftPrescriptionsProps) {
     <div class="space-y-3">
       {/* Show when Loading */}
       <Show when={isLoading()}>
-        <For each={[...merged.templateIds, ...merged.prescriptionIds]}>
+        <For each={allDraftPrescriptionIds()}>
           {() => (
             <DraftPrescription
               LeftChildren={

--- a/packages/components/src/systems/PatientMedHistory/PatientMedHistoryTable.stories.tsx
+++ b/packages/components/src/systems/PatientMedHistory/PatientMedHistoryTable.stories.tsx
@@ -9,6 +9,7 @@ type Story = StoryObj<typeof PatientMedHistoryTable>;
 export const Default: Story = {
   args: {
     enableLinks: false,
+    enableRefillButton: false,
     medHistory: [],
     baseURL: 'test-base-url.com/'
   }
@@ -17,7 +18,11 @@ export const Default: Story = {
 const testData: PatientTreatmentHistoryElement[] = [
   {
     active: false,
-    prescription: createTestPrescription({ dispenseQuantity: 30, dispenseUnit: 'unit' }),
+    prescription: createTestPrescription({
+      id: 'rx-id-1',
+      dispenseQuantity: 30,
+      dispenseUnit: 'unit'
+    }),
     treatment: createTestTreatment({ name: 'treatment name 1' })
   },
   {
@@ -25,6 +30,13 @@ const testData: PatientTreatmentHistoryElement[] = [
     prescription: createTestPrescription({ instructions: 'very long instructions '.repeat(10) }),
     treatment: createTestTreatment({
       name: 'treatment name 2 is very long and might get truncated on a small screen'
+    })
+  },
+  {
+    active: false,
+    prescription: undefined,
+    treatment: createTestTreatment({
+      name: 'External Medication'
     })
   }
 ];
@@ -37,6 +49,7 @@ export default {
       <div>
         <PatientMedHistoryTable
           enableLinks={props.enableLinks}
+          enableRefillButton={props.enableRefillButton}
           medHistory={testData}
           baseURL={'test-base-url.com/'}
           chronological={true}

--- a/packages/components/src/systems/PatientMedHistory/PatientMedHistoryTable.stories.tsx
+++ b/packages/components/src/systems/PatientMedHistory/PatientMedHistoryTable.stories.tsx
@@ -41,6 +41,7 @@ export default {
           baseURL={'test-base-url.com/'}
           chronological={true}
           onChronologicalChange={() => {}}
+          onRefillClick={() => {}}
         ></PatientMedHistoryTable>
       </div>
     );

--- a/packages/components/src/systems/PatientMedHistory/PatientMedHistoryTable.tsx
+++ b/packages/components/src/systems/PatientMedHistory/PatientMedHistoryTable.tsx
@@ -2,6 +2,7 @@ import { createSignal, For, Show } from 'solid-js';
 import { formatDate, formatPrescriptionDetails, generateString, Icon, Table, Text } from '../../';
 import { PatientTreatmentHistoryElement } from './index';
 import { Treatment } from '@photonhealth/sdk/dist/types';
+import { FlyoutMenu, FlyoutOption } from '../../particles/FlyoutMenu';
 
 const LoadingRowFallback = (props: { enableLinks: boolean }) => (
   <Table.Row>
@@ -111,33 +112,9 @@ export default function PatientMedHistoryTable(props: PatientMedHistoryTableProp
                   </div>
                 </Table.Cell>
                 <Table.Cell>{formatDate(med.prescription?.writtenAt) || 'N/A'}</Table.Cell>
-                <Show when={props.enableLinks}>
+                <Show when={props.enableLinks || props.enableRefillButton}>
                   <Table.Cell>
-                    {med.prescription?.id ? (
-                      <a
-                        class="text-blue-500 underline"
-                        target="_blank"
-                        href={`${props.baseURL}${med.prescription?.id}`}
-                      >
-                        Link
-                      </a>
-                    ) : (
-                      'External'
-                    )}
-                  </Table.Cell>
-                </Show>
-                <Show when={props.enableRefillButton && med.prescription !== undefined}>
-                  <Table.Cell>
-                    <button
-                      type="button"
-                      onClick={() => {
-                        med.prescription && props.onRefillClick(med.prescription.id, med.treatment);
-                      }}
-                      aria-label={`Refill ${med.treatment.name}`}
-                      class="text-blue-500 hover:text-blue-700 text-sm"
-                    >
-                      <Icon name="documentPlus" size="sm" aria-hidden="true" />
-                    </button>
+                    <FlyoutMenu options={getOptions(props, med)} />
                   </Table.Cell>
                 </Show>
               </Table.Row>
@@ -147,4 +124,25 @@ export default function PatientMedHistoryTable(props: PatientMedHistoryTableProp
       </Table.Body>
     </Table>
   );
+}
+
+function getOptions(
+  props: PatientMedHistoryTableProps,
+  med: PatientTreatmentHistoryElement
+): FlyoutOption[] {
+  const options: FlyoutOption[] = [];
+  if (props.enableLinks) {
+    options.push({
+      link: `${props.baseURL}${med.prescription?.id}`,
+      label: 'Link'
+    });
+  }
+  if (props.enableRefillButton) {
+    options.push({
+      label: 'Refill',
+      icon: 'documentPlus',
+      onClick: () => med.prescription && props.onRefillClick(med.prescription.id, med.treatment)
+    });
+  }
+  return options;
 }

--- a/packages/components/src/systems/PatientMedHistory/PatientMedHistoryTable.tsx
+++ b/packages/components/src/systems/PatientMedHistory/PatientMedHistoryTable.tsx
@@ -4,6 +4,7 @@ import { PatientTreatmentHistoryElement } from './index';
 import { Treatment } from '@photonhealth/sdk/dist/types';
 import { IconButton } from '../../particles/IconButton';
 import { debounce } from '@solid-primitives/scheduled';
+import clsx from 'clsx';
 
 const LoadingRowFallback = (props: { enableLinks: boolean }) => (
   <Table.Row>
@@ -53,97 +54,112 @@ export default function PatientMedHistoryTable(props: PatientMedHistoryTableProp
     }, 300);
   });
 
+  const showRefillColumn = createMemo(() => {
+    return props.enableRefillButton;
+  });
+
+  const gridHeaderClass = createMemo(() =>
+    clsx('grid grid-cols-subgrid border-b text-xs font-semibold text-gray-900', {
+      'col-span-3': showRefillColumn(),
+      'col-span-2': !showRefillColumn()
+    })
+  );
+
   return (
-    <Table>
-      <Table.Header>
-        <Table.Col width="16rem">Medication</Table.Col>
-        <Table.Col>
-          <span class="cursor-pointer flex" onClick={() => props.onChronologicalChange()}>
-            Written
-            <div class="ml-1">
-              <Show when={props.chronological}>
-                <Icon name="chevronDown" size="sm" />
-              </Show>
-              <Show when={!props.chronological}>
-                <Icon name="chevronUp" size="sm" />
-              </Show>
-            </div>
-          </span>
-        </Table.Col>
+    <div
+      class="grid w-full text-xs"
+      style={{
+        'grid-template-columns': `1fr min-content ${showRefillColumn() ? 'min-content' : ''}`
+      }}
+    >
+      <div class={gridHeaderClass()}>
+        <div class="px-3 py-3.5">Medication</div>
+        <div class="px-3 py-3.5 cursor-pointer flex" onClick={() => props.onChronologicalChange()}>
+          Written
+          <div class="ml-1">
+            <Show when={props.chronological}>
+              <Icon name="chevronDown" size="sm" />
+            </Show>
+            <Show when={!props.chronological}>
+              <Icon name="chevronUp" size="sm" />
+            </Show>
+          </div>
+        </div>
         <Show when={props.enableRefillButton}>
-          <Table.Col>Actions</Table.Col>
+          <div class="px-3 py-3.5">Actions</div>
         </Show>
-      </Table.Header>
-      <Table.Body>
-        <Show
-          when={props.medHistory}
-          fallback={
+      </div>
+
+      <Show
+        when={props.medHistory}
+        fallback={
+          <>
+            <LoadingRowFallback enableLinks={props.enableLinks} />
+            <LoadingRowFallback enableLinks={props.enableLinks} />
+            <LoadingRowFallback enableLinks={props.enableLinks} />
+          </>
+        }
+      >
+        <For each={props.medHistory}>
+          {(med) => (
             <>
-              <LoadingRowFallback enableLinks={props.enableLinks} />
-              <LoadingRowFallback enableLinks={props.enableLinks} />
-              <LoadingRowFallback enableLinks={props.enableLinks} />
-            </>
-          }
-        >
-          <For each={props.medHistory}>
-            {(med) => (
-              <Table.Row>
-                <Table.Cell width="16rem">
-                  <div class="flex items-stretch h-full">
-                    <div
-                      class={`flex-col flex-1 min-w-0 ${
-                        expandedRows().has(med.treatment.id) ? '' : 'whitespace-nowrap'
-                      }`}
-                    >
-                      <MedicationName
-                        med={med}
-                        enableLinks={props.enableLinks}
-                        link={`${props.baseURL}${med.prescription?.id}`}
-                      />
-                      <div class="text-gray-500 text-ellipsis overflow-hidden">
-                        {formatPrescriptionDetails(med.prescription)}
-                      </div>
-                    </div>
-                    <button
-                      type="button"
-                      onClick={() => toggleExpand(med.treatment?.id)}
-                      class="text-blue-500 hover:text-blue-700 text-sm ml-2 self-stretch flex items-center"
-                      aria-expanded={expandedRows().has(med.treatment?.id)}
-                      aria-label={
-                        expandedRows().has(med.treatment?.id)
-                          ? 'Collapse medication details'
-                          : 'Expand medication details'
-                      }
-                    >
-                      <Icon
-                        name={expandedRows().has(med.treatment?.id) ? 'minus' : 'plus'}
-                        size="sm"
-                        aria-hidden="true"
-                      />
-                    </button>
-                  </div>
-                </Table.Cell>
-                <Table.Cell>{presentWrittenAt(med)}</Table.Cell>
-                <Show when={props.enableRefillButton}>
-                  <Table.Cell>
-                    <IconButton
-                      iconName="documentPlus"
-                      label="Refill"
-                      onClick={() => {
-                        if (med.prescription) {
-                          debouncedRefill()(med.prescription.id, med.treatment);
-                        }
-                      }}
-                      disabled={!med.prescription}
+              <div class="px-3 py-4 truncate">
+                <div class="flex">
+                  <div
+                    class={`flex-col flex-1 min-w-0 ${
+                      expandedRows().has(med.treatment.id) ? 'whitespace-normal' : ''
+                    }`}
+                  >
+                    <MedicationName
+                      med={med}
+                      enableLinks={props.enableLinks}
+                      link={`${props.baseURL}${med.prescription?.id}`}
                     />
-                  </Table.Cell>
-                </Show>
-              </Table.Row>
-            )}
-          </For>
-        </Show>
-      </Table.Body>
-    </Table>
+                    <div class="text-gray-500 text-ellipsis overflow-hidden">
+                      {formatPrescriptionDetails(med.prescription)}
+                    </div>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => toggleExpand(med.treatment?.id)}
+                    class="text-blue-500 hover:text-blue-700 text-sm ml-2 self-stretch flex items-center"
+                    aria-expanded={expandedRows().has(med.treatment?.id)}
+                    aria-label={
+                      expandedRows().has(med.treatment?.id)
+                        ? 'Collapse medication details'
+                        : 'Expand medication details'
+                    }
+                  >
+                    <Icon
+                      name={expandedRows().has(med.treatment?.id) ? 'minus' : 'plus'}
+                      size="sm"
+                      aria-hidden="true"
+                    />
+                  </button>
+                </div>
+              </div>
+              <div class="px-3 py-4 self-center">{presentWrittenAt(med)}</div>
+
+              <Show when={props.enableRefillButton}>
+                <div class="px-3 py-4 self-center">
+                  <IconButton
+                    iconName="documentPlus"
+                    iconSize="sm"
+                    label="Refill"
+                    onClick={() => {
+                      if (med.prescription) {
+                        debouncedRefill()(med.prescription.id, med.treatment);
+                      }
+                    }}
+                    disabled={!med.prescription}
+                  />
+                </div>
+              </Show>
+            </>
+          )}
+        </For>
+      </Show>
+    </div>
   );
 }
 

--- a/packages/components/src/systems/PatientMedHistory/PatientMedHistoryTable.tsx
+++ b/packages/components/src/systems/PatientMedHistory/PatientMedHistoryTable.tsx
@@ -21,6 +21,7 @@ const LoadingRowFallback = (props: { enableLinks: boolean }) => (
 
 export type PatientMedHistoryTableProps = {
   enableLinks: boolean;
+  enableRefillButton: boolean;
   medHistory?: PatientTreatmentHistoryElement[] | undefined;
   baseURL: string;
   onChronologicalChange: () => void;
@@ -63,7 +64,6 @@ export default function PatientMedHistoryTable(props: PatientMedHistoryTableProp
         <Show when={props.enableLinks}>
           <Table.Col>Source</Table.Col>
         </Show>
-        <Table.Col>Actions</Table.Col>
       </Table.Header>
       <Table.Body>
         <Show
@@ -126,7 +126,7 @@ export default function PatientMedHistoryTable(props: PatientMedHistoryTableProp
                     )}
                   </Table.Cell>
                 </Show>
-                <Show when={med.prescription !== undefined}>
+                <Show when={props.enableRefillButton && med.prescription !== undefined}>
                   <Table.Cell>
                     <button
                       type="button"

--- a/packages/components/src/systems/PatientMedHistory/PatientMedHistoryTable.tsx
+++ b/packages/components/src/systems/PatientMedHistory/PatientMedHistoryTable.tsx
@@ -1,27 +1,29 @@
 import { Component, createMemo, createSignal, For, Show } from 'solid-js';
-import { formatDate, formatPrescriptionDetails, generateString, Icon, Table, Text } from '../../';
+import { formatDate, formatPrescriptionDetails, generateString, Icon, Text } from '../../';
 import { PatientTreatmentHistoryElement } from './index';
 import { Treatment } from '@photonhealth/sdk/dist/types';
 import { IconButton } from '../../particles/IconButton';
 import { debounce } from '@solid-primitives/scheduled';
 import clsx from 'clsx';
 
-const LoadingRowFallback = (props: { enableLinks: boolean }) => (
-  <Table.Row>
-    <Table.Cell>
-      <Text sampleLoadingText={generateString(10, 25)} loading />
-    </Table.Cell>
-    <Table.Cell>
-      <Text sampleLoadingText={generateString(2, 8)} loading />
-    </Table.Cell>
-    <Show when={props.enableLinks}>
-      <Table.Cell>
-        <Text sampleLoadingText={generateString(4, 8)} loading />
-      </Table.Cell>
-    </Show>
-  </Table.Row>
-);
-
+const LoadingRowFallback = (props: { enableRefill: boolean }) => {
+  const cellClasses = 'px-4 py-4 select-none';
+  return (
+    <>
+      <div class={cellClasses}>
+        <Text sampleLoadingText={generateString(10, 25)} loading />
+      </div>
+      <div class={cellClasses}>
+        <Text sampleLoadingText="aaaaa" loading />
+      </div>
+      <Show when={props.enableRefill}>
+        <div class={cellClasses}>
+          <Text sampleLoadingText="aaa" loading />
+        </div>
+      </Show>
+    </>
+  );
+};
 export type PatientMedHistoryTableProps = {
   enableLinks: boolean;
   enableRefillButton: boolean;
@@ -59,22 +61,25 @@ export default function PatientMedHistoryTable(props: PatientMedHistoryTableProp
   });
 
   const gridHeaderClass = createMemo(() =>
-    clsx('grid grid-cols-subgrid border-b text-xs font-semibold text-gray-900', {
-      'col-span-3': showRefillColumn(),
-      'col-span-2': !showRefillColumn()
-    })
+    clsx(
+      'grid grid-cols-subgrid border-b text-xs font-semibold text-gray-900 sticky top-0 bg-white z-10',
+      {
+        'col-span-3': showRefillColumn(),
+        'col-span-2': !showRefillColumn()
+      }
+    )
   );
 
   return (
     <div
-      class="grid w-full text-xs"
+      class="grid w-full text-xs relative"
       style={{
         'grid-template-columns': `1fr min-content ${showRefillColumn() ? 'min-content' : ''}`
       }}
     >
       <div class={gridHeaderClass()}>
-        <div class="px-3 py-3.5">Medication</div>
-        <div class="px-3 py-3.5 cursor-pointer flex" onClick={() => props.onChronologicalChange()}>
+        <div class="px-4 py-3.5">Medication</div>
+        <div class="px-4 py-3.5 cursor-pointer flex" onClick={() => props.onChronologicalChange()}>
           Written
           <div class="ml-1">
             <Show when={props.chronological}>
@@ -86,7 +91,7 @@ export default function PatientMedHistoryTable(props: PatientMedHistoryTableProp
           </div>
         </div>
         <Show when={props.enableRefillButton}>
-          <div class="px-3 py-3.5">Actions</div>
+          <div class="px-4 py-3.5">Actions</div>
         </Show>
       </div>
 
@@ -94,16 +99,16 @@ export default function PatientMedHistoryTable(props: PatientMedHistoryTableProp
         when={props.medHistory}
         fallback={
           <>
-            <LoadingRowFallback enableLinks={props.enableLinks} />
-            <LoadingRowFallback enableLinks={props.enableLinks} />
-            <LoadingRowFallback enableLinks={props.enableLinks} />
+            <LoadingRowFallback enableRefill={props.enableRefillButton} />
+            <LoadingRowFallback enableRefill={props.enableRefillButton} />
+            <LoadingRowFallback enableRefill={props.enableRefillButton} />
           </>
         }
       >
         <For each={props.medHistory}>
           {(med) => (
             <>
-              <div class="px-3 py-4 truncate">
+              <div class="px-4 py-4 truncate">
                 <div class="flex">
                   <div
                     class={`flex-col flex-1 min-w-0 ${
@@ -138,10 +143,10 @@ export default function PatientMedHistoryTable(props: PatientMedHistoryTableProp
                   </button>
                 </div>
               </div>
-              <div class="px-3 py-4 self-center">{presentWrittenAt(med)}</div>
+              <div class="px-4 py-4 self-center">{presentWrittenAt(med)}</div>
 
               <Show when={props.enableRefillButton}>
-                <div class="px-3 py-4 self-center">
+                <div class="px-4 py-4 self-center">
                   <IconButton
                     iconName="documentPlus"
                     iconSize="sm"

--- a/packages/components/src/systems/PatientMedHistory/PatientMedHistoryTable.tsx
+++ b/packages/components/src/systems/PatientMedHistory/PatientMedHistoryTable.tsx
@@ -1,6 +1,7 @@
 import { createSignal, For, Show } from 'solid-js';
 import { formatDate, formatPrescriptionDetails, generateString, Icon, Table, Text } from '../../';
 import { PatientTreatmentHistoryElement } from './index';
+import { Treatment } from '@photonhealth/sdk/dist/types';
 
 const LoadingRowFallback = (props: { enableLinks: boolean }) => (
   <Table.Row>
@@ -24,6 +25,7 @@ export type PatientMedHistoryTableProps = {
   baseURL: string;
   onChronologicalChange: () => void;
   chronological: boolean;
+  onRefillClick: (prescriptionId: string, treatment: Treatment) => void;
 };
 
 export default function PatientMedHistoryTable(props: PatientMedHistoryTableProps) {
@@ -61,6 +63,7 @@ export default function PatientMedHistoryTable(props: PatientMedHistoryTableProp
         <Show when={props.enableLinks}>
           <Table.Col>Source</Table.Col>
         </Show>
+        <Table.Col>Actions</Table.Col>
       </Table.Header>
       <Table.Body>
         <Show
@@ -121,6 +124,20 @@ export default function PatientMedHistoryTable(props: PatientMedHistoryTableProp
                     ) : (
                       'External'
                     )}
+                  </Table.Cell>
+                </Show>
+                <Show when={med.prescription !== undefined}>
+                  <Table.Cell>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        med.prescription && props.onRefillClick(med.prescription.id, med.treatment);
+                      }}
+                      aria-label={`Refill ${med.treatment.name}`}
+                      class="text-blue-500 hover:text-blue-700 text-sm"
+                    >
+                      <Icon name="documentPlus" size="sm" aria-hidden="true" />
+                    </button>
                   </Table.Cell>
                 </Show>
               </Table.Row>

--- a/packages/components/src/systems/PatientMedHistory/index.tsx
+++ b/packages/components/src/systems/PatientMedHistory/index.tsx
@@ -40,6 +40,7 @@ const ADD_MED_HISTORY = gql`
 type PatientMedHistoryProps = {
   patientId: string;
   enableLinks: boolean;
+  enableRefillButton: boolean;
   newMedication?: Treatment;
   openAddMedicationDialog?: () => void;
   hideAddMedicationDialog?: () => void;
@@ -185,6 +186,7 @@ export default function PatientMedHistory(props: PatientMedHistoryProps) {
       <div class="max-h-80 overflow-y-auto">
         <PatientMedHistoryTable
           enableLinks={props.enableLinks}
+          enableRefillButton={props.enableRefillButton}
           baseURL={baseURL()}
           medHistory={medHistory()}
           chronological={chronological()}

--- a/packages/components/src/systems/PatientMedHistory/index.tsx
+++ b/packages/components/src/systems/PatientMedHistory/index.tsx
@@ -173,8 +173,8 @@ export default function PatientMedHistory(props: PatientMedHistoryProps) {
   });
 
   return (
-    <Card addChildrenDivider={true}>
-      <div class="flex items-center justify-between">
+    <Card addChildrenDivider={true} autoPadding={false}>
+      <div class="flex items-center justify-between px-4 py-3 sm:px-6 sm:py-4">
         <Text color="gray">Medication History</Text>
         <Show when={props?.openAddMedicationDialog}>
           <Button variant="secondary" size="sm" onClick={props?.openAddMedicationDialog}>

--- a/packages/components/src/systems/PatientMedHistory/index.tsx
+++ b/packages/components/src/systems/PatientMedHistory/index.tsx
@@ -43,6 +43,7 @@ type PatientMedHistoryProps = {
   newMedication?: Treatment;
   openAddMedicationDialog?: () => void;
   hideAddMedicationDialog?: () => void;
+  onRefillClick?: (prescriptionId: string, treatment: Treatment) => void;
 };
 
 export type PatientTreatmentHistoryElement = {
@@ -188,6 +189,9 @@ export default function PatientMedHistory(props: PatientMedHistoryProps) {
           medHistory={medHistory()}
           chronological={chronological()}
           onChronologicalChange={() => setChronological(!chronological())}
+          onRefillClick={(rxId, treatment) =>
+            props.onRefillClick && props.onRefillClick(rxId, treatment)
+          }
         />
       </div>
     </Card>

--- a/packages/elements/README.md
+++ b/packages/elements/README.md
@@ -14,6 +14,10 @@ To modify the embedded component, edit attributes of element `photon-prescribe-w
 
 To view available attributes/options, see [photon-prescribe-workflow-component.tsx](src/photon-multirx-form/photon-prescribe-workflow-component.tsx) or [official docs](https://docs.photon.health/docs/elements#prescribe-element)
 
+### Components
+
+After editing `packages/components`, re-run `npx nx run components:build` to see TypeScript and other changes load into `packages/elements`
+
 ## Usage
 
 ### Installation

--- a/packages/elements/index.html
+++ b/packages/elements/index.html
@@ -43,6 +43,7 @@
           hide-templates="true"
           pharmacy-id="phr_01GA9HPXAF9BC9PC8XM25Q836N"
           template-ids="tmp_01J6DBEHZX11BPMY38G9PWASMH"
+          enable-med-history="true"
           id="one"
         ></photon-prescribe-workflow>
       </div>

--- a/packages/elements/index.html
+++ b/packages/elements/index.html
@@ -44,6 +44,7 @@
           pharmacy-id="phr_01GA9HPXAF9BC9PC8XM25Q836N"
           template-ids="tmp_01J6DBEHZX11BPMY38G9PWASMH"
           enable-med-history="true"
+          enable-med-history-refill-button="true"
           id="one"
         ></photon-prescribe-workflow>
       </div>

--- a/packages/elements/index.html
+++ b/packages/elements/index.html
@@ -45,6 +45,7 @@
           template-ids="tmp_01J6DBEHZX11BPMY38G9PWASMH"
           enable-med-history="true"
           enable-med-history-refill-button="true"
+          enable-combine-and-duplicate="true"
           id="one"
         ></photon-prescribe-workflow>
       </div>

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@photonhealth/elements",
-  "version": "0.14.5",
+  "version": "0.14.6",
   "description": "",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/elements/src/photon-med-history/photon-med-history.tsx
+++ b/packages/elements/src/photon-med-history/photon-med-history.tsx
@@ -10,7 +10,11 @@ const PatientMedHistoryWrapper = (props: PatientMedProps) => {
   return (
     <div>
       <style>{photonStyles}</style>
-      <PatientMedHistory patientId={props.patientId} enableLinks={false} />
+      <PatientMedHistory
+        patientId={props.patientId}
+        enableLinks={false}
+        enableRefillButton={false}
+      />
     </div>
   );
 };

--- a/packages/elements/src/photon-multirx-form-wrapper/photon-multirx-form-wrapper-component.tsx
+++ b/packages/elements/src/photon-multirx-form-wrapper/photon-multirx-form-wrapper-component.tsx
@@ -25,6 +25,7 @@ const shouldWarn = (form: any) =>
 const Component = (props: {
   enableMedHistory: boolean;
   enableMedHistoryLinks: boolean;
+  enableMedHistoryRefillButton: boolean;
   hideTemplates?: boolean;
   patientId?: string;
   pharmacyId?: string;
@@ -237,6 +238,7 @@ const Component = (props: {
               additional-notes={props.additionalNotes}
               enable-med-history={props.enableMedHistory}
               enable-med-history-links={props.enableMedHistoryLinks}
+              enable-med-history-refill-button={props.enableMedHistoryRefillButton}
               enable-order={props.enableOrder}
               enable-local-pickup={props.enableLocalPickup}
               enable-send-to-patient={props.enableSendToPatient}
@@ -301,6 +303,7 @@ customElement(
     enableSendToPatient: false,
     enableMedHistory: false,
     enableMedHistoryLinks: false,
+    enableMedHistoryRefillButton: false,
     enableCombineAndDuplicate: false,
     mailOrderIds: undefined,
     enableOrder: false,

--- a/packages/elements/src/photon-multirx-form/components/AddPrescriptionCard.tsx
+++ b/packages/elements/src/photon-multirx-form/components/AddPrescriptionCard.tsx
@@ -3,10 +3,11 @@ import {
   Card,
   DoseCalculator,
   Icon,
+  ScreeningAlerts,
+  ScreeningAlertType,
   Text,
   triggerToast,
-  useRecentOrders,
-  ScreeningAlerts
+  useRecentOrders
 } from '@photonhealth/components';
 import photonStyles from '@photonhealth/components/dist/style.css?inline';
 import { DispenseUnit, Medication } from '@photonhealth/sdk/dist/types';
@@ -23,7 +24,6 @@ import { createSignal, onMount, Show } from 'solid-js';
 import { usePhoton } from '../../context';
 import clearForm from '../util/clearForm';
 import repopulateForm from '../util/repopulateForm';
-import { ScreeningAlertType } from '@photonhealth/components';
 
 setBasePath('https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.4.0/dist/');
 
@@ -132,8 +132,9 @@ export const AddPrescriptionCard = (props: {
     const errorsPresent = props.actions.hasErrors(keys);
 
     const draftedPrescriptions = [...props.store.draftPrescriptions.value];
-    const prescriptionAlreadyExistsInOrder = draftedPrescriptions.some(
-      (draft) => draft.treatment.id === props.store.treatment?.value?.id
+    const prescriptionAlreadyExistsInOrder = isTreatmentInOrder(
+      props.store.treatment?.value?.id,
+      draftedPrescriptions
     );
 
     if (prescriptionAlreadyExistsInOrder) {
@@ -527,3 +528,10 @@ export const AddPrescriptionCard = (props: {
     </div>
   );
 };
+
+export function isTreatmentInOrder(
+  treatmentId: string,
+  draftedPrescriptions: { treatment: { id: string } }[]
+) {
+  return draftedPrescriptions.some((draft) => draft.treatment.id === treatmentId);
+}

--- a/packages/elements/src/photon-multirx-form/components/AddPrescriptionCard.tsx
+++ b/packages/elements/src/photon-multirx-form/components/AddPrescriptionCard.tsx
@@ -132,12 +132,12 @@ export const AddPrescriptionCard = (props: {
     const errorsPresent = props.actions.hasErrors(keys);
 
     const draftedPrescriptions = [...props.store.draftPrescriptions.value];
-    const prescriptionAlreadyExistsInOrder = isTreatmentInOrder(
+    const isPrescriptionAlreadyAdded = isTreatmentInDraftPrescriptions(
       props.store.treatment?.value?.id,
       draftedPrescriptions
     );
 
-    if (prescriptionAlreadyExistsInOrder) {
+    if (isPrescriptionAlreadyAdded) {
       triggerToast({
         status: 'error',
         body: 'You already have this prescription in your order. You can modify the prescription or delete it in Pending Order.'
@@ -529,7 +529,7 @@ export const AddPrescriptionCard = (props: {
   );
 };
 
-export function isTreatmentInOrder(
+export function isTreatmentInDraftPrescriptions(
   treatmentId: string,
   draftedPrescriptions: { treatment: { id: string } }[]
 ) {

--- a/packages/elements/src/photon-multirx-form/components/DraftPrescriptionCard.tsx
+++ b/packages/elements/src/photon-multirx-form/components/DraftPrescriptionCard.tsx
@@ -24,7 +24,7 @@ export const DraftPrescriptionCard = (props: {
   actions: Record<string, (...args: any) => any>;
   store: Record<string, any>;
   setIsEditing: (isEditing: boolean) => void;
-  handleDeletedDraftPrescription: () => void;
+  handleDraftPrescriptionsChange: () => void;
   screeningAlerts: ScreeningAlertType[];
   enableOrder: boolean;
 }) => {
@@ -73,7 +73,7 @@ export const DraftPrescriptionCard = (props: {
           70
       });
 
-      props.handleDeletedDraftPrescription();
+      props.handleDraftPrescriptionsChange();
     }
   };
 
@@ -119,7 +119,7 @@ export const DraftPrescriptionCard = (props: {
       props.setIsEditing(true);
     }
 
-    props.handleDeletedDraftPrescription();
+    props.handleDraftPrescriptionsChange();
   };
   const handleDeleteCancel = () => {
     setDeleteDialogOpen(false);
@@ -184,6 +184,7 @@ export const DraftPrescriptionCard = (props: {
               key: 'draftPrescriptions',
               value: draftPrescriptions
             });
+            props.handleDraftPrescriptionsChange();
           }}
           error={props.store['draftPrescriptions']?.error}
           screeningAlerts={props.screeningAlerts}

--- a/packages/elements/src/photon-multirx-form/components/PatientCard.tsx
+++ b/packages/elements/src/photon-multirx-form/components/PatientCard.tsx
@@ -32,6 +32,7 @@ export const PatientCard = (props: {
   weightUnit?: string;
   enableMedHistory?: boolean;
   enableMedHistoryLinks?: boolean;
+  enableMedHistoryRefillButton?: boolean;
   hidePatientCard?: boolean;
   onRefillClick?: (prescriptionId: string, treatment: Treatment) => void;
 }) => {
@@ -156,6 +157,7 @@ export const PatientCard = (props: {
             patientId={patientId()}
             newMedication={newMedication()}
             enableLinks={props.enableMedHistoryLinks ?? false}
+            enableRefillButton={props.enableMedHistoryRefillButton ?? false}
             openAddMedicationDialog={() => setShowAddMedDialog(true)}
             hideAddMedicationDialog={() => setShowAddMedDialog(false)}
             onRefillClick={(rxId, treatment) => {

--- a/packages/elements/src/photon-multirx-form/components/PatientCard.tsx
+++ b/packages/elements/src/photon-multirx-form/components/PatientCard.tsx
@@ -33,6 +33,7 @@ export const PatientCard = (props: {
   enableMedHistory?: boolean;
   enableMedHistoryLinks?: boolean;
   hidePatientCard?: boolean;
+  onRefillClick?: (prescriptionId: string, treatment: Treatment) => void;
 }) => {
   const [newMedication, setNewMedication] = createSignal<Treatment | undefined>();
   undefined;
@@ -157,6 +158,9 @@ export const PatientCard = (props: {
             enableLinks={props.enableMedHistoryLinks ?? false}
             openAddMedicationDialog={() => setShowAddMedDialog(true)}
             hideAddMedicationDialog={() => setShowAddMedDialog(false)}
+            onRefillClick={(rxId, treatment) => {
+              props.onRefillClick && props.onRefillClick(rxId, treatment);
+            }}
           />
           <photon-add-medication-history-dialog
             title="Add Medication History"

--- a/packages/elements/src/photon-multirx-form/photon-prescribe-workflow-component.tsx
+++ b/packages/elements/src/photon-multirx-form/photon-prescribe-workflow-component.tsx
@@ -34,6 +34,7 @@ const Component = (props: PrescribeProps) => {
         enableSendToPatient={props.enableSendToPatient}
         enableMedHistory={props.enableMedHistory}
         enableMedHistoryLinks={props.enableMedHistoryLinks}
+        enableMedHistoryRefillButton={props.enableMedHistoryRefillButton}
         enableCombineAndDuplicate={props.enableCombineAndDuplicate}
         mailOrderIds={props.mailOrderIds}
         pharmacyId={props.pharmacyId}
@@ -68,6 +69,7 @@ customElement(
     enableSendToPatient: false,
     enableCombineAndDuplicate: false,
     enableMedHistory: false,
+    enableMedHistoryRefillButton: false,
     enableMedHistoryLinks: false,
     mailOrderIds: undefined,
     pharmacyId: undefined,

--- a/packages/elements/src/photon-multirx-form/photon-prescribe-workflow.tsx
+++ b/packages/elements/src/photon-multirx-form/photon-prescribe-workflow.tsx
@@ -4,7 +4,10 @@ import { PhotonAuthorized } from '../photon-authorized';
 import type { FormError } from '../stores/form';
 import tailwind from '../tailwind.css?inline';
 import { checkHasPermission } from '../utils';
-import { AddPrescriptionCard, isTreatmentInOrder } from './components/AddPrescriptionCard';
+import {
+  AddPrescriptionCard,
+  isTreatmentInDraftPrescriptions
+} from './components/AddPrescriptionCard';
 import { DraftPrescriptionCard } from './components/DraftPrescriptionCard';
 import { OrderCard } from './components/OrderCard';
 import { PatientCard } from './components/PatientCard';
@@ -514,7 +517,7 @@ export function PrescribeWorkflow(props: PrescribeProps) {
   }
 
   function tryAddRefillToDrafts(rxId: string, treatment: Treatment) {
-    if (isTreatmentInOrder(treatment.id, props.formStore.draftPrescriptions.value)) {
+    if (isTreatmentInDraftPrescriptions(treatment.id, props.formStore.draftPrescriptions.value)) {
       triggerToast({
         status: 'error',
         body: 'You already have this prescription in your order. You can modify the prescription or delete it in Pending Order.'

--- a/packages/elements/src/photon-multirx-form/photon-prescribe-workflow.tsx
+++ b/packages/elements/src/photon-multirx-form/photon-prescribe-workflow.tsx
@@ -61,6 +61,7 @@ export type PrescribeProps = {
   enableSendToPatient: boolean;
   enableMedHistory: boolean;
   enableMedHistoryLinks: boolean;
+  enableMedHistoryRefillButton: boolean;
   enableCombineAndDuplicate: boolean;
   mailOrderIds?: string;
   pharmacyId?: string;
@@ -603,6 +604,7 @@ export function PrescribeWorkflow(props: PrescribeProps) {
                 weightUnit={props.weightUnit}
                 enableMedHistory={props.enableMedHistory}
                 enableMedHistoryLinks={props.enableMedHistoryLinks ?? false}
+                enableMedHistoryRefillButton={props.enableMedHistoryRefillButton ?? false}
                 hidePatientCard={props.hidePatientCard}
                 onRefillClick={tryAddRefillToDrafts}
               />

--- a/packages/elements/src/photon-multirx-form/photon-prescribe-workflow.tsx
+++ b/packages/elements/src/photon-multirx-form/photon-prescribe-workflow.tsx
@@ -504,15 +504,32 @@ export function PrescribeWorkflow(props: PrescribeProps) {
     );
   });
 
+  function addRefillToDrafts(rxId: string) {
+    setPrescriptionIds((prev) => [...prev, rxId]);
+    triggerToast({
+      status: 'success',
+      header: 'Prescription Added',
+      body: 'You can send this order or add another prescription before sending it'
+    });
+  }
+
   function tryAddRefillToDrafts(rxId: string, treatment: Treatment) {
-    const isDuplicate = isTreatmentInOrder(treatment.id, props.formStore.draftPrescriptions.value);
-    if (!isDuplicate) {
-      setPrescriptionIds((prev) => [...prev, rxId]);
-    } else {
+    if (isTreatmentInOrder(treatment.id, props.formStore.draftPrescriptions.value)) {
       triggerToast({
         status: 'error',
         body: 'You already have this prescription in your order. You can modify the prescription or delete it in Pending Order.'
       });
+    } else if (
+      props.enableCombineAndDuplicate &&
+      recentOrdersActions.checkDuplicateFill(treatment.name)
+    ) {
+      recentOrdersActions.setIsDuplicateDialogOpen(
+        true,
+        recentOrdersActions.checkDuplicateFill(treatment.name),
+        () => addRefillToDrafts(rxId)
+      );
+    } else {
+      addRefillToDrafts(rxId);
     }
   }
 


### PR DESCRIPTION
- [X] Add Refill button within PatientMedHistory
  - [X] checks current order for duplicate treatment
  - [x] adds to order
  - [x] checks recent orders for duplicate treatment
- [x] add config option to hide refill button
- [x] Medication name is anchor link, instead of separate column having "Link" anchor
- [x] Improve styling by switching from Table to CSS Grid
- [x] Fix scrolling/padding of Card around the PatientMedHistory data
- [x] debounce clicking of refill button

Added FlyoutMenu, but ended up not using it. Left it in for potential future use.
- [x] ellipsis flyout menu (for rxlink, refill buttons)

## Demos

### clinical app
https://github.com/user-attachments/assets/00924392-f516-4c68-a713-230b0d9833e2

### elements
https://github.com/user-attachments/assets/67751d6c-7b87-47b9-be32-b7e5094e5af5


