### PR TITLE
Fix errors when agent has cached node packages

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,8 +19,11 @@ jobs:
         with:
           node-version: 20
 
+      - name: Clear npm cache
+        run: npm cache clean --force
+
       - name: Install Node.js dependencies
-        run: npm ci
+        run: npm ci --force
 
       - name: Run Lint
         run: npx nx run-many --all --target=lint


### PR DESCRIPTION
Sometimes Node is already installed/cached on the agents so we need to clear the cache when linting.

This should fix cache issues such as this:

```

Run npm ci
npm error code EEXIST
npm error syscall rename
npm error path /home/runner/.npm/_cacache/tmp/9f8c2973
npm error dest /home/runner/.npm/_cacache/content-v2/sha512/00/0d/d3563fb40368ae2284245842bfb6a16306ada3fba3cee98d3325cbf32c016110520edc72f4be5b3d8562e77196c001b2b499aafba19e15d3bf48fea3ccc6
npm error errno -2
npm error ENOENT: no such file or directory, rename '/home/runner/.npm/_cacache/tmp/9f8c2973' -> '/home/runner/.npm/_cacache/content-v2/sha512/00/0d/d3563fb40368ae2284245842bfb6a16306ada3fba3cee98d3325cbf32c016110520edc72f4be5b3d8562e77196c001b2b499aafba19e15d3bf48fea3ccc6'
npm error File exists: /home/runner/.npm/_cacache/content-v2/sha512/00/0d/d3563fb40368ae2284245842bfb6a16306ada3fba3cee98d3325cbf32c016110520edc72f4be5b3d8562e77196c001b2b499aafba19e15d3bf48fea3ccc6
npm error Remove the existing file and try again, or run npm
npm error with --force to overwrite files recklessly.
npm error A complete log of this run can be found in: /home/runner/.npm/_logs/2025-03-24T16_04_41_413Z-debug-0.log
Error: Process completed with exit code 254.
```