### PR TITLE
Fix/med history expand

### DIFF
--- a/packages/components/src/systems/PatientMedHistory/PatientMedHistoryTable.stories.tsx
+++ b/packages/components/src/systems/PatientMedHistory/PatientMedHistoryTable.stories.tsx
@@ -1,8 +1,8 @@
 import type { Meta, StoryObj } from '@storybook/html';
 import type { ComponentProps } from 'solid-js';
-import { PatientTreatmentHistoryElement } from './index';
-import PatientMedHistoryTable from './PatientMedHistoryTable';
+import PatientMedHistoryTable, { MedHistoryRowItem } from './PatientMedHistoryTable';
 import { createTestPrescription, createTestTreatment } from '../../utils/storybookUtils';
+import { ulid } from 'ulid';
 
 type Story = StoryObj<typeof PatientMedHistoryTable>;
 
@@ -15,9 +15,9 @@ export const Default: Story = {
   }
 };
 
-const testData: PatientTreatmentHistoryElement[] = [
+const testData: MedHistoryRowItem[] = [
   {
-    active: false,
+    rowId: ulid(),
     prescription: createTestPrescription({
       id: 'rx-id-1',
       dispenseQuantity: 30,
@@ -26,14 +26,14 @@ const testData: PatientTreatmentHistoryElement[] = [
     treatment: createTestTreatment({ name: 'treatment name 1' })
   },
   {
-    active: false,
+    rowId: ulid(),
     prescription: createTestPrescription({ instructions: 'very long instructions '.repeat(10) }),
     treatment: createTestTreatment({
       name: 'treatment name 2 is very long and might get truncated on a small screen'
     })
   },
   {
-    active: false,
+    rowId: ulid(),
     prescription: undefined,
     treatment: createTestTreatment({
       name: 'External Medication'
@@ -50,7 +50,7 @@ export default {
         <PatientMedHistoryTable
           enableLinks={props.enableLinks}
           enableRefillButton={props.enableRefillButton}
-          medHistory={testData}
+          rowItems={testData}
           baseURL={'test-base-url.com/'}
           chronological={true}
           onChronologicalChange={() => {}}

--- a/packages/components/src/systems/PatientMedHistory/PatientMedHistoryTable.tsx
+++ b/packages/components/src/systems/PatientMedHistory/PatientMedHistoryTable.tsx
@@ -6,24 +6,6 @@ import { IconButton } from '../../particles/IconButton';
 import { debounce } from '@solid-primitives/scheduled';
 import clsx from 'clsx';
 
-const LoadingRowFallback = (props: { enableRefill: boolean }) => {
-  const cellClasses = 'px-4 py-4 select-none';
-  return (
-    <>
-      <div class={cellClasses}>
-        <Text sampleLoadingText={generateString(10, 25)} loading />
-      </div>
-      <div class={cellClasses}>
-        <Text sampleLoadingText="aaaaa" loading />
-      </div>
-      <Show when={props.enableRefill}>
-        <div class={cellClasses}>
-          <Text sampleLoadingText="aaa" loading />
-        </div>
-      </Show>
-    </>
-  );
-};
 export type PatientMedHistoryTableProps = {
   enableLinks: boolean;
   enableRefillButton: boolean;
@@ -167,6 +149,25 @@ export default function PatientMedHistoryTable(props: PatientMedHistoryTableProp
     </div>
   );
 }
+
+const LoadingRowFallback = (props: { enableRefill: boolean }) => {
+  const cellClasses = 'px-4 py-4 select-none';
+  return (
+    <>
+      <div class={cellClasses}>
+        <Text sampleLoadingText={generateString(10, 25)} loading />
+      </div>
+      <div class={cellClasses}>
+        <Text sampleLoadingText="aaaaa" loading />
+      </div>
+      <Show when={props.enableRefill}>
+        <div class={cellClasses}>
+          <Text sampleLoadingText="aaa" loading />
+        </div>
+      </Show>
+    </>
+  );
+};
 
 function presentWrittenAt(med: PatientTreatmentHistoryElement) {
   if (!med.prescription) {


### PR DESCRIPTION
* Mainly fixes clicking items with the same Treatment ID (e.g. 2+ prescriptions of "amoxicillin 500mg") expanding all rows with that Treatment ID
* Refactors
  *  type mappings, prop naming, code organization
  * Remove unused `active` and `comment` fields