### PR TITLE
Disable med refill button

### DIFF
--- a/apps/app/src/views/routes/PrescriptionForm.tsx
+++ b/apps/app/src/views/routes/PrescriptionForm.tsx
@@ -119,7 +119,7 @@ export const PrescriptionForm = () => {
           enable-order={orgSettings?.enableRxAndOrder ?? true}
           enable-med-history={orgSettings?.enableMedHistory ?? false}
           enable-med-history-links={true}
-          enable-med-history-refill-button={true}
+          enable-med-history-refill-button={false}
           enable-local-pickup={orgSettings?.pickUp ?? false}
           enable-send-to-patient={orgSettings?.sendToPatient ?? false}
           enable-combine-and-duplicate={orgSettings?.enableCombineAndDuplicate ?? false}


### PR DESCRIPTION
- mainly due to z-index conflicts between IconButton, sticky grid header, and recent orders duplicate popup