### PR TITLE
Enable med history refill button

### DIFF
--- a/apps/app/src/views/routes/PrescriptionForm.tsx
+++ b/apps/app/src/views/routes/PrescriptionForm.tsx
@@ -119,7 +119,7 @@ export const PrescriptionForm = () => {
           enable-order={orgSettings?.enableRxAndOrder ?? true}
           enable-med-history={orgSettings?.enableMedHistory ?? false}
           enable-med-history-links={true}
-          enable-med-history-refill-button={false}
+          enable-med-history-refill-button={true}
           enable-local-pickup={orgSettings?.pickUp ?? false}
           enable-send-to-patient={orgSettings?.sendToPatient ?? false}
           enable-combine-and-duplicate={orgSettings?.enableCombineAndDuplicate ?? false}

--- a/packages/components/src/particles/Dialog/index.tsx
+++ b/packages/components/src/particles/Dialog/index.tsx
@@ -3,6 +3,7 @@ import { Transition } from 'solid-transition-group';
 import Icon from '../Icon';
 import createTransition from '../../utils/createTransition';
 import clsx from 'clsx';
+import { ZendeskMessagingWidget } from '../../../types/zendesk';
 
 const transitionDuration = 100;
 export interface DialogProps {
@@ -27,11 +28,12 @@ function Dialog(props: DialogProps) {
   );
 
   createEffect(() => {
-    if (window?.zE) {
+    const ze = window?.zE as ZendeskMessagingWidget | undefined;
+    if (ze) {
       if (merged.open) {
-        window.zE('messenger', 'hide');
+        ze('messenger', 'hide');
       } else {
-        window.zE('messenger', 'show');
+        ze('messenger', 'show');
       }
     }
   });

--- a/packages/components/src/particles/Dialog/index.tsx
+++ b/packages/components/src/particles/Dialog/index.tsx
@@ -37,7 +37,7 @@ function Dialog(props: DialogProps) {
   });
 
   return (
-    <div class="relative z-10">
+    <div class="relative z-20">
       <Transition
         onEnter={createTransition([{ opacity: 0 }, { opacity: 1 }], {
           duration: transitionDuration,

--- a/packages/components/src/systems/DraftPrescriptions/index.tsx
+++ b/packages/components/src/systems/DraftPrescriptions/index.tsx
@@ -123,6 +123,14 @@ export default function DraftPrescriptions(props: DraftPrescriptionsProps) {
     ...merged.prescriptionIds
   ]);
 
+  onMount(() => {
+    if (allDraftPrescriptionIds().length > 0) {
+      fetchDrafts();
+    } else {
+      setIsLoading(false);
+    }
+  });
+
   async function fetchDrafts() {
     setIsLoading(true);
     const draftPrescriptions: DraftPrescription[] = [];
@@ -197,14 +205,6 @@ export default function DraftPrescriptions(props: DraftPrescriptionsProps) {
     }
     setIsLoading(false);
   }
-
-  onMount(() => {
-    if (allDraftPrescriptionIds().length > 0) {
-      fetchDrafts();
-    } else {
-      setIsLoading(false);
-    }
-  });
 
   return (
     <div class="space-y-3">

--- a/packages/components/src/systems/DraftPrescriptions/index.tsx
+++ b/packages/components/src/systems/DraftPrescriptions/index.tsx
@@ -1,14 +1,6 @@
 import { Catalog, PrescriptionTemplate } from '@photonhealth/sdk/dist/types';
 import gql from 'graphql-tag';
-import {
-  createEffect,
-  createMemo,
-  createSignal,
-  For,
-  JSXElement,
-  mergeProps,
-  Show
-} from 'solid-js';
+import { createMemo, createSignal, For, JSXElement, mergeProps, onMount, Show } from 'solid-js';
 import Banner from '../../particles/Banner';
 import Card from '../../particles/Card';
 import Icon from '../../particles/Icon';
@@ -206,7 +198,7 @@ export default function DraftPrescriptions(props: DraftPrescriptionsProps) {
     setIsLoading(false);
   }
 
-  createEffect(() => {
+  onMount(() => {
     if (allDraftPrescriptionIds().length > 0) {
       fetchDrafts();
     } else {

--- a/packages/components/src/systems/PatientMedHistory/PatientMedHistoryTable.stories.tsx
+++ b/packages/components/src/systems/PatientMedHistory/PatientMedHistoryTable.stories.tsx
@@ -1,8 +1,8 @@
 import type { Meta, StoryObj } from '@storybook/html';
 import type { ComponentProps } from 'solid-js';
-import { PatientTreatmentHistoryElement } from './index';
-import PatientMedHistoryTable from './PatientMedHistoryTable';
+import PatientMedHistoryTable, { MedHistoryRowItem } from './PatientMedHistoryTable';
 import { createTestPrescription, createTestTreatment } from '../../utils/storybookUtils';
+import { ulid } from 'ulid';
 
 type Story = StoryObj<typeof PatientMedHistoryTable>;
 
@@ -15,9 +15,9 @@ export const Default: Story = {
   }
 };
 
-const testData: PatientTreatmentHistoryElement[] = [
+const testData: MedHistoryRowItem[] = [
   {
-    active: false,
+    rowId: ulid(),
     prescription: createTestPrescription({
       id: 'rx-id-1',
       dispenseQuantity: 30,
@@ -26,14 +26,14 @@ const testData: PatientTreatmentHistoryElement[] = [
     treatment: createTestTreatment({ name: 'treatment name 1' })
   },
   {
-    active: false,
+    rowId: ulid(),
     prescription: createTestPrescription({ instructions: 'very long instructions '.repeat(10) }),
     treatment: createTestTreatment({
       name: 'treatment name 2 is very long and might get truncated on a small screen'
     })
   },
   {
-    active: false,
+    rowId: ulid(),
     prescription: undefined,
     treatment: createTestTreatment({
       name: 'External Medication'
@@ -50,7 +50,7 @@ export default {
         <PatientMedHistoryTable
           enableLinks={props.enableLinks}
           enableRefillButton={props.enableRefillButton}
-          medHistory={testData}
+          rowItems={testData}
           baseURL={'test-base-url.com/'}
           chronological={true}
           onChronologicalChange={() => {}}

--- a/packages/components/src/systems/PatientMedHistory/PatientMedHistoryTable.stories.tsx
+++ b/packages/components/src/systems/PatientMedHistory/PatientMedHistoryTable.stories.tsx
@@ -2,7 +2,6 @@ import type { Meta, StoryObj } from '@storybook/html';
 import type { ComponentProps } from 'solid-js';
 import PatientMedHistoryTable, { MedHistoryRowItem } from './PatientMedHistoryTable';
 import { createTestPrescription, createTestTreatment } from '../../utils/storybookUtils';
-import { ulid } from 'ulid';
 
 type Story = StoryObj<typeof PatientMedHistoryTable>;
 
@@ -17,7 +16,6 @@ export const Default: Story = {
 
 const testData: MedHistoryRowItem[] = [
   {
-    rowId: ulid(),
     prescription: createTestPrescription({
       id: 'rx-id-1',
       dispenseQuantity: 30,
@@ -26,14 +24,12 @@ const testData: MedHistoryRowItem[] = [
     treatment: createTestTreatment({ name: 'treatment name 1' })
   },
   {
-    rowId: ulid(),
     prescription: createTestPrescription({ instructions: 'very long instructions '.repeat(10) }),
     treatment: createTestTreatment({
       name: 'treatment name 2 is very long and might get truncated on a small screen'
     })
   },
   {
-    rowId: ulid(),
     prescription: undefined,
     treatment: createTestTreatment({
       name: 'External Medication'

--- a/packages/components/src/systems/PatientMedHistory/PatientMedHistoryTable.stories.tsx
+++ b/packages/components/src/systems/PatientMedHistory/PatientMedHistoryTable.stories.tsx
@@ -50,8 +50,8 @@ export default {
           enableRefillButton={props.enableRefillButton}
           rowItems={testData}
           baseURL={'test-base-url.com/'}
-          chronological={true}
-          onChronologicalChange={() => {}}
+          sortOrder={'desc'}
+          onSortOrderToggle={() => {}}
           onRefillClick={() => {}}
         ></PatientMedHistoryTable>
       </div>

--- a/packages/components/src/systems/PatientMedHistory/PatientMedHistoryTable.stories.tsx
+++ b/packages/components/src/systems/PatientMedHistory/PatientMedHistoryTable.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/html';
 import type { ComponentProps } from 'solid-js';
 import PatientMedHistoryTable, { MedHistoryRowItem } from './PatientMedHistoryTable';
-import { createTestPrescription, createTestTreatment } from '../../utils/storybookUtils';
+import { createTestMedHistoryPrescription, createTestTreatment } from '../../utils/storybookUtils';
 
 type Story = StoryObj<typeof PatientMedHistoryTable>;
 
@@ -16,7 +16,7 @@ export const Default: Story = {
 
 const testData: MedHistoryRowItem[] = [
   {
-    prescription: createTestPrescription({
+    prescription: createTestMedHistoryPrescription({
       id: 'rx-id-1',
       dispenseQuantity: 30,
       dispenseUnit: 'unit'
@@ -24,7 +24,9 @@ const testData: MedHistoryRowItem[] = [
     treatment: createTestTreatment({ name: 'treatment name 1' })
   },
   {
-    prescription: createTestPrescription({ instructions: 'very long instructions '.repeat(10) }),
+    prescription: createTestMedHistoryPrescription({
+      instructions: 'very long instructions '.repeat(10)
+    }),
     treatment: createTestTreatment({
       name: 'treatment name 2 is very long and might get truncated on a small screen'
     })

--- a/packages/components/src/systems/PatientMedHistory/PatientMedHistoryTable.tsx
+++ b/packages/components/src/systems/PatientMedHistory/PatientMedHistoryTable.tsx
@@ -7,14 +7,15 @@ import {
   Text,
   useRecentOrders
 } from '../../';
-import { Prescription, Treatment } from '@photonhealth/sdk/dist/types';
+import { Treatment } from '@photonhealth/sdk/dist/types';
 import { IconButton } from '../../particles/IconButton';
 import { debounce } from '@solid-primitives/scheduled';
 import clsx from 'clsx';
+import { MedHistoryPrescription } from './index';
 
 export type MedHistoryRowItem = {
   treatment: Treatment;
-  prescription?: Prescription;
+  prescription?: MedHistoryPrescription;
 };
 
 export type PatientMedHistoryTableProps = {
@@ -24,7 +25,7 @@ export type PatientMedHistoryTableProps = {
   baseURL: string;
   onChronologicalChange: () => void;
   chronological: boolean;
-  onRefillClick: (prescriptionId: string, treatment: Treatment) => void;
+  onRefillClick: (prescription: MedHistoryPrescription, treatment: Treatment) => void;
 };
 
 export default function PatientMedHistoryTable(props: PatientMedHistoryTableProps) {
@@ -32,8 +33,8 @@ export default function PatientMedHistoryTable(props: PatientMedHistoryTableProp
 
   const debouncedRefill = createMemo(() => {
     const onRefillClick = props.onRefillClick;
-    return debounce(async (prescriptionId: string, treatment: Treatment) => {
-      onRefillClick(prescriptionId, treatment);
+    return debounce(async (prescription: MedHistoryPrescription, treatment: Treatment) => {
+      onRefillClick(prescription, treatment);
     }, 300);
   });
 
@@ -115,7 +116,7 @@ export default function PatientMedHistoryTable(props: PatientMedHistoryTableProp
                     label="Refill"
                     onClick={() => {
                       if (rowItem.prescription) {
-                        debouncedRefill()(rowItem.prescription.id, rowItem.treatment);
+                        debouncedRefill()(rowItem.prescription, rowItem.treatment);
                       }
                     }}
                     disabled={!rowItem.prescription}

--- a/packages/components/src/systems/PatientMedHistory/PatientMedHistoryTable.tsx
+++ b/packages/components/src/systems/PatientMedHistory/PatientMedHistoryTable.tsx
@@ -23,8 +23,8 @@ export type PatientMedHistoryTableProps = {
   enableRefillButton: boolean;
   rowItems?: MedHistoryRowItem[] | undefined;
   baseURL: string;
-  onChronologicalChange: () => void;
-  chronological: boolean;
+  onSortOrderToggle: () => void;
+  sortOrder: 'asc' | 'desc';
   onRefillClick: (prescription: MedHistoryPrescription, treatment: Treatment) => void;
 };
 
@@ -63,14 +63,14 @@ export default function PatientMedHistoryTable(props: PatientMedHistoryTableProp
         <div class="px-4 sm:px-6 py-3.5">Medication</div>
         <div
           class="px-4 sm:px-6 py-3.5 cursor-pointer flex"
-          onClick={() => props.onChronologicalChange()}
+          onClick={() => props.onSortOrderToggle()}
         >
           Written
           <div class="ml-1">
-            <Show when={props.chronological}>
+            <Show when={props.sortOrder === 'desc'}>
               <Icon name="chevronDown" size="sm" />
             </Show>
-            <Show when={!props.chronological}>
+            <Show when={props.sortOrder === 'asc'}>
               <Icon name="chevronUp" size="sm" />
             </Show>
           </div>

--- a/packages/components/src/systems/PatientMedHistory/PatientMedHistoryTable.tsx
+++ b/packages/components/src/systems/PatientMedHistory/PatientMedHistoryTable.tsx
@@ -1,5 +1,12 @@
 import { Component, createMemo, createSignal, For, Show } from 'solid-js';
-import { formatDate, formatPrescriptionDetails, generateString, Icon, Text } from '../../';
+import {
+  formatDate,
+  formatPrescriptionDetails,
+  generateString,
+  Icon,
+  Text,
+  useRecentOrders
+} from '../../';
 import { Prescription, Treatment } from '@photonhealth/sdk/dist/types';
 import { IconButton } from '../../particles/IconButton';
 import { debounce } from '@solid-primitives/scheduled';
@@ -23,6 +30,7 @@ export type PatientMedHistoryTableProps = {
 };
 
 export default function PatientMedHistoryTable(props: PatientMedHistoryTableProps) {
+  const [ordersState] = useRecentOrders();
   const [expandedRows, setExpandedRows] = createSignal<Set<string>>(new Set());
 
   const toggleExpand = (rowItem: MedHistoryRowItem) => {
@@ -153,7 +161,7 @@ export default function PatientMedHistoryTable(props: PatientMedHistoryTableProp
                         debouncedRefill()(rowItem.prescription.id, rowItem.treatment);
                       }
                     }}
-                    disabled={!rowItem.prescription}
+                    disabled={ordersState.isLoading || !rowItem.prescription}
                   />
                 </div>
               </Show>

--- a/packages/components/src/systems/PatientMedHistory/PatientMedHistoryTable.tsx
+++ b/packages/components/src/systems/PatientMedHistory/PatientMedHistoryTable.tsx
@@ -1,4 +1,4 @@
-import { Component, createMemo, createSignal, For, Show } from 'solid-js';
+import { Component, createMemo, For, Show } from 'solid-js';
 import {
   formatDate,
   formatPrescriptionDetails,
@@ -30,20 +30,6 @@ export type PatientMedHistoryTableProps = {
 
 export default function PatientMedHistoryTable(props: PatientMedHistoryTableProps) {
   const [ordersState] = useRecentOrders();
-  const [expandedRows, setExpandedRows] = createSignal<Set<string>>(new Set());
-
-  const toggleExpand = (rowItem: MedHistoryRowItem) => {
-    const rowId = rowItem.rowId;
-    setExpandedRows((prev) => {
-      const newSet = new Set(prev);
-      if (newSet.has(rowId)) {
-        newSet.delete(rowId);
-      } else {
-        newSet.add(rowId);
-      }
-      return newSet;
-    });
-  };
 
   const debouncedRefill = createMemo(() => {
     const onRefillClick = props.onRefillClick;
@@ -75,7 +61,10 @@ export default function PatientMedHistoryTable(props: PatientMedHistoryTableProp
     >
       <div class={gridHeaderClass()}>
         <div class="px-4 sm:px-6 py-3.5">Medication</div>
-        <div class="px-4 py-3.5 cursor-pointer flex" onClick={() => props.onChronologicalChange()}>
+        <div
+          class="px-4 sm:px-6 py-3.5 cursor-pointer flex"
+          onClick={() => props.onChronologicalChange()}
+        >
           Written
           <div class="ml-1">
             <Show when={props.chronological}>
@@ -105,42 +94,19 @@ export default function PatientMedHistoryTable(props: PatientMedHistoryTableProp
           {(rowItem) => (
             <>
               <div class="px-4 sm:px-6 py-4 truncate">
-                <div class="flex">
-                  <div
-                    class={`flex-col flex-1 min-w-0 ${
-                      expandedRows().has(rowItem.rowId) ? 'whitespace-normal' : ''
-                    }`}
-                  >
-                    <MedicationName
-                      treatmentName={rowItem.treatment.name}
-                      prescriptionId={rowItem.prescription?.id}
-                      enableLinks={props.enableLinks}
-                      linkBaseUrl={props.baseURL}
-                    />
-                    <div class="text-gray-500 text-ellipsis overflow-hidden">
-                      {formatPrescriptionDetails(rowItem.prescription)}
-                    </div>
+                <div class="flex-col flex-1 min-w-0 whitespace-normal">
+                  <MedicationName
+                    treatmentName={rowItem.treatment.name}
+                    prescriptionId={rowItem.prescription?.id}
+                    enableLinks={props.enableLinks}
+                    linkBaseUrl={props.baseURL}
+                  />
+                  <div class="text-gray-500 text-ellipsis overflow-hidden">
+                    {formatPrescriptionDetails(rowItem.prescription)}
                   </div>
-                  <button
-                    type="button"
-                    onClick={() => toggleExpand(rowItem)}
-                    class="text-blue-500 hover:text-blue-700 text-sm ml-2 self-stretch flex items-center"
-                    aria-expanded={expandedRows().has(rowItem.rowId)}
-                    aria-label={
-                      expandedRows().has(rowItem.rowId)
-                        ? 'Collapse medication details'
-                        : 'Expand medication details'
-                    }
-                  >
-                    <Icon
-                      name={expandedRows().has(rowItem.rowId) ? 'minus' : 'plus'}
-                      size="sm"
-                      aria-hidden="true"
-                    />
-                  </button>
                 </div>
               </div>
-              <div class="px-4 py-4 self-center">{presentWrittenAt(rowItem)}</div>
+              <div class="px-4 sm:px-6 py-4 self-center">{presentWrittenAt(rowItem)}</div>
 
               <Show when={props.enableRefillButton}>
                 <div class="px-4 sm:px-6 py-4 m-auto">
@@ -162,7 +128,7 @@ export default function PatientMedHistoryTable(props: PatientMedHistoryTableProp
         </For>
       </Show>
       <Show when={!ordersState.isLoading && props.rowItems && props.rowItems.length === 0}>
-        <div class="p-4 col-span-3 text-center">
+        <div class="px-4 sm:px-6 py-4 col-span-3 text-center">
           <Text color="gray">No medication history found.</Text>
         </div>
       </Show>
@@ -171,7 +137,7 @@ export default function PatientMedHistoryTable(props: PatientMedHistoryTableProp
 }
 
 const LoadingRowFallback = (props: { enableRefill: boolean }) => {
-  const cellClasses = 'px-4 py-4 select-none';
+  const cellClasses = 'px-4 sm:px-6 py-4 select-none';
   return (
     <>
       <div class={cellClasses}>

--- a/packages/components/src/systems/PatientMedHistory/PatientMedHistoryTable.tsx
+++ b/packages/components/src/systems/PatientMedHistory/PatientMedHistoryTable.tsx
@@ -13,7 +13,6 @@ import { debounce } from '@solid-primitives/scheduled';
 import clsx from 'clsx';
 
 export type MedHistoryRowItem = {
-  rowId: string;
   treatment: Treatment;
   prescription?: Prescription;
 };

--- a/packages/components/src/systems/PatientMedHistory/PatientMedHistoryTable.tsx
+++ b/packages/components/src/systems/PatientMedHistory/PatientMedHistoryTable.tsx
@@ -134,7 +134,7 @@ export default function PatientMedHistoryTable(props: PatientMedHistoryTableProp
               <div class="px-4 py-4 self-center">{presentWrittenAt(rowItem)}</div>
 
               <Show when={props.enableRefillButton}>
-                <div class="px-4 py-4 self-center">
+                <div class="px-4 py-4 m-auto">
                   <IconButton
                     iconName="documentPlus"
                     iconSize="sm"

--- a/packages/components/src/systems/PatientMedHistory/PatientMedHistoryTable.tsx
+++ b/packages/components/src/systems/PatientMedHistory/PatientMedHistoryTable.tsx
@@ -153,7 +153,7 @@ export default function PatientMedHistoryTable(props: PatientMedHistoryTableProp
                         debouncedRefill()(rowItem.prescription.id, rowItem.treatment);
                       }
                     }}
-                    disabled={ordersState.isLoading || !rowItem.prescription}
+                    disabled={!rowItem.prescription}
                   />
                 </div>
               </Show>

--- a/packages/components/src/systems/PatientMedHistory/PatientMedHistoryTable.tsx
+++ b/packages/components/src/systems/PatientMedHistory/PatientMedHistoryTable.tsx
@@ -6,24 +6,6 @@ import { IconButton } from '../../particles/IconButton';
 import { debounce } from '@solid-primitives/scheduled';
 import clsx from 'clsx';
 
-const LoadingRowFallback = (props: { enableRefill: boolean }) => {
-  const cellClasses = 'px-4 py-4 select-none';
-  return (
-    <>
-      <div class={cellClasses}>
-        <Text sampleLoadingText={generateString(10, 25)} loading />
-      </div>
-      <div class={cellClasses}>
-        <Text sampleLoadingText="aaaaa" loading />
-      </div>
-      <Show when={props.enableRefill}>
-        <div class={cellClasses}>
-          <Text sampleLoadingText="aaa" loading />
-        </div>
-      </Show>
-    </>
-  );
-};
 export type PatientMedHistoryTableProps = {
   enableLinks: boolean;
   enableRefillButton: boolean;
@@ -167,6 +149,25 @@ export default function PatientMedHistoryTable(props: PatientMedHistoryTableProp
     </div>
   );
 }
+
+const LoadingRowFallback = (props: { enableRefill: boolean }) => {
+  const cellClasses = 'px-4 py-4 select-none';
+  return (
+    <>
+      <div class={cellClasses}>
+        <Text sampleLoadingText={generateString(10, 25)} loading />
+      </div>
+      <div class={cellClasses}>
+        <Text sampleLoadingText="aaaaa" loading />
+      </div>
+      <Show when={props.enableRefill}>
+        <div class={cellClasses}>
+          <Text sampleLoadingText="aaa" loading />
+        </div>
+      </Show>
+    </>
+  );
+};
 
 function presentWrittenAt(med: PatientTreatmentHistoryElement) {
   if (!med.prescription) {

--- a/packages/components/src/systems/PatientMedHistory/PatientMedHistoryTable.tsx
+++ b/packages/components/src/systems/PatientMedHistory/PatientMedHistoryTable.tsx
@@ -74,7 +74,7 @@ export default function PatientMedHistoryTable(props: PatientMedHistoryTableProp
       }}
     >
       <div class={gridHeaderClass()}>
-        <div class="px-4 py-3.5">Medication</div>
+        <div class="px-4 sm:px-6 py-3.5">Medication</div>
         <div class="px-4 py-3.5 cursor-pointer flex" onClick={() => props.onChronologicalChange()}>
           Written
           <div class="ml-1">
@@ -87,7 +87,7 @@ export default function PatientMedHistoryTable(props: PatientMedHistoryTableProp
           </div>
         </div>
         <Show when={props.enableRefillButton}>
-          <div class="px-4 py-3.5">Actions</div>
+          <div class="px-4 sm:px-6 py-3.5">Actions</div>
         </Show>
       </div>
 
@@ -104,7 +104,7 @@ export default function PatientMedHistoryTable(props: PatientMedHistoryTableProp
         <For each={props.rowItems}>
           {(rowItem) => (
             <>
-              <div class="px-4 py-4 truncate">
+              <div class="px-4 sm:px-6 py-4 truncate">
                 <div class="flex">
                   <div
                     class={`flex-col flex-1 min-w-0 ${
@@ -143,7 +143,7 @@ export default function PatientMedHistoryTable(props: PatientMedHistoryTableProp
               <div class="px-4 py-4 self-center">{presentWrittenAt(rowItem)}</div>
 
               <Show when={props.enableRefillButton}>
-                <div class="px-4 py-4 m-auto">
+                <div class="px-4 sm:px-6 py-4 m-auto">
                   <IconButton
                     iconName="documentPlus"
                     iconSize="sm"
@@ -160,6 +160,11 @@ export default function PatientMedHistoryTable(props: PatientMedHistoryTableProp
             </>
           )}
         </For>
+      </Show>
+      <Show when={!ordersState.isLoading && props.rowItems && props.rowItems.length === 0}>
+        <div class="p-4 col-span-3 text-center">
+          <Text color="gray">No medication history found.</Text>
+        </div>
       </Show>
     </div>
   );

--- a/packages/components/src/systems/PatientMedHistory/PatientMedHistoryTable.tsx
+++ b/packages/components/src/systems/PatientMedHistory/PatientMedHistoryTable.tsx
@@ -92,7 +92,7 @@ export default function PatientMedHistoryTable(props: PatientMedHistoryTableProp
       </div>
 
       <Show
-        when={props.rowItems}
+        when={!ordersState.isLoading && props.rowItems}
         fallback={
           <>
             <LoadingRowFallback enableRefill={props.enableRefillButton} />

--- a/packages/components/src/systems/PatientMedHistory/PatientMedHistoryTable.tsx
+++ b/packages/components/src/systems/PatientMedHistory/PatientMedHistoryTable.tsx
@@ -10,7 +10,6 @@ import {
 import { Prescription, Treatment } from '@photonhealth/sdk/dist/types';
 import { IconButton } from '../../particles/IconButton';
 import { debounce } from '@solid-primitives/scheduled';
-import { datadogRum } from '@datadog/browser-rum';
 import clsx from 'clsx';
 
 export type MedHistoryRowItem = {
@@ -44,19 +43,12 @@ export default function PatientMedHistoryTable(props: PatientMedHistoryTableProp
       }
       return newSet;
     });
-
-    datadogRum.addAction('med_history_toggle_expand_btn_click', {
-      prescriptionId: rowItem.prescription?.id && 'external-rx'
-    });
   };
 
   const debouncedRefill = createMemo(() => {
     const onRefillClick = props.onRefillClick;
     return debounce(async (prescriptionId: string, treatment: Treatment) => {
       onRefillClick(prescriptionId, treatment);
-      datadogRum.addAction('med_history_renew_btn_click', {
-        prescriptionId: prescriptionId
-      });
     }, 300);
   });
 

--- a/packages/components/src/systems/PatientMedHistory/index.tsx
+++ b/packages/components/src/systems/PatientMedHistory/index.tsx
@@ -95,7 +95,7 @@ export default function PatientMedHistory(props: PatientMedHistoryProps) {
   const [medHistoryRowItems, setMedHistoryRowItems] = createSignal<MedHistoryRowItem[] | undefined>(
     undefined
   );
-  const [chronological, setChronological] = createSignal<boolean>(false);
+  const [sortOrder, setSortOrder] = createSignal<'asc' | 'desc'>('asc');
 
   const baseURL = createMemo(() => `${client?.clinicalUrl}/prescriptions/`);
 
@@ -118,7 +118,7 @@ export default function PatientMedHistory(props: PatientMedHistoryProps) {
       setMedHistoryRowItems(undefined);
     } else if (getPatientResponse) {
       const rowItems = mapToMedHistoryRowItems(getPatientResponse);
-      const sortedRowItems = rowItems.slice().sort(sortHistoryByDate(chronological()));
+      const sortedRowItems = rowItems.slice().sort(sortHistoryByDate(sortOrder()));
       setMedHistoryRowItems(sortedRowItems);
     } else {
       setMedHistoryRowItems([]);
@@ -206,8 +206,8 @@ export default function PatientMedHistory(props: PatientMedHistoryProps) {
           enableRefillButton={props.enableRefillButton}
           baseURL={baseURL()}
           rowItems={medHistoryRowItems()}
-          chronological={chronological()}
-          onChronologicalChange={() => setChronological(!chronological())}
+          sortOrder={sortOrder()}
+          onSortOrderToggle={() => setSortOrder((prev) => (prev === 'asc' ? 'desc' : 'asc'))}
           onRefillClick={(prescription, treatment) =>
             props.onRefillClick && props.onRefillClick(prescription, treatment)
           }
@@ -223,7 +223,7 @@ const mapToMedHistoryRowItems = (getPatientResponse: GetPatientResponse): MedHis
     prescription: historyItem.prescription as MedHistoryPrescription
   }));
 
-const sortHistoryByDate = (chronological: boolean) => {
+const sortHistoryByDate = (order: 'asc' | 'desc') => {
   return (a: MedHistoryRowItem, b: MedHistoryRowItem) => {
     const dateA = a?.prescription?.writtenAt
       ? new Date(a.prescription.writtenAt).getTime()
@@ -231,7 +231,7 @@ const sortHistoryByDate = (chronological: boolean) => {
     const dateB = b?.prescription?.writtenAt
       ? new Date(b.prescription.writtenAt).getTime()
       : -Infinity;
-    if (chronological) return dateA - dateB;
+    if (order === 'desc') return dateA - dateB;
     return dateB - dateA;
   };
 };

--- a/packages/components/src/systems/PatientMedHistory/index.tsx
+++ b/packages/components/src/systems/PatientMedHistory/index.tsx
@@ -5,6 +5,7 @@ import { Prescription, Treatment } from '@photonhealth/sdk/dist/types';
 import { Button, Card, createQuery, Text, triggerToast } from '../../';
 import { ApolloCache } from '@apollo/client';
 import PatientMedHistoryTable, { MedHistoryRowItem } from './PatientMedHistoryTable';
+import { Maybe } from 'graphql/jsutils/Maybe';
 
 const GET_PATIENT_MED_HISTORY = gql`
   query GetPatient($id: ID!) {
@@ -16,8 +17,11 @@ const GET_PATIENT_MED_HISTORY = gql`
           id
           writtenAt
           instructions
+          notes
+          fillsAllowed
           dispenseQuantity
           dispenseUnit
+          dispenseAsWritten
           daysSupply
         }
         treatment {
@@ -28,6 +32,33 @@ const GET_PATIENT_MED_HISTORY = gql`
     }
   }
 `;
+
+type RemoveMaybe<T> = T extends Maybe<infer U>
+  ? Exclude<U, null>
+  : T extends undefined
+  ? never
+  : Exclude<T, null>;
+
+type RemoveMaybeFromArray<T> = T extends Array<Maybe<infer U>>
+  ? Array<Exclude<RemoveMaybe<U>, null>>
+  : RemoveMaybe<T>;
+
+type PrescriptionWithoutMaybes = {
+  [K in keyof Prescription]-?: RemoveMaybeFromArray<RemoveMaybe<Prescription[K]>>;
+};
+
+export type MedHistoryPrescription = Pick<
+  PrescriptionWithoutMaybes,
+  | 'id'
+  | 'writtenAt'
+  | 'dispenseQuantity'
+  | 'dispenseUnit'
+  | 'daysSupply'
+  | 'instructions'
+  | 'fillsAllowed'
+  | 'dispenseAsWritten'
+  | 'notes'
+>;
 
 const ADD_MED_HISTORY = gql`
   mutation UpdateMedicationHistory($id: ID!, $medicationHistory: [MedHistoryInput!]!) {
@@ -44,7 +75,7 @@ type PatientMedHistoryProps = {
   newMedication?: Treatment;
   openAddMedicationDialog?: () => void;
   hideAddMedicationDialog?: () => void;
-  onRefillClick?: (prescriptionId: string, treatment: Treatment) => void;
+  onRefillClick?: (prescription: MedHistoryPrescription, treatment: Treatment) => void;
 };
 
 export type GetPatientTreatmentHistoryItem = {
@@ -177,8 +208,8 @@ export default function PatientMedHistory(props: PatientMedHistoryProps) {
           rowItems={medHistoryRowItems()}
           chronological={chronological()}
           onChronologicalChange={() => setChronological(!chronological())}
-          onRefillClick={(rxId, treatment) =>
-            props.onRefillClick && props.onRefillClick(rxId, treatment)
+          onRefillClick={(prescription, treatment) =>
+            props.onRefillClick && props.onRefillClick(prescription, treatment)
           }
         />
       </div>
@@ -189,11 +220,11 @@ export default function PatientMedHistory(props: PatientMedHistoryProps) {
 const mapToMedHistoryRowItems = (getPatientResponse: GetPatientResponse): MedHistoryRowItem[] =>
   getPatientResponse?.patient?.treatmentHistory.map((historyItem) => ({
     treatment: historyItem.treatment,
-    prescription: historyItem.prescription
+    prescription: historyItem.prescription as MedHistoryPrescription
   }));
 
 const sortHistoryByDate = (chronological: boolean) => {
-  return (a: GetPatientTreatmentHistoryItem, b: GetPatientTreatmentHistoryItem) => {
+  return (a: MedHistoryRowItem, b: MedHistoryRowItem) => {
     const dateA = a?.prescription?.writtenAt
       ? new Date(a.prescription.writtenAt).getTime()
       : -Infinity;

--- a/packages/components/src/systems/PatientMedHistory/index.tsx
+++ b/packages/components/src/systems/PatientMedHistory/index.tsx
@@ -92,12 +92,13 @@ export default function PatientMedHistory(props: PatientMedHistoryProps) {
   createEffect(() => {
     const getPatientResponse = patientMedHistory();
     const medicationHistory = getPatientResponse?.patient?.treatmentHistory;
-    if (medicationHistory) {
+    if (patientMedHistory.loading) {
+      setMedHistoryRowItems(undefined);
+    } else if (medicationHistory) {
       const rowItems = mapToMedHistoryRowItems(getPatientResponse);
       const sortedRowItems = rowItems.slice().sort(sortHistoryByDate(chronological()));
       setMedHistoryRowItems(sortedRowItems);
-    }
-    if (!patientMedHistory.loading && !medicationHistory) {
+    } else {
       setMedHistoryRowItems([]);
     }
   });

--- a/packages/components/src/systems/RecentOrders/RecentOrders.tsx
+++ b/packages/components/src/systems/RecentOrders/RecentOrders.tsx
@@ -80,6 +80,7 @@ type RecentOrdersState = {
   isCombineDialogOpen: boolean;
   isDuplicateDialogOpen: boolean;
   isIssueDialogOpen: boolean;
+  isLoading: boolean;
   patientId?: string;
   patientName?: string;
   // in case the combine order fails, we need address to make a new order
@@ -118,6 +119,7 @@ type RecentOrdersContextValue = [RecentOrdersState, RecentOrdersActions];
 const RecentOrdersContext = createContext<RecentOrdersContextValue>([
   {
     orders: [],
+    isLoading: true,
     isCombineDialogOpen: false,
     isDuplicateDialogOpen: false,
     isIssueDialogOpen: false
@@ -140,6 +142,7 @@ function RecentOrders(props: SDKProviderProps) {
   const client = usePhotonClient();
   const [state, setState] = createStore<RecentOrdersState>({
     orders: [],
+    isLoading: true,
     isCombineDialogOpen: false,
     isDuplicateDialogOpen: false,
     isIssueDialogOpen: false,
@@ -207,6 +210,7 @@ function RecentOrders(props: SDKProviderProps) {
   ];
 
   createEffect(() => {
+    setState({ isLoading: data.loading });
     const patient = data()?.patient;
     if (!data.loading && patient) {
       const orders = patient?.orders;
@@ -221,6 +225,7 @@ function RecentOrders(props: SDKProviderProps) {
         });
 
         setState({
+          isLoading: false,
           orders: recentOrders,
           patientName: patient?.name?.full,
           patientId: patient?.id

--- a/packages/components/src/systems/RecentOrders/RecentOrders.tsx
+++ b/packages/components/src/systems/RecentOrders/RecentOrders.tsx
@@ -119,7 +119,7 @@ type RecentOrdersContextValue = [RecentOrdersState, RecentOrdersActions];
 const RecentOrdersContext = createContext<RecentOrdersContextValue>([
   {
     orders: [],
-    isLoading: true,
+    isLoading: false,
     isCombineDialogOpen: false,
     isDuplicateDialogOpen: false,
     isIssueDialogOpen: false
@@ -225,7 +225,6 @@ function RecentOrders(props: SDKProviderProps) {
         });
 
         setState({
-          isLoading: false,
           orders: recentOrders,
           patientName: patient?.name?.full,
           patientId: patient?.id

--- a/packages/components/src/utils/storybookUtils.ts
+++ b/packages/components/src/utils/storybookUtils.ts
@@ -9,6 +9,7 @@ import {
   SexType,
   Treatment
 } from '@photonhealth/sdk/src/types';
+import { MedHistoryPrescription } from '../systems/PatientMedHistory';
 
 export function createTestPatient(): Patient {
   return {
@@ -69,6 +70,23 @@ export function createTestPrescription(options: Partial<Prescription> = {}): Pre
     prescriber: createTestPrescriber(),
     state: PrescriptionState.Expired,
     treatment: createTestTreatment(),
+    writtenAt: undefined,
+    dispenseUnit: 'Each',
+    ...options
+  };
+}
+
+export function createTestMedHistoryPrescription(
+  options: Partial<MedHistoryPrescription> = {}
+): MedHistoryPrescription {
+  return {
+    dispenseQuantity: 0,
+    daysSupply: 0,
+    dispenseAsWritten: false,
+    fillsAllowed: 0,
+    id: '',
+    instructions: '',
+    notes: '',
     writtenAt: undefined,
     dispenseUnit: 'Each',
     ...options

--- a/packages/components/types/zendesk.d.ts
+++ b/packages/components/types/zendesk.d.ts
@@ -5,7 +5,7 @@
  * Zendesk messaging Web Widget SDK
  * https://developer.zendesk.com/api-reference/widget-messaging/introduction/
  */
-interface ZendeskMessagingWidget {
+export interface ZendeskMessagingWidget {
   /**
    * If your application has a login flow, or if a user needs to access the same conversation from multiple devices,
    * you can use the `loginUser` API.
@@ -166,6 +166,8 @@ interface ZendeskMessagingWidget {
   (type: 'messenger:set', setting: 'conversationTags', conversationTags: string[]): void;
 }
 
-interface Window {
-  zE?: ZendeskMessagingWidget;
+declare global {
+  interface Window {
+    zE?: ZendeskMessagingWidget;
+  }
 }

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@photonhealth/elements",
-  "version": "0.14.10",
+  "version": "0.14.11",
   "description": "",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/elements/src/photon-multirx-form/components/AddPrescriptionCard.tsx
+++ b/packages/elements/src/photon-multirx-form/components/AddPrescriptionCard.tsx
@@ -43,7 +43,7 @@ const validators = {
   effectiveDate: message(afterDate(new Date()), "Please choose a date that isn't in the past")
 };
 
-type DraftPrescription = {
+export type AddDraftPrescription = {
   id: string;
   effectiveDate: string;
   treatment: {
@@ -115,7 +115,7 @@ export const AddPrescriptionCard = (props: {
     ref?.dispatchEvent(event);
   };
 
-  const dispatchDraftPrescriptionCreated = (draftPrescription: DraftPrescription) => {
+  const dispatchDraftPrescriptionCreated = (draftPrescription: AddDraftPrescription) => {
     const event = new CustomEvent('photon-draft-prescription-created', {
       composed: true,
       bubbles: true,
@@ -143,7 +143,7 @@ export const AddPrescriptionCard = (props: {
         body: 'You already have this prescription in your order. You can modify the prescription or delete it in Pending Order.'
       });
     } else if (!errorsPresent) {
-      const draft: DraftPrescription = {
+      const draft: AddDraftPrescription = {
         id: String(Math.random()),
         effectiveDate: props.store.effectiveDate.value,
         treatment: props.store.treatment.value,

--- a/packages/elements/src/photon-multirx-form/components/AddPrescriptionCard.tsx
+++ b/packages/elements/src/photon-multirx-form/components/AddPrescriptionCard.tsx
@@ -74,6 +74,7 @@ export const AddPrescriptionCard = (props: {
   enableCombineAndDuplicate?: boolean;
   screenDraftedPrescriptions: () => void;
   draftedPrescriptionChanged: () => void;
+  onDraftPrescriptionCreated: (draft: AddDraftPrescription) => void;
   screeningAlerts: ScreeningAlertType[];
   catalogId?: string;
   allowOffCatalogSearch?: boolean;
@@ -110,17 +111,6 @@ export const AddPrescriptionCard = (props: {
       bubbles: true,
       detail: {
         errors: errors
-      }
-    });
-    ref?.dispatchEvent(event);
-  };
-
-  const dispatchDraftPrescriptionCreated = (draftPrescription: AddDraftPrescription) => {
-    const event = new CustomEvent('photon-draft-prescription-created', {
-      composed: true,
-      bubbles: true,
-      detail: {
-        draft: draftPrescription
       }
     });
     ref?.dispatchEvent(event);
@@ -217,7 +207,7 @@ export const AddPrescriptionCard = (props: {
           body: 'You can send this order or add another prescription before sending it'
         });
 
-        dispatchDraftPrescriptionCreated(draft);
+        props.onDraftPrescriptionCreated(draft);
       };
 
       if (props.enableCombineAndDuplicate && duplicate) {

--- a/packages/elements/src/photon-multirx-form/components/DraftPrescriptionCard.tsx
+++ b/packages/elements/src/photon-multirx-form/components/DraftPrescriptionCard.tsx
@@ -184,7 +184,6 @@ export const DraftPrescriptionCard = (props: {
               key: 'draftPrescriptions',
               value: draftPrescriptions
             });
-            props.handleDraftPrescriptionsChange();
           }}
           error={props.store['draftPrescriptions']?.error}
           screeningAlerts={props.screeningAlerts}

--- a/packages/elements/src/photon-multirx-form/components/PatientCard.tsx
+++ b/packages/elements/src/photon-multirx-form/components/PatientCard.tsx
@@ -6,6 +6,7 @@ import { message } from '../../validators';
 import { PatientStore } from '../../stores/patient';
 import { PhotonClientStore } from '../../store';
 import type { Address } from '../photon-prescribe-workflow';
+import { MedHistoryPrescription } from '@photonhealth/components/dist/packages/components/src/systems/PatientMedHistory';
 
 const patientValidator = message(record(string(), any()), 'Please select a patient...');
 
@@ -34,7 +35,7 @@ export const PatientCard = (props: {
   enableMedHistoryLinks?: boolean;
   enableMedHistoryRefillButton?: boolean;
   hidePatientCard?: boolean;
-  onRefillClick?: (prescriptionId: string, treatment: Treatment) => void;
+  onRefillClick?: (prescription: MedHistoryPrescription, treatment: Treatment) => void;
 }) => {
   const [newMedication, setNewMedication] = createSignal<Treatment | undefined>();
   undefined;
@@ -160,8 +161,8 @@ export const PatientCard = (props: {
             enableRefillButton={props.enableMedHistoryRefillButton ?? false}
             openAddMedicationDialog={() => setShowAddMedDialog(true)}
             hideAddMedicationDialog={() => setShowAddMedDialog(false)}
-            onRefillClick={(rxId, treatment) => {
-              props.onRefillClick && props.onRefillClick(rxId, treatment);
+            onRefillClick={(prescription, treatment) => {
+              props.onRefillClick && props.onRefillClick(prescription, treatment);
             }}
           />
           <photon-add-medication-history-dialog

--- a/packages/elements/src/photon-multirx-form/photon-prescribe-workflow.tsx
+++ b/packages/elements/src/photon-multirx-form/photon-prescribe-workflow.tsx
@@ -5,6 +5,7 @@ import type { FormError } from '../stores/form';
 import tailwind from '../tailwind.css?inline';
 import { checkHasPermission } from '../utils';
 import {
+  AddDraftPrescription,
   AddPrescriptionCard,
   isTreatmentInDraftPrescriptions
 } from './components/AddPrescriptionCard';
@@ -39,6 +40,8 @@ import shoelaceLightStyles from '@shoelace-style/shoelace/dist/themes/light.css?
 import { setBasePath } from '@shoelace-style/shoelace/dist/utilities/base-path.js';
 import { GraphQLFormattedError } from 'graphql';
 import { createEffect, createMemo, createSignal, For, onMount, Ref, Show, untrack } from 'solid-js';
+import { format } from 'date-fns';
+import { MedHistoryPrescription } from '@photonhealth/components/src/systems/PatientMedHistory';
 
 setBasePath('https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.4.0/dist/');
 
@@ -121,13 +124,6 @@ export function PrescribeWorkflow(props: PrescribeProps) {
 
   const [overrideScreenAlerts, setOverrideScreenAlerts] = createSignal<boolean>(false);
   const [isScreeningAlertWarningOpen, setIsScreeningAlertWarningOpen] = createSignal(false);
-
-  const [prescriptionIds, setPrescriptionIds] = createSignal<string[]>([]);
-
-  createEffect(() => {
-    const initialIds = props.prescriptionIds?.split(',') ?? [];
-    setPrescriptionIds(initialIds);
-  });
 
   // we can ignore the warnings to put inside of a createEffect, the additionalNotes or weight shouldn't be updating
   let prefillNotes = '';
@@ -507,8 +503,29 @@ export function PrescribeWorkflow(props: PrescribeProps) {
     );
   });
 
-  function addRefillToDrafts(rxId: string) {
-    setPrescriptionIds((prev) => [...prev, rxId]);
+  function addRefillToDrafts(prescription: MedHistoryPrescription, treatment: Treatment) {
+    const draft: AddDraftPrescription = {
+      id: String(Math.random()),
+      effectiveDate: format(new Date(), 'yyyy-MM-dd').toString(),
+      treatment: treatment,
+      dispenseAsWritten: prescription.dispenseAsWritten,
+      dispenseQuantity: prescription.dispenseQuantity,
+      dispenseUnit: prescription.dispenseUnit,
+      daysSupply: prescription.daysSupply,
+      refillsInput: prescription.fillsAllowed ? prescription.fillsAllowed - 1 : 0,
+      instructions: prescription.instructions,
+      notes: prescription.notes,
+      fillsAllowed: prescription.fillsAllowed,
+      templateName: '',
+      addToTemplates: false,
+      catalogId: undefined
+    };
+
+    props.formActions.updateFormValue({
+      key: 'draftPrescriptions',
+      value: [...(props.formStore.draftPrescriptions?.value || []), draft]
+    });
+
     triggerToast({
       status: 'success',
       header: 'Prescription Added',
@@ -516,7 +533,7 @@ export function PrescribeWorkflow(props: PrescribeProps) {
     });
   }
 
-  function tryAddRefillToDrafts(rxId: string, treatment: Treatment) {
+  function tryAddRefillToDrafts(prescription: MedHistoryPrescription, treatment: Treatment) {
     if (isTreatmentInDraftPrescriptions(treatment.id, props.formStore.draftPrescriptions.value)) {
       triggerToast({
         status: 'error',
@@ -529,10 +546,10 @@ export function PrescribeWorkflow(props: PrescribeProps) {
       recentOrdersActions.setIsDuplicateDialogOpen(
         true,
         recentOrdersActions.checkDuplicateFill(treatment.name),
-        () => addRefillToDrafts(rxId)
+        () => addRefillToDrafts(prescription, treatment)
       );
     } else {
-      addRefillToDrafts(rxId);
+      addRefillToDrafts(prescription, treatment);
     }
   }
 
@@ -668,7 +685,7 @@ export function PrescribeWorkflow(props: PrescribeProps) {
                 <DraftPrescriptionCard
                   templateIds={props.templateIds?.split(',') || []}
                   templateOverrides={props.templateOverrides || {}}
-                  prescriptionIds={prescriptionIds()}
+                  prescriptionIds={props.prescriptionIds?.split(',') || []}
                   prescriptionRef={prescriptionRef}
                   actions={props.formActions}
                   store={props.formStore}

--- a/packages/elements/src/photon-multirx-form/photon-prescribe-workflow.tsx
+++ b/packages/elements/src/photon-multirx-form/photon-prescribe-workflow.tsx
@@ -191,6 +191,17 @@ export function PrescribeWorkflow(props: PrescribeProps) {
     ref?.dispatchEvent(event);
   };
 
+  const dispatchDraftPrescriptionCreated = (draftPrescription: AddDraftPrescription) => {
+    const event = new CustomEvent('photon-draft-prescription-created', {
+      composed: true,
+      bubbles: true,
+      detail: {
+        draft: draftPrescription
+      }
+    });
+    ref?.dispatchEvent(event);
+  };
+
   const dispatchOrderCreated = (order: Order) => {
     const event = new CustomEvent('photon-order-created', {
       composed: true,
@@ -531,6 +542,8 @@ export function PrescribeWorkflow(props: PrescribeProps) {
       header: 'Prescription Added',
       body: 'You can send this order or add another prescription before sending it'
     });
+
+    dispatchDraftPrescriptionCreated(draft);
   }
 
   function tryAddRefillToDrafts(prescription: MedHistoryPrescription, treatment: Treatment) {
@@ -675,6 +688,7 @@ export function PrescribeWorkflow(props: PrescribeProps) {
                       draftedPrescriptionChanged={function () {
                         screenDraftedPrescriptions();
                       }}
+                      onDraftPrescriptionCreated={dispatchDraftPrescriptionCreated}
                       screeningAlerts={screeningAlerts()}
                       catalogId={props.catalogId}
                       allowOffCatalogSearch={props.allowOffCatalogSearch}

--- a/packages/elements/src/photon-multirx-form/util/repopulateForm.ts
+++ b/packages/elements/src/photon-multirx-form/util/repopulateForm.ts
@@ -29,10 +29,11 @@ const repopulateForm = (actions: Record<string, (...args: any) => any>, draft: a
   }
   // if a template is selected in the treatment dropdown, field needs to update to use the fillsAllowed value from the template.
   // this is why there is a -1 here.
-  if (draft.fillsAllowed) {
+  if (draft.fillsAllowed !== undefined && draft.fillsAllowed !== null) {
+    const fillsAllowed = Number(draft.fillsAllowed);
     actions.updateFormValue({
       key: 'refillsInput',
-      value: Number(draft.fillsAllowed) - 1
+      value: fillsAllowed > 0 ? fillsAllowed - 1 : 0
     });
   }
   if (draft.instructions) {


### PR DESCRIPTION
* Rework how refill is added to form state. No longer managing separate `prescriptionIds` signal-state
* Empty history shows "No medication history found" message
* Remove toggle button - medication name/details are always expanded
* Fix z-index conflicts between IconButtons, sticky grid header, and dialog popups
* Fix clicking items with the same Treatment ID (e.g. 2+ prescriptions of "amoxicillin 500mg") expanding all rows with that Treatment ID
* Fix refill being clickable while orders are loading/reloading
* Refactors
  *  type mappings, prop naming, code organization
  * Remove unused `active` and `comment` fields