### PR TITLE
adding a null check so we don't display things that are temporarily unavailable with no delivery estimate

### DIFF
--- a/apps/patient/src/views/Pharmacy.tsx
+++ b/apps/patient/src/views/Pharmacy.tsx
@@ -174,7 +174,7 @@ export const Pharmacy = () => {
         .filter((offer) => offer.supplier === 'AMAZON_PHARMACY')
         .filter((offer) => offer.deliveryEstimate !== undefined);
 
-      if (amazonOffers.length > 0) {
+      if (amazonOffers.length > 0 && amazonOffers[0]?.deliveryEstimate?.deliveryPromise) {
         setAmazonPharmacyOverride(
           'Arrives by ' + amazonOffers[0]?.deliveryEstimate?.deliveryPromise
         );


### PR DESCRIPTION
things with no delivery estimate (due to being temporairly unavialable) will show up as an available option with no delivery estimate. we'll never show anything for something that doesn't have a delivery estimate.