### PR TITLE
Close rx form after editing

### DIFF
--- a/packages/elements/src/photon-multirx-form/photon-prescribe-workflow.tsx
+++ b/packages/elements/src/photon-multirx-form/photon-prescribe-workflow.tsx
@@ -111,6 +111,7 @@ export function PrescribeWorkflow(props: PrescribeProps) {
 
   const client = usePhoton();
   const [showForm, setShowForm] = createSignal<boolean>(
+    // this logic keeps the rx form closed when refilling a particular template/prescription
     !props.templateIds && !props.prescriptionIds
   );
   const [errors, setErrors] = createSignal<FormError[]>([]);
@@ -566,6 +567,13 @@ export function PrescribeWorkflow(props: PrescribeProps) {
     }
   }
 
+  const handleDraftPrescriptionCreated = (draft: AddDraftPrescription) => {
+    dispatchDraftPrescriptionCreated(draft);
+    if (isEditing()) {
+      setIsEditing(false);
+    }
+  };
+
   return (
     <div ref={ref}>
       <style>{tailwind}</style>
@@ -688,7 +696,7 @@ export function PrescribeWorkflow(props: PrescribeProps) {
                       draftedPrescriptionChanged={function () {
                         screenDraftedPrescriptions();
                       }}
-                      onDraftPrescriptionCreated={dispatchDraftPrescriptionCreated}
+                      onDraftPrescriptionCreated={handleDraftPrescriptionCreated}
                       screeningAlerts={screeningAlerts()}
                       catalogId={props.catalogId}
                       allowOffCatalogSearch={props.allowOffCatalogSearch}


### PR DESCRIPTION
* In embed flow, after editing a prescription, we want the prescription form to auto close.
* In clinical app flow, the form is currently always open, and this PR shouldn't affect that.
  * One exception: clicking "Renew" button from prescription details page will navigate to the prescription form page with the form closed by default.



[Notion issue ticket](https://www.notion.so/photons/Collapse-prescriber-form-after-a-template-edit-1cb8bfbbf4ec80aab2c9c4da030a328d?pvs=4)