### PR TITLE
Enable pricing for sesame non-GLP1s

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ node_modules
 *.launch
 .settings/
 *.sublime-workspace
+/.cursor
 
 # IDE - VSCode
 .vscode/*

--- a/apps/patient/src/views/Pharmacy.tsx
+++ b/apps/patient/src/views/Pharmacy.tsx
@@ -105,7 +105,10 @@ export const Pharmacy = () => {
   const isLoading = loadingLocation || loadingPharmacies;
 
   // pricing
-  const showPriceToggle = orgSettings.enablePricing ?? false;
+  const orderContainsGLP1Medication = flattenedFills.some((fill) => isGLP(fill.treatment.name));
+
+  // note: prices are only for Sesame, non-GLP-1 right now
+  const showPriceToggle = (orgSettings.enablePricing && !orderContainsGLP1Medication) ?? false;
 
   // filters
   const [enableOpenNow, setEnableOpenNow] = useState(

--- a/packages/settings/src/lib/neutron.ts
+++ b/packages/settings/src/lib/neutron.ts
@@ -265,7 +265,8 @@ const organizationSettings: {
     mailOrderNavigate: true,
     mailOrderNavigateProviders: [AMAZON_PHARMACY_ID],
     paExceptionMessage:
-      'Your insurance needs additional information from your provider before it will cover your prescription. Use the messaging feature in your Sesame profile to ask your provider to submit a prior authorization. If you’re paying cash, disregard and work with your pharmacy directly to pay the out-of-pocket price.'
+      'Your insurance needs additional information from your provider before it will cover your prescription. Use the messaging feature in your Sesame profile to ask your provider to submit a prior authorization. If you’re paying cash, disregard and work with your pharmacy directly to pay the out-of-pocket price.',
+    enablePricing: true
   },
   // Oshi Health
   org_yOgsgGMBVUZIBcwp: {

--- a/packages/settings/src/lib/photon.ts
+++ b/packages/settings/src/lib/photon.ts
@@ -386,7 +386,8 @@ const organizationSettings: {
     accentColor: '#5224C7',
     topRankedCostco: true,
     paExceptionMessage:
-      'Your insurance needs additional information from your provider before it will cover your prescription. Use the messaging feature in your Sesame profile to ask your provider to submit a prior authorization. If you’re paying cash, disregard and work with your pharmacy directly to pay the out-of-pocket price.'
+      'Your insurance needs additional information from your provider before it will cover your prescription. Use the messaging feature in your Sesame profile to ask your provider to submit a prior authorization. If you’re paying cash, disregard and work with your pharmacy directly to pay the out-of-pocket price.',
+    enablePricing: true
   },
   // DrTelx
   org_6DKb7celAunAoLzb: {


### PR DESCRIPTION
To show the price toggle for sesame, off by default, and surface prices once again from rxsense.