### PR TITLE
Trim template ids and prescription ids with whitespace

### DIFF
--- a/packages/elements/src/photon-multirx-form/photon-prescribe-workflow-component.tsx
+++ b/packages/elements/src/photon-multirx-form/photon-prescribe-workflow-component.tsx
@@ -29,9 +29,9 @@ const Component = (props: PrescribeProps) => {
     <DraftPrescriptionsProvider>
       <RecentOrders patientId={store.patient?.value?.id}>
         <PrescribeProvider
-          templateIdsPrefill={props.templateIds?.split(',') || []}
+          templateIdsPrefill={props.templateIds?.split(',').map((id) => id.trim()) || []}
           templateOverrides={props.templateOverrides || {}}
-          prescriptionIdsPrefill={props.prescriptionIds?.split(',') || []}
+          prescriptionIdsPrefill={props.prescriptionIds?.split(',').map((id) => id.trim()) || []}
           patientId={store.patient?.value?.id}
           enableCombineAndDuplicate={props.enableCombineAndDuplicate}
         >

--- a/packages/elements/src/photon-multirx-form/photon-prescribe-workflow.tsx
+++ b/packages/elements/src/photon-multirx-form/photon-prescribe-workflow.tsx
@@ -601,9 +601,9 @@ export function PrescribeWorkflow(props: PrescribeProps) {
                   </div>
                 </Show>
                 <DraftPrescriptionCard
-                  templateIds={props.templateIds?.split(',') || []}
+                  templateIds={props.templateIds?.split(',').map((id) => id.trim()) || []}
                   templateOverrides={props.templateOverrides || {}}
-                  prescriptionIds={props.prescriptionIds?.split(',') || []}
+                  prescriptionIds={props.prescriptionIds?.split(',').map((id) => id.trim()) || []}
                   prescriptionRef={prescriptionRef}
                   actions={props.formActions}
                   store={props.formStore}


### PR DESCRIPTION
Ran into this notion issue: https://www.notion.so/photons/Embedded-flow-not-accepting-more-than-1-template-1e48bfbbf4ec80bb8b3ce4835e9871cc?pvs=4

Looks like some of our customers are passing a plain string to `templateIds` in the prescribe workflow web component. They like to comma separate with spaces. We need to trim whitespace so they don't hate us. 