### PR TITLE
Fix edit reselecting old treatment data

### DIFF
--- a/packages/elements/src/photon-dropdown/photon-dropdown.tsx
+++ b/packages/elements/src/photon-dropdown/photon-dropdown.tsx
@@ -166,7 +166,6 @@ export const PhotonDropdown = <T extends { id: string }>(props: {
     if (props.selectedData) {
       // @ts-ignore
       setSelected(props.selectedData);
-      dispatchSelect(props.selectedData);
     }
     if (props.selectedData === undefined) {
       setSelected(undefined);

--- a/packages/elements/src/photon-medication-dropdown/photon-medication-dropdown.tsx
+++ b/packages/elements/src/photon-medication-dropdown/photon-medication-dropdown.tsx
@@ -30,7 +30,7 @@ import tailwind from '../tailwind.css?inline';
 import styles from './style.css?inline';
 
 // Types
-import { Treatment, PrescriptionTemplate, TreatmentOption } from '@photonhealth/sdk/dist/types';
+import { PrescriptionTemplate, Treatment, TreatmentOption } from '@photonhealth/sdk/dist/types';
 
 //Virtual List
 import { createVirtualizer, VirtualItem } from '@tanstack/solid-virtual';
@@ -167,7 +167,6 @@ export const PhotonMedicationDropdown = <T extends { id: string }>(props: {
     if (props.selectedData) {
       // @ts-ignore
       setSelected(props.selectedData);
-      dispatchSelect(props.selectedData);
     }
     if (props.selectedData === undefined) {
       setSelected(undefined);

--- a/packages/elements/src/photon-medication-search/photon-medication-search-component.tsx
+++ b/packages/elements/src/photon-medication-search/photon-medication-search-component.tsx
@@ -292,9 +292,7 @@ const Component = (props: ComponentProps) => {
     <div
       ref={ref}
       on:photon-data-selected={(e: any) => {
-        if (store.catalog.data) {
-          dispatchTreatmentSelected(ref, e.detail.data, store.catalog.data.id || '');
-        }
+        dispatchTreatmentSelected(ref, e.detail.data, store.catalog.data?.id || '');
 
         if ('treatment' in e.detail.data) {
           dispatchSearchTextChanged(ref, e.detail.data.treatment.name);

--- a/packages/elements/src/photon-medication-search/photon-medication-search-component.tsx
+++ b/packages/elements/src/photon-medication-search/photon-medication-search-component.tsx
@@ -292,7 +292,9 @@ const Component = (props: ComponentProps) => {
     <div
       ref={ref}
       on:photon-data-selected={(e: any) => {
-        dispatchTreatmentSelected(ref, e.detail.data, store.catalog.data!.id || '');
+        if (store.catalog.data) {
+          dispatchTreatmentSelected(ref, e.detail.data, store.catalog.data.id || '');
+        }
 
         if ('treatment' in e.detail.data) {
           dispatchSearchTextChanged(ref, e.detail.data.treatment.name);

--- a/packages/elements/src/photon-multirx-form/components/AddPrescriptionCard.tsx
+++ b/packages/elements/src/photon-multirx-form/components/AddPrescriptionCard.tsx
@@ -21,7 +21,7 @@ import '@shoelace-style/shoelace/dist/components/icon/icon';
 import '@shoelace-style/shoelace/dist/components/button/button';
 import { setBasePath } from '@shoelace-style/shoelace/dist/utilities/base-path.js';
 import { GraphQLFormattedError } from 'graphql';
-import { createSignal, onMount, Show } from 'solid-js';
+import { createEffect, createSignal, onMount, Show } from 'solid-js';
 import clearForm from '../util/clearForm';
 import repopulateForm from '../util/repopulateForm';
 import { TryCreatePrescriptionTemplateOptions } from '@photonhealth/components/src/systems/PrescribeProvider';
@@ -173,6 +173,12 @@ export const AddPrescriptionCard = (props: {
 
     setSearchText('');
   };
+
+  createEffect(() => {
+    if (props.store.treatment?.value && searchText().length === 0) {
+      setSearchText(props.store.treatment.value.name);
+    }
+  });
 
   return (
     <div ref={ref}>

--- a/packages/elements/src/photon-multirx-form/components/AddPrescriptionCard.tsx
+++ b/packages/elements/src/photon-multirx-form/components/AddPrescriptionCard.tsx
@@ -175,7 +175,7 @@ export const AddPrescriptionCard = (props: {
   };
 
   createEffect(() => {
-    if (props.store.treatment?.value && searchText().length === 0) {
+    if (props.store.treatment?.value) {
       setSearchText(props.store.treatment.value.name);
     }
   });

--- a/packages/elements/src/photon-multirx-form/components/DraftPrescriptionCard.tsx
+++ b/packages/elements/src/photon-multirx-form/components/DraftPrescriptionCard.tsx
@@ -4,8 +4,8 @@ import {
   CoverageOption,
   DraftPrescriptionList,
   PrescriptionFormData,
-  ScreeningAlertType,
   RoutingConstraint,
+  ScreeningAlertType,
   Text,
   useDraftPrescriptions,
   usePrescribe
@@ -60,12 +60,9 @@ export const DraftPrescriptionCard = (props: {
         deletePrescription(formData.id);
       }
 
-      window.scrollTo({
+      props.prescriptionRef?.scrollIntoView({
         behavior: 'smooth',
-        top:
-          (props.prescriptionRef?.getBoundingClientRect().top || 0) -
-          document.body.getBoundingClientRect().top -
-          70
+        block: 'start'
       });
 
       props.handleDraftPrescriptionsChange();


### PR DESCRIPTION
- fix editing a draft prescription, and then clicking "Send Order" (or "Edit" draft again) showing a popup about "Lose Unsaved Prescription" improperly
- fix catalog.data null error
- bonus: this also seems to fix the ResizeObserverLoop error we keep seeing when interacting with the Med Search component