### PR TITLE
improve cancel order UI response time

### DIFF
--- a/apps/app/src/views/routes/Order.tsx
+++ b/apps/app/src/views/routes/Order.tsx
@@ -243,7 +243,37 @@ export const Order = () => {
     cancelReasonRef.current = cancelReason;
   }, [cancelReason]);
 
-  const [cancelOrder] = useMutation(CANCEL_ORDER);
+  const [cancelOrder] = useMutation(CANCEL_ORDER, {
+    /*
+    optimisticResponse: {
+      cancelOrder: {
+        __typename: 'Order',
+        id: id,
+        state: 'CANCELED'
+      }
+    },
+    */
+    update: (cache) => {
+      // TODO manually updating, this can be automatic but current mutation returns wrong data
+      // https://www.notion.so/photons/Successful-Cancel-Order-Returns-Incorrect-State-6bca56ec94cf49d88246730f002500fd?pvs=4
+      const existingOrder: { order: types.Order } | null = cache.readQuery({
+        query: GET_ORDER,
+        variables: { id: id! }
+      });
+      if (existingOrder && existingOrder.order) {
+        cache.writeQuery({
+          query: GET_ORDER,
+          data: {
+            order: {
+              ...existingOrder?.order,
+              state: types.OrderState.Canceled
+            }
+          },
+          variables: { id: id! }
+        });
+      }
+    }
+  });
   const [rerouteOrder] = useMutation(REROUTE_ORDER, {
     update: async (cache) => {
       // after routing an order, we need to update the cache with the new pharmacy data optimistically
@@ -276,6 +306,9 @@ export const Order = () => {
   });
 
   const order = data?.order;
+  if (data?.order.state == 'ROUTING') {
+    console.log('Order State:', order?.state);
+  }
   const {
     isOpen: isOpenLocation,
     onOpen: onOpenLocation,
@@ -481,7 +514,7 @@ export const Order = () => {
                 }
               }}
             >
-              Cancel Order!!!
+              Cancel Order!!!!
             </Button>
 
             <Button

--- a/apps/app/src/views/routes/Order.tsx
+++ b/apps/app/src/views/routes/Order.tsx
@@ -243,29 +243,7 @@ export const Order = () => {
     cancelReasonRef.current = cancelReason;
   }, [cancelReason]);
 
-  const [cancelOrder] = useMutation(CANCEL_ORDER, {
-    update: (cache) => {
-      // TODO manually updating, this can be automatic but current mutation returns wrong data
-      // https://www.notion.so/photons/Successful-Cancel-Order-Returns-Incorrect-State-6bca56ec94cf49d88246730f002500fd?pvs=4
-      const existingOrder: { order: types.Order } | null = cache.readQuery({
-        query: GET_ORDER,
-        variables: { id: id! }
-      });
-      if (existingOrder && existingOrder.order) {
-        cache.writeQuery({
-          query: GET_ORDER,
-          data: {
-            order: {
-              ...existingOrder?.order,
-              state: types.OrderState.Canceled
-            }
-          },
-          variables: { id: id! }
-        });
-      }
-    }
-  });
-
+  const [cancelOrder] = useMutation(CANCEL_ORDER);
   const [rerouteOrder] = useMutation(REROUTE_ORDER, {
     update: async (cache) => {
       // after routing an order, we need to update the cache with the new pharmacy data optimistically
@@ -503,8 +481,9 @@ export const Order = () => {
                 }
               }}
             >
-              Cancel Order
+              Cancel Order!!!
             </Button>
+
             <Button
               aria-label="Report Issue"
               colorScheme="blue"

--- a/apps/app/src/views/routes/Order.tsx
+++ b/apps/app/src/views/routes/Order.tsx
@@ -488,7 +488,7 @@ export const Order = () => {
                 }
               }}
             >
-              Cancel Order!!!!
+              Cancel Order
             </Button>
 
             <Button

--- a/apps/app/src/views/routes/Order.tsx
+++ b/apps/app/src/views/routes/Order.tsx
@@ -490,7 +490,6 @@ export const Order = () => {
             >
               Cancel Order
             </Button>
-
             <Button
               aria-label="Report Issue"
               colorScheme="blue"


### PR DESCRIPTION
- No longer manually updating the cache since we get the correct status from the `cancelOrder` mutation: https://github.com/Photon-Health/lambdas/pull/2021
- When `onQueryUpdated` is called for the `cancelOrder` mutation, do not execute the `GET_ORDER` query again. The query would run before `order.state` has been updated to `CANCELED`, so the order would appear as if it had not been canceled at all.