### PR TITLE
Reset prescribe provider state on patient change

### DIFF
--- a/packages/components/src/systems/PrescribeProvider/PrescribeProvider.tsx
+++ b/packages/components/src/systems/PrescribeProvider/PrescribeProvider.tsx
@@ -171,6 +171,17 @@ export const PrescribeProvider = (props: PrescribeProviderProps) => {
     }
   });
 
+  createEffect(() => {
+    // reset state on patient change
+    if (props.patientId) {
+      setDraftPrescriptions([]);
+      setSelectedCoverageOption(undefined);
+      setDidSelectOtherCoverageOption(false);
+      setCoverageOptions([]);
+      setHasCreatedPrescriptions(false);
+    }
+  });
+
   // if we have prescriptions, coverage check is enabled, and the patient has a preferred pharmacy,
   // then we need to check the coverage of the prescriptions
   createEffect(() => {

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@photonhealth/elements",
-  "version": "0.16.2",
+  "version": "0.16.3",
   "description": "",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
* Fixes draft prescriptions not resetting when Patient Select dropdown change the patient
* Also resets other state that should reset on patient change

https://www.notion.so/photons/Changing-patients-does-not-clear-Draft-Prescriptions-1f28bfbbf4ec807fa474dec9dbdd3757?pvs=4