### PR TITLE
Fix double prefill prescriptions added

### DIFF
--- a/packages/components/src/systems/PrescribeProvider/PrescribeProvider.tsx
+++ b/packages/components/src/systems/PrescribeProvider/PrescribeProvider.tsx
@@ -178,7 +178,6 @@ export const PrescribeProvider = (props: PrescribeProviderProps) => {
       setSelectedCoverageOption(undefined);
       setDidSelectOtherCoverageOption(false);
       setCoverageOptions([]);
-      setHasCreatedPrescriptions(false);
     }
   });
 

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@photonhealth/elements",
-  "version": "0.16.3",
+  "version": "0.16.4",
   "description": "",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
* Remove reset of `hasCreatedPrescriptions` because it caused double prescriptions to be added when using prefills.
* It isn't necessary because prefill feature (via query param or embed web component props) already involves a page reload (and thus state reset)

related to https://github.com/Photon-Health/client/pull/1841