### PR TITLE
Rate limit generateCoverageOptions to 5 calls

### DIFF
--- a/packages/components/src/systems/PrescribeProvider/PrescribeProvider.tsx
+++ b/packages/components/src/systems/PrescribeProvider/PrescribeProvider.tsx
@@ -5,6 +5,7 @@ import {
   createMemo,
   createSignal,
   JSXElement,
+  untrack,
   useContext
 } from 'solid-js';
 import { format } from 'date-fns';
@@ -125,8 +126,9 @@ export const PrescribeProvider = (props: PrescribeProviderProps) => {
   const [patientPreferredPharmacyId, setPatientPreferredPharmacyId] = createSignal<string | null>(
     null
   );
-  const [didSelectOtherCoverageOption, setDidSelectOtherCoverageOption] =
-    createSignal<boolean>(false);
+  const [previousPrescriptionIds, setPreviousPrescriptionIds] = createSignal<string[]>([]);
+  const [generateCoverageOptionCallCount, setGenerateCoverageOptionCallCount] =
+    createSignal<number>(0);
   const [selectedCoverageOption, setSelectedCoverageOption] = createSignal<
     CoverageOption | undefined
   >();
@@ -176,7 +178,8 @@ export const PrescribeProvider = (props: PrescribeProviderProps) => {
     if (props.patientId) {
       setDraftPrescriptions([]);
       setSelectedCoverageOption(undefined);
-      setDidSelectOtherCoverageOption(false);
+      setGenerateCoverageOptionCallCount(0);
+      setPreviousPrescriptionIds([]);
       setCoverageOptions([]);
     }
   });
@@ -186,16 +189,25 @@ export const PrescribeProvider = (props: PrescribeProviderProps) => {
   createEffect(() => {
     const pharmacyId = patientPreferredPharmacyId();
     const prescriptions = draftPrescriptions();
+
+    const GENERATE_COVERAGE_OPTIONS_RATE_LIMIT = 5;
+    const callCount = untrack(() => generateCoverageOptionCallCount());
+    const isBelowRateLimit = callCount < GENERATE_COVERAGE_OPTIONS_RATE_LIMIT;
+    const previousPrescriptionCount = untrack(() => previousPrescriptionIds().length);
+    const hasAddedPrescriptions = prescriptions.length > previousPrescriptionCount;
+
     if (
-      !didSelectOtherCoverageOption() && // after an alternate is chosen, stop fetching coverages for this patient
+      isBelowRateLimit &&
       props.enableCoverageCheck &&
-      prescriptions.length > 0 &&
+      hasAddedPrescriptions &&
       pharmacyId !== null
     ) {
       generateCoverageOptions(prescriptions, pharmacyId).then((generatedCoverageOptions) => {
         setCoverageOptions(generatedCoverageOptions);
       });
     }
+
+    setPreviousPrescriptionIds(prescriptionIds());
   });
 
   async function createPrescriptionsFromIds() {
@@ -312,6 +324,7 @@ export const PrescribeProvider = (props: PrescribeProviderProps) => {
         }))
       }
     });
+    setGenerateCoverageOptionCallCount((prev) => prev + 1);
     return response.data.generateCoverageOptions as CoverageOption[];
   };
 
@@ -457,7 +470,6 @@ export const PrescribeProvider = (props: PrescribeProviderProps) => {
   const selectOtherCoverageOption = (value: CoverageOption) => {
     setOrderFormData('pharmacyId', value.pharmacy.id);
     setSelectedCoverageOption(value);
-    setDidSelectOtherCoverageOption(true);
   };
 
   const value = {


### PR DESCRIPTION
* Up to 5 calls per patient session (instead of 1)
* Extra logic so that deleting a draft prescription does not trigger an unnecessary call
* reset call count on patient change or page reload
* this fixes a selected therapeutic alternative prescription not being linked to a coverage, and thus no price visible in Patient App (see this [mini RFC](https://www.notion.so/photons/Mini-RFC-RTBC-Link-Therapeutic-Alternative-Coverage-to-Prescription-1f28bfbbf4ec80b99a43f28369d47e0a?pvs=4)) (though the coverage would still be missing if the rate limit is reached)