### PR TITLE
Screen Prescriptions from med history

### DIFF
--- a/packages/elements/src/photon-multirx-form/photon-prescribe-workflow.tsx
+++ b/packages/elements/src/photon-multirx-form/photon-prescribe-workflow.tsx
@@ -287,6 +287,16 @@ export function PrescribeWorkflow(props: PrescribeProps) {
     setScreeningAlerts(data?.prescriptionScreen?.alerts ?? []);
   };
 
+  createEffect(() => {
+    if (draftPrescriptions().length > 0) {
+      // if drafted prescriptions gets appended to,
+      // such as in the case of re-prescribing from
+      // med history, we need to screen the new
+      // prescriptions
+      screenDraftedPrescriptions();
+    }
+  });
+
   const dispatchPrescriptionsError = (errors: readonly Error[]) => {
     const event = new CustomEvent('photon-prescriptions-error', {
       composed: true,


### PR DESCRIPTION
I'd make a loom but boson is down

https://www.notion.so/photons/Renewed-and-Refilled-Prescriptions-do-not-show-screening-alerts-1e58bfbbf4ec809f9c4afd24f74d007a?pvs=4