### PR TITLE
Add neutron org for testing non-honeybee partner prescriber

### DIFF
--- a/packages/settings/src/lib/neutron.ts
+++ b/packages/settings/src/lib/neutron.ts
@@ -86,6 +86,10 @@ const orgMailOrders: Record<string, Partial<MailOrderPharmacyConfigs>> = {
   org_TY5GFYPIRo3xQGYM: {
     patient: [AMAZON_PHARMACY_ID]
   },
+  // Jake's Test Org (photon as non-honeybee partner prescriber)
+  org_FR93NzavObFoddnt: {
+    provider: [HONEYBEE_PHARMACY_ID]
+  },
   // River Health
   org_U3ofDUVRsNTYt7d8: {
     provider: [CAREPOINT_PHARMACY_ID]


### PR DESCRIPTION
Want this to help test changes for this ticket: https://www.notion.so/photons/Take-Two-Successful-Honeybee-orders-stuck-in-Pending-1f38bfbbf4ec800ea515f1baa717d3b6?pvs=4

This lambda PR includes the change I will be testing: https://github.com/Photon-Health/lambdas/pull/2040
