### PR TITLE
bump elements to 0.16.7 to disable & show alerts for unroutable pharmacies

### DIFF
--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@photonhealth/elements",
-  "version": "0.16.6",
+  "version": "0.16.7",
   "description": "",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
<img width="1279" alt="image" src="https://github.com/user-attachments/assets/29edc891-5710-45a4-97e7-8653215fadc6" />
