### PR TITLE
Option for disabling toasts for prescribe flow element

### DIFF
--- a/packages/components/dev/App.tsx
+++ b/packages/components/dev/App.tsx
@@ -87,6 +87,7 @@ const App = () => {
               patientId={patientId}
               enableCombineAndDuplicate={true}
               enableCoverageCheck={true}
+              enableToasts={true}
             >
               <div class="mb-10">
                 <h2>Patient Info</h2>

--- a/packages/components/dev/App.tsx
+++ b/packages/components/dev/App.tsx
@@ -87,7 +87,6 @@ const App = () => {
               patientId={patientId}
               enableCombineAndDuplicate={true}
               enableCoverageCheck={true}
-              enableToasts={true}
             >
               <div class="mb-10">
                 <h2>Patient Info</h2>

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -30,7 +30,7 @@ import {
 } from './systems/ScreeningAlerts';
 import { RoutingConstraint } from './systems/RoutingConstraints';
 
-import triggerToast from './utils/toastTriggers';
+import triggerToast, { isToastStatus, ToastStatus } from './utils/toastTriggers';
 import generateString from './utils/generateString';
 import { createQuery } from './utils/createQuery';
 import formatDate from './utils/formatDate';
@@ -49,6 +49,7 @@ import {
 } from './systems/PrescribeProvider';
 
 import { GoogleServiceProvider, useGoogleService } from './systems/GoogleServiceProvider';
+import { ToastProvider } from './systems/ToastProvider';
 
 export { usePhoton, PhotonClientStore, PhotonContext };
 
@@ -89,7 +90,9 @@ export {
   PrescribeProvider,
   GoogleServiceProvider,
   usePrescribe,
-  useGoogleService
+  useGoogleService,
+  ToastProvider,
+  isToastStatus
 };
 
 // Export types
@@ -98,5 +101,6 @@ export type {
   RoutingConstraint,
   TemplateOverrides,
   PrescriptionFormData,
-  CoverageOption
+  CoverageOption,
+  ToastStatus
 };

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -16,7 +16,7 @@ import PharmacySearch from './systems/PharmacySearch';
 import { PharmacySelect } from './systems/PharmacySelect';
 import Spinner from './particles/Spinner';
 import RadioGroupCards from './particles/RadioGroupCards';
-import { useRecentOrders, RecentOrders } from './systems/RecentOrders';
+import { RecentOrders, useRecentOrders } from './systems/RecentOrders';
 import Dialog from './particles/Dialog';
 import Button from './particles/Button';
 import SDKProvider, { usePhotonClient } from './systems/SDKProvider';
@@ -24,8 +24,8 @@ import Table from './particles/Table';
 import Text from './particles/Text';
 import Toaster from './particles/Toaster';
 import {
-  ScreeningAlerts,
   ScreeningAlertAcknowledgementDialog,
+  ScreeningAlerts,
   ScreeningAlertType
 } from './systems/ScreeningAlerts';
 import { RoutingConstraint } from './systems/RoutingConstraints';
@@ -40,18 +40,17 @@ import { SignatureAttestationModal } from './systems/SignatureAttestation';
 
 import { PhotonContext, usePhoton } from './context';
 import { PhotonClientStore } from './store';
-
-export { usePhoton, PhotonClientStore, PhotonContext };
-
 import {
   CoverageOption,
   PrescribeProvider,
-  usePrescribe,
   type PrescriptionFormData,
-  type TemplateOverrides
+  type TemplateOverrides,
+  usePrescribe
 } from './systems/PrescribeProvider';
 
 import { GoogleServiceProvider, useGoogleService } from './systems/GoogleServiceProvider';
+
+export { usePhoton, PhotonClientStore, PhotonContext };
 
 export {
   AddressForm,

--- a/packages/components/src/systems/PrescribeProvider/PrescribeProvider.tsx
+++ b/packages/components/src/systems/PrescribeProvider/PrescribeProvider.tsx
@@ -28,13 +28,14 @@ import {
 import { triggerToast, useRecentOrders } from '../../index';
 import { useDraftPrescriptions } from '../DraftPrescriptions';
 import {
-  getRoutingConstraint,
   combineAllRoutingConstraints,
+  getRoutingConstraint,
   RoutingConstraint
 } from '../RoutingConstraints';
 import { createStore } from 'solid-js/store';
 import getLocation from '../../utils/getLocations';
 import { useGoogleService } from '../GoogleServiceProvider';
+import { ToastProps } from '../../utils/toastTriggers';
 // The order form data will consist of, at least, the list of selected prescription IDs and pharmacy ID.
 // The prescription form data (todo) will consist of a single prescription's data during user input
 // Note: Multiple prescription "sub" forms can be opened/completed within a single order form
@@ -109,6 +110,7 @@ interface PrescribeProviderProps {
   patientId: string;
   enableCombineAndDuplicate: boolean;
   enableCoverageCheck: boolean;
+  enableToasts: boolean;
 }
 
 const transformPrescription = (prescription: PrescriptionFormData, patientId: string) => ({
@@ -146,6 +148,12 @@ export const PrescribeProvider = (props: PrescribeProviderProps) => {
   const client = usePhotonClient();
   const { draftPrescriptions, setDraftPrescriptions } = useDraftPrescriptions();
   const [, recentOrdersActions] = useRecentOrders();
+
+  const tryTriggerToast = (options: ToastProps) => {
+    if (options.status === 'error' || props.enableToasts) {
+      triggerToast(options);
+    }
+  };
 
   const prescriptionIds = createMemo(() =>
     draftPrescriptions().map((prescription) => prescription.id)
@@ -376,7 +384,7 @@ export const PrescribeProvider = (props: PrescribeProviderProps) => {
         address: response.data.patient.address as Address
       };
     } catch (error) {
-      triggerToast({
+      tryTriggerToast({
         status: 'error',
         header: 'Error Looking Up Patient Pharmacy',
         body: (error as Error).message
@@ -412,7 +420,7 @@ export const PrescribeProvider = (props: PrescribeProviderProps) => {
     );
 
     if (isPrescriptionAlreadyAdded) {
-      triggerToast({
+      tryTriggerToast({
         status: 'error',
         body: 'You already have this prescription in your order. You can modify the prescription or delete it in Pending Order.'
       });
@@ -466,7 +474,7 @@ export const PrescribeProvider = (props: PrescribeProviderProps) => {
       return res.data.updatePrescriptionStates as boolean;
     } catch (error) {
       console.error('Mutation error:', error);
-      triggerToast({
+      tryTriggerToast({
         status: 'error',
         header: 'Error Saving Prescription(s)',
         body: (error as Error).message
@@ -490,7 +498,7 @@ export const PrescribeProvider = (props: PrescribeProviderProps) => {
       setDraftPrescriptions((prev) => [...prev, created]);
     } catch (error) {
       console.error('Mutation error:', error);
-      triggerToast({
+      tryTriggerToast({
         status: 'error',
         header: 'Error Adding Prescription',
         body: 'There was an issue adding the prescription. Please try again.'
@@ -505,13 +513,13 @@ export const PrescribeProvider = (props: PrescribeProviderProps) => {
         options.templateName
       );
 
-      triggerToast({
+      tryTriggerToast({
         status: 'success',
         header: 'Personal Template Saved'
       });
     }
 
-    triggerToast({
+    tryTriggerToast({
       status: 'success',
       header: 'Prescription Added',
       body: 'You can send this order or add another prescription before sending it'

--- a/packages/components/src/systems/PrescribeProvider/PrescribeProvider.tsx
+++ b/packages/components/src/systems/PrescribeProvider/PrescribeProvider.tsx
@@ -110,7 +110,7 @@ interface PrescribeProviderProps {
   patientId: string;
   enableCombineAndDuplicate: boolean;
   enableCoverageCheck: boolean;
-  enableToasts: boolean;
+  disableToasts?: string;
 }
 
 const transformPrescription = (prescription: PrescriptionFormData, patientId: string) => ({
@@ -150,9 +150,11 @@ export const PrescribeProvider = (props: PrescribeProviderProps) => {
   const [, recentOrdersActions] = useRecentOrders();
 
   const tryTriggerToast = (options: ToastProps) => {
-    if (options.status === 'error' || props.enableToasts) {
-      triggerToast(options);
+    const disabledTypes = props.disableToasts?.split(',');
+    if (disabledTypes && disabledTypes.includes(options.status)) {
+      return;
     }
+    triggerToast(options);
   };
 
   const prescriptionIds = createMemo(() =>

--- a/packages/components/src/systems/PrescribeProvider/PrescribeProvider.tsx
+++ b/packages/components/src/systems/PrescribeProvider/PrescribeProvider.tsx
@@ -25,7 +25,7 @@ import {
   GetTemplatesFromCatalogs,
   UpdatePrescriptionStates
 } from '../../fetch';
-import { triggerToast, useRecentOrders } from '../../index';
+import { useRecentOrders } from '../../index';
 import { useDraftPrescriptions } from '../DraftPrescriptions';
 import {
   combineAllRoutingConstraints,
@@ -35,7 +35,7 @@ import {
 import { createStore } from 'solid-js/store';
 import getLocation from '../../utils/getLocations';
 import { useGoogleService } from '../GoogleServiceProvider';
-import { ToastProps } from '../../utils/toastTriggers';
+import { useToasts } from '../ToastProvider';
 // The order form data will consist of, at least, the list of selected prescription IDs and pharmacy ID.
 // The prescription form data (todo) will consist of a single prescription's data during user input
 // Note: Multiple prescription "sub" forms can be opened/completed within a single order form
@@ -148,14 +148,7 @@ export const PrescribeProvider = (props: PrescribeProviderProps) => {
   const client = usePhotonClient();
   const { draftPrescriptions, setDraftPrescriptions } = useDraftPrescriptions();
   const [, recentOrdersActions] = useRecentOrders();
-
-  const tryTriggerToast = (options: ToastProps) => {
-    const disabledTypes = props.disableToasts?.split(',');
-    if (disabledTypes && disabledTypes.includes(options.status)) {
-      return;
-    }
-    triggerToast(options);
-  };
+  const { tryTriggerToast } = useToasts();
 
   const prescriptionIds = createMemo(() =>
     draftPrescriptions().map((prescription) => prescription.id)

--- a/packages/components/src/systems/ToastProvider/ToastProvider.tsx
+++ b/packages/components/src/systems/ToastProvider/ToastProvider.tsx
@@ -1,0 +1,36 @@
+import { createContext, JSXElement, useContext } from 'solid-js';
+import { ToastProps } from '../../utils/toastTriggers';
+import { triggerToast } from '../../index';
+
+interface ToastContextType {
+  tryTriggerToast: (props: ToastProps) => void;
+}
+
+const ToastContext = createContext<ToastContextType>();
+
+interface ToastProviderProps {
+  children: JSXElement;
+  disableToastStatuses: Array<ToastProps['status']>;
+}
+
+export const ToastProvider = (props: ToastProviderProps) => {
+  const tryTriggerToast = (options: ToastProps) => {
+    if (props.disableToastStatuses.includes(options.status)) {
+      return;
+    }
+    triggerToast(options);
+  };
+
+  const value: ToastContextType = {
+    tryTriggerToast
+  };
+
+  return <ToastContext.Provider value={value}>{props.children}</ToastContext.Provider>;
+};
+export const useToasts = () => {
+  const context = useContext(ToastContext);
+  if (!context) {
+    throw new Error('useToasts must be used within the ToastProvider');
+  }
+  return context;
+};

--- a/packages/components/src/systems/ToastProvider/index.tsx
+++ b/packages/components/src/systems/ToastProvider/index.tsx
@@ -1,0 +1,1 @@
+export * from './ToastProvider';

--- a/packages/components/src/utils/toastTriggers.tsx
+++ b/packages/components/src/utils/toastTriggers.tsx
@@ -3,11 +3,19 @@ import Icon from '../particles/Icon';
 import { Show } from 'solid-js';
 import Text from '../particles/Text';
 
+export type ToastStatus = 'success' | 'info' | 'error';
 export type ToastProps = {
   header?: string;
   body?: string;
-  status: 'success' | 'info' | 'error';
+  status: ToastStatus;
 };
+
+export function isToastStatus(value: string): value is ToastStatus {
+  if (value === 'success' || value === 'error' || value === 'info') {
+    return true;
+  }
+  return false;
+}
 
 const triggerToast = (props: ToastProps) => {
   toast.custom(

--- a/packages/components/src/utils/toastTriggers.tsx
+++ b/packages/components/src/utils/toastTriggers.tsx
@@ -3,7 +3,7 @@ import Icon from '../particles/Icon';
 import { Show } from 'solid-js';
 import Text from '../particles/Text';
 
-type ToastProps = {
+export type ToastProps = {
   header?: string;
   body?: string;
   status: 'success' | 'info' | 'error';

--- a/packages/elements/index.html
+++ b/packages/elements/index.html
@@ -46,6 +46,7 @@
           enable-coverage-check="true"
           enable-send-to-patient="true"
           enable-local-pickup="true"
+          disable-toasts="success"
           id="one"
         ></photon-prescribe-workflow>
       </div>

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@photonhealth/elements",
-  "version": "0.16.7",
+  "version": "0.16.8",
   "description": "",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/elements/src/photon-multirx-form/photon-prescribe-workflow-component.tsx
+++ b/packages/elements/src/photon-multirx-form/photon-prescribe-workflow-component.tsx
@@ -35,7 +35,7 @@ const Component = (props: PrescribeProps) => {
           patientId={store.patient?.value?.id}
           enableCombineAndDuplicate={props.enableCombineAndDuplicate}
           enableCoverageCheck={props.enableCoverageCheck}
-          enableToasts={props.enableToasts}
+          disableToasts={props.disableToasts}
         >
           <PrescribeWorkflow
             patientId={props.patientId}
@@ -54,7 +54,7 @@ const Component = (props: PrescribeProps) => {
             enableMedHistoryRefillButton={props.enableMedHistoryRefillButton}
             enableCombineAndDuplicate={props.enableCombineAndDuplicate}
             enableCoverageCheck={props.enableCoverageCheck}
-            enableToasts={props.enableToasts}
+            disableToasts={props.disableToasts}
             mailOrderIds={props.mailOrderIds}
             pharmacyId={props.pharmacyId}
             loading={props.loading}
@@ -93,7 +93,7 @@ customElement(
     enableMedHistory: false,
     enableMedHistoryRefillButton: false,
     enableMedHistoryLinks: false,
-    enableToasts: true,
+    disableToasts: undefined,
     mailOrderIds: undefined,
     pharmacyId: undefined,
     loading: false,

--- a/packages/elements/src/photon-multirx-form/photon-prescribe-workflow-component.tsx
+++ b/packages/elements/src/photon-multirx-form/photon-prescribe-workflow-component.tsx
@@ -35,6 +35,7 @@ const Component = (props: PrescribeProps) => {
           patientId={store.patient?.value?.id}
           enableCombineAndDuplicate={props.enableCombineAndDuplicate}
           enableCoverageCheck={props.enableCoverageCheck}
+          enableToasts={props.enableToasts}
         >
           <PrescribeWorkflow
             patientId={props.patientId}
@@ -53,6 +54,7 @@ const Component = (props: PrescribeProps) => {
             enableMedHistoryRefillButton={props.enableMedHistoryRefillButton}
             enableCombineAndDuplicate={props.enableCombineAndDuplicate}
             enableCoverageCheck={props.enableCoverageCheck}
+            enableToasts={props.enableToasts}
             mailOrderIds={props.mailOrderIds}
             pharmacyId={props.pharmacyId}
             loading={props.loading}
@@ -91,6 +93,7 @@ customElement(
     enableMedHistory: false,
     enableMedHistoryRefillButton: false,
     enableMedHistoryLinks: false,
+    enableToasts: true,
     mailOrderIds: undefined,
     pharmacyId: undefined,
     loading: false,

--- a/packages/elements/src/photon-multirx-form/photon-prescribe-workflow-component.tsx
+++ b/packages/elements/src/photon-multirx-form/photon-prescribe-workflow-component.tsx
@@ -1,12 +1,15 @@
 import {
   DraftPrescriptionsProvider,
+  isToastStatus,
   PrescribeProvider,
-  RecentOrders
+  RecentOrders,
+  ToastProvider,
+  ToastStatus
 } from '@photonhealth/components';
 import { customElement } from 'solid-element';
 import { createFormStore } from '../stores/form';
 import { PrescribeProps, PrescribeWorkflow } from './photon-prescribe-workflow';
-import { onCleanup } from 'solid-js';
+import { createMemo, onCleanup } from 'solid-js';
 import { PatientStore } from '../stores/patient';
 
 const Component = (props: PrescribeProps) => {
@@ -25,54 +28,67 @@ const Component = (props: PrescribeProps) => {
     actions.reset();
   });
 
+  const disableToastStatuses = createMemo<ToastStatus[]>(() => {
+    let toastStatuses: ToastStatus[] = [];
+    if (props.disableToasts) {
+      toastStatuses = props.disableToasts
+        .split(',')
+        .map((value) => value.toLowerCase().trim())
+        .filter(isToastStatus);
+    }
+    return toastStatuses;
+  });
+
   return (
-    <DraftPrescriptionsProvider>
-      <RecentOrders patientId={store.patient?.value?.id}>
-        <PrescribeProvider
-          templateIdsPrefill={props.templateIds?.split(',').map((id) => id.trim()) || []}
-          templateOverrides={props.templateOverrides || {}}
-          prescriptionIdsPrefill={props.prescriptionIds?.split(',').map((id) => id.trim()) || []}
-          patientId={store.patient?.value?.id}
-          enableCombineAndDuplicate={props.enableCombineAndDuplicate}
-          enableCoverageCheck={props.enableCoverageCheck}
-          disableToasts={props.disableToasts}
-        >
-          <PrescribeWorkflow
-            patientId={props.patientId}
-            templateIds={props.templateIds}
-            templateOverrides={props.templateOverrides}
-            prescriptionIds={props.prescriptionIds}
-            hideSubmit={props.hideSubmit}
-            hideTemplates={props.hideTemplates}
-            hidePatientCard={props.hidePatientCard}
-            enableOrder={props.enableOrder}
-            enableLocalPickup={props.enableLocalPickup}
-            enableSendToPatient={props.enableSendToPatient}
-            enableDeliveryPharmacies={props.enableDeliveryPharmacies}
-            enableMedHistory={props.enableMedHistory}
-            enableMedHistoryLinks={props.enableMedHistoryLinks}
-            enableMedHistoryRefillButton={props.enableMedHistoryRefillButton}
+    <ToastProvider disableToastStatuses={disableToastStatuses()}>
+      <DraftPrescriptionsProvider>
+        <RecentOrders patientId={store.patient?.value?.id}>
+          <PrescribeProvider
+            templateIdsPrefill={props.templateIds?.split(',').map((id) => id.trim()) || []}
+            templateOverrides={props.templateOverrides || {}}
+            prescriptionIdsPrefill={props.prescriptionIds?.split(',').map((id) => id.trim()) || []}
+            patientId={store.patient?.value?.id}
             enableCombineAndDuplicate={props.enableCombineAndDuplicate}
             enableCoverageCheck={props.enableCoverageCheck}
             disableToasts={props.disableToasts}
-            mailOrderIds={props.mailOrderIds}
-            pharmacyId={props.pharmacyId}
-            loading={props.loading}
-            address={props.address}
-            weight={props.weight}
-            weightUnit={props.weightUnit}
-            additionalNotes={props.additionalNotes}
-            triggerSubmit={props.triggerSubmit}
-            toastBuffer={props.toastBuffer}
-            formStore={store}
-            formActions={actions}
-            externalOrderId={props.externalOrderId}
-            catalogId={props.catalogId}
-            allowOffCatalogSearch={props.allowOffCatalogSearch}
-          />
-        </PrescribeProvider>
-      </RecentOrders>
-    </DraftPrescriptionsProvider>
+          >
+            <PrescribeWorkflow
+              patientId={props.patientId}
+              templateIds={props.templateIds}
+              templateOverrides={props.templateOverrides}
+              prescriptionIds={props.prescriptionIds}
+              hideSubmit={props.hideSubmit}
+              hideTemplates={props.hideTemplates}
+              hidePatientCard={props.hidePatientCard}
+              enableOrder={props.enableOrder}
+              enableLocalPickup={props.enableLocalPickup}
+              enableSendToPatient={props.enableSendToPatient}
+              enableDeliveryPharmacies={props.enableDeliveryPharmacies}
+              enableMedHistory={props.enableMedHistory}
+              enableMedHistoryLinks={props.enableMedHistoryLinks}
+              enableMedHistoryRefillButton={props.enableMedHistoryRefillButton}
+              enableCombineAndDuplicate={props.enableCombineAndDuplicate}
+              enableCoverageCheck={props.enableCoverageCheck}
+              disableToasts={props.disableToasts}
+              mailOrderIds={props.mailOrderIds}
+              pharmacyId={props.pharmacyId}
+              loading={props.loading}
+              address={props.address}
+              weight={props.weight}
+              weightUnit={props.weightUnit}
+              additionalNotes={props.additionalNotes}
+              triggerSubmit={props.triggerSubmit}
+              toastBuffer={props.toastBuffer}
+              formStore={store}
+              formActions={actions}
+              externalOrderId={props.externalOrderId}
+              catalogId={props.catalogId}
+              allowOffCatalogSearch={props.allowOffCatalogSearch}
+            />
+          </PrescribeProvider>
+        </RecentOrders>
+      </DraftPrescriptionsProvider>
+    </ToastProvider>
   );
 };
 customElement(

--- a/packages/elements/src/photon-multirx-form/photon-prescribe-workflow.tsx
+++ b/packages/elements/src/photon-multirx-form/photon-prescribe-workflow.tsx
@@ -67,7 +67,7 @@ export type PrescribeProps = {
   enableCombineAndDuplicate: boolean;
   enableDeliveryPharmacies: boolean;
   enableCoverageCheck: boolean;
-  enableToasts: boolean;
+  disableToasts?: string;
   mailOrderIds?: string;
   pharmacyId?: string;
   loading: boolean;

--- a/packages/elements/src/photon-multirx-form/photon-prescribe-workflow.tsx
+++ b/packages/elements/src/photon-multirx-form/photon-prescribe-workflow.tsx
@@ -67,6 +67,7 @@ export type PrescribeProps = {
   enableCombineAndDuplicate: boolean;
   enableDeliveryPharmacies: boolean;
   enableCoverageCheck: boolean;
+  enableToasts: boolean;
   mailOrderIds?: string;
   pharmacyId?: string;
   loading: boolean;


### PR DESCRIPTION
Making "Prescription Added" toasts optonal to disable. These were too chatty when a customer would add several prescriptions in sequence via `template-ids` prop. 

Toasts enable to ON by default. Error toasts will display even when toasts are disabled.

Example:
```
<photon-prescribe-workflow
    enable-toasts="false"
></photon-prescribe-workflow>
```

Part of this ticket: https://www.notion.so/photons/Elements-are-glitching-when-bumping-from-0-14-14-to-0-16-5-1f98bfbbf4ec80c7abdee941a8becf74?pvs=4