### PR TITLE
Bug fix: Prescribers can click Save Prescriptions or Send Order while templated RXs are loading, results in error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46676,7 +46676,7 @@
     },
     "packages/elements": {
       "name": "@photonhealth/elements",
-      "version": "0.14.14",
+      "version": "0.16.10",
       "license": "ISC",
       "dependencies": {
         "@photonhealth/components": "*",

--- a/packages/components/src/particles/Button/index.tsx
+++ b/packages/components/src/particles/Button/index.tsx
@@ -45,14 +45,19 @@ export default function Button(props: ButtonProps) {
         'bg-blue-50 text-blue-600 hover:bg-blue-100': otherProps.variant === 'tertiary',
         'text-blue-600 hover:text-blue-500 bg-transparent focus:outline-none focus:ring-2 focus:ring-blue-300':
           otherProps.variant === 'naked',
-        'opacity-50 cursor-not-allowed': buttonProps.disabled
+        'opacity-50 cursor-not-allowed': buttonProps.disabled || otherProps.loading
       },
       props?.class
     )
   );
 
   return (
-    <button {...buttonProps} class={buttonClasses()} type={props?.type}>
+    <button
+      {...buttonProps}
+      class={buttonClasses()}
+      disabled={buttonProps.disabled || otherProps.loading}
+      type={props?.type}
+    >
       <Show when={otherProps?.loading}>
         <Spinner size="sm" />
       </Show>

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@photonhealth/elements",
-  "version": "0.16.10",
+  "version": "0.16.11",
   "description": "",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/elements/src/photon-multirx-form/photon-prescribe-workflow.tsx
+++ b/packages/elements/src/photon-multirx-form/photon-prescribe-workflow.tsx
@@ -112,6 +112,7 @@ export function PrescribeWorkflow(props: PrescribeProps) {
     routingConstraints,
     combinedRoutingConstraint,
     tryUpdatePrescriptionStates,
+    isLoadingPrefills,
     orderFormData
   } = usePrescribe();
 
@@ -689,7 +690,7 @@ export function PrescribeWorkflow(props: PrescribeProps) {
                         Add Prescription
                       </Button>
                     </Show>
-                    <Button loading={isLoading()} onClick={combineOrSubmit}>
+                    <Button loading={isLoadingPrefills() || isLoading()} onClick={combineOrSubmit}>
                       {props.enableOrder ? 'Send Order' : 'Save Prescriptions'}
                     </Button>
                   </div>


### PR DESCRIPTION
Per Remedy Meds:https://photonhealth.slack.com/archives/C02V18YAEE9/p1748532411318539

Need to make the button component non-clickable while it's in a loading state. 

https://github.com/user-attachments/assets/ac0db9cf-d48b-4915-8600-86917e52b088

This, combined with the usage of `isLoadingPrefills` from the prescribe context should prevent fast-clicking providers from saving rxs or sending orders before the templated prescriptions are loaded into the form. 