### PR TITLE
Update copy for delayed provider-selected pharmacy orders

### DIFF
--- a/apps/app/src/views/routes/Order.tsx
+++ b/apps/app/src/views/routes/Order.tsx
@@ -205,7 +205,7 @@ Order:
 
 ----
 Patient:
-  ID: ${order?.patient?.id} 
+  ID: ${order?.patient?.id}
   Name: ${order?.patient?.name?.full}
 
 ----
@@ -222,8 +222,8 @@ ${fills.map(
 `
 )}
 
----- 
-Description: 
+----
+Description:
   `;
 }
 
@@ -621,26 +621,28 @@ export const Order = () => {
                       <VStack spacing={1} align="start">
                         <VStack spacing={0} align="start">
                           <Text fontSize="md" fontWeight="medium">
-                            This order is pending pharmacy selection by the patient.
+                            {getRoutingOrderStatusText(order)}
                           </Text>
                           <Text fontSize="md" color="gray.500">
-                            Select a pharmacy for the patient if needed.
+                            {getRoutingOrderSubText(order)}
                           </Text>
                         </VStack>
-                        <Button
-                          onClick={() => {
-                            datadogRum.addAction('select_pharmacy_btn_click', {
-                              orderId: id
-                            });
+                        {shouldShowSelectPharmacyButton(order) ? (
+                          <Button
+                            onClick={() => {
+                              datadogRum.addAction('select_pharmacy_btn_click', {
+                                orderId: id
+                              });
 
-                            onOpen();
-                          }}
-                          colorScheme="blue"
-                          variant="link"
-                          mt={2}
-                        >
-                          Select Pharmacy
-                        </Button>
+                              onOpen();
+                            }}
+                            colorScheme="blue"
+                            variant="link"
+                            mt={2}
+                          >
+                            Select Pharmacy
+                          </Button>
+                        ) : null}
                       </VStack>
                     </CardBody>
                   </Card>
@@ -840,3 +842,24 @@ export const Order = () => {
     </>
   );
 };
+
+function getRoutingOrderStatusText(order: OrderType) {
+  return isOrderMissingPharmacy(order)
+    ? 'This order is pending pharmacy selection by the patient.'
+    : 'This order is pending pharmacy confirmation by the patient.';
+}
+
+function getRoutingOrderSubText(order: OrderType) {
+  return isOrderMissingPharmacy(order)
+    ? 'Select a pharmacy for the patient if needed.'
+    : 'The order will be routed to the below pharmacy if the patient does not confirm within 15 minutes.';
+}
+
+function shouldShowSelectPharmacyButton(order: OrderType): boolean {
+  const shouldShowButton = isOrderMissingPharmacy(order);
+  return shouldShowButton;
+}
+
+function isOrderMissingPharmacy(order: OrderType): boolean {
+  return order.pharmacy === null || order.pharmacy === undefined;
+}


### PR DESCRIPTION
Copy change to reduce confusion for Providers when we introduce the 15 minute delay to sending orders for provider-selected pharmacy orders.

~~We should deploy this after the Lambda PR is merged and deployed: https://github.com/Photon-Health/lambdas/pull/2145~~
Edit: We can release this whenever because the if predicates won't affect anything until the lambdas are released. The provider-selected pharmacies will be in PENDING until we release the lambda changes. For send-to-patient, the order will be in ROUTING but the pharmacyID will be `null`, so the old copy will continue to show.

[notion ticket](https://www.notion.so/photons/Add-delay-to-provider-selected-pharmacy-orders-2378bfbbf4ec800dbe58c8745ced3c0a?source=copy_link)

<img width="678" height="720" alt="image" src="https://github.com/user-attachments/assets/be79d40a-b2c9-43cc-a06d-057049d7f755" />
