### PR TITLE
Preparatory refactors for Patient App navigation rework

### DIFF
--- a/apps/patient/src/App.tsx
+++ b/apps/patient/src/App.tsx
@@ -1,34 +1,7 @@
-import {
-  createBrowserRouter,
-  createRoutesFromElements,
-  Route,
-  RouterProvider
-} from 'react-router-dom';
+import { createBrowserRouter, createRoutesFromElements, RouterProvider } from 'react-router-dom';
+import { routeElements } from './Routes';
 
-import { Canceled } from './views/Canceled';
-import { Main } from './views/Main';
-import { NoMatch } from './views/NoMatch';
-import { Pharmacy } from './views/Pharmacy';
-import { ReadyBy } from './views/ReadyBy';
-import { Review } from './views/Review';
-import { Status } from './views/Status';
-
-const router = createBrowserRouter(
-  createRoutesFromElements(
-    <Route>
-      <Route path="/" element={<Main />}>
-        <Route path="/review" element={<Review />} />
-        <Route path="/readyBy" element={<ReadyBy />} />
-        <Route path="/pharmacy" element={<Pharmacy />} />
-        <Route path="/status" element={<Status />} />
-        {/* Leaving this here in case we need to roll back */}
-        {/* <Route path="/status" element={<Status />} /> */}
-        <Route path="/canceled" element={<Canceled />} />
-      </Route>
-      <Route path="*" element={<NoMatch />} />
-    </Route>
-  )
-);
+const router = createBrowserRouter(createRoutesFromElements(routeElements));
 
 export const App = () => {
   return <RouterProvider router={router} />;

--- a/apps/patient/src/Navigation.test.tsx
+++ b/apps/patient/src/Navigation.test.tsx
@@ -20,6 +20,7 @@ vi.mock('./api', () => ({
   }),
   getOrder: vi.fn(),
   getPharmacies: vi.fn().mockResolvedValue({ pharmaciesByLocation: [] }),
+  getOffers: vi.fn().mockResolvedValue([]),
   rerouteOrder: vi.fn(),
   setOrderPharmacy: vi.fn(),
   setPreferredPharmacy: vi.fn(),
@@ -30,8 +31,7 @@ vi.mock('./api', () => ({
 vi.mock('./configs/graphqlClient', () => ({
   setAuthHeader: vi.fn(),
   graphQLClient: {
-    request: vi.fn().mockResolvedValue({}),
-    GetOffersForOrder: vi.fn().mockResolvedValue({ offers: [] })
+    request: vi.fn().mockResolvedValue({})
   },
   gqlSerializer: {
     parse: vi.fn(),

--- a/apps/patient/src/Navigation.test.tsx
+++ b/apps/patient/src/Navigation.test.tsx
@@ -1,0 +1,122 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, vi } from 'vitest';
+import { createMemoryRouter, createRoutesFromElements, RouterProvider } from 'react-router-dom';
+import { OrderContextType } from './views/Main';
+import {
+  generateFill,
+  generateFulfillment,
+  generateOrder,
+  generatePatient,
+  generatePharmacy
+} from './test-utils/generators';
+import userEvent from '@testing-library/user-event';
+import { routeElements } from './Routes';
+
+vi.mock('./api', () => ({
+  geocode: vi.fn().mockResolvedValue({
+    lat: 40.7128,
+    lng: -74.006,
+    address: '123 Main St, New York, NY 10001'
+  }),
+  getOrder: vi.fn(),
+  getPharmacies: vi.fn().mockResolvedValue({ pharmaciesByLocation: [] }),
+  rerouteOrder: vi.fn(),
+  setOrderPharmacy: vi.fn(),
+  setPreferredPharmacy: vi.fn(),
+  triggerDemoNotification: vi.fn(),
+  AUTH_HEADER_ERRORS: []
+}));
+
+vi.mock('./configs/graphqlClient', () => ({
+  setAuthHeader: vi.fn(),
+  graphQLClient: {
+    request: vi.fn().mockResolvedValue({}),
+    GetOffersForOrder: vi.fn().mockResolvedValue({ offers: [] })
+  },
+  gqlSerializer: {
+    parse: vi.fn(),
+    stringify: vi.fn()
+  }
+}));
+
+vi.mock('@datadog/browser-rum');
+vi.mock('./configs/analytics');
+vi.mock('./hooks/usePageAnalytics');
+vi.mock('react-ga4');
+
+vi.mock('./components', () => ({
+  CouponModal: () => <div data-testid="coupon-modal">Coupon Modal</div>,
+  FixedFooter: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="fixed-footer">{children}</div>
+  ),
+  LocationModal: () => <div data-testid="location-modal">Location Modal</div>,
+  PoweredBy: () => <div data-testid="powered-by">Powered By</div>,
+  Nav: () => <div>Nav</div>,
+  PrescriptionsList: () => <div>PrescriptionsList</div>,
+  DemoCtaModal: () => <div data-testid="demo-cta-modal">Demo Cta Modal</div>,
+  PharmacyInfo: () => <div data-testid="pharmacy-info">Pharmacy Info</div>,
+  Coupons: () => <div data-testid="coupons">Coupons</div>
+}));
+
+describe('App', () => {
+  const testOrder = generateOrder({
+    id: 'ord_testId777',
+    state: 'ROUTING',
+    patient: generatePatient({ name: { full: 'Jane Doe' } }),
+    fills: [generateFill('test-treatment')],
+    fulfillments: [generateFulfillment({ state: 'PROCESSING' })]
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('navigates from review page to readyBy to pharmacy to status', async () => {
+    const { getPharmacies, setOrderPharmacy, getOrder } = await import('./api');
+    const getOrderMock = vi.mocked(getOrder);
+    getOrderMock.mockResolvedValue(testOrder);
+    const getPharmaciesMock = vi.mocked(getPharmacies);
+    getPharmaciesMock.mockResolvedValue({
+      pharmaciesByLocation: [
+        generatePharmacy({
+          id: 'phr_testId123',
+          name: 'Test Local Pickup Pharmacy',
+          price: 101,
+          retailPrice: 1000
+        })
+      ]
+    });
+    const setOrderPharmacyMock = vi.mocked(setOrderPharmacy);
+    setOrderPharmacyMock.mockResolvedValue(true);
+
+    renderApp({ order: testOrder });
+
+    expect(await screen.findByText('Review your prescription')).toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', { name: 'Search for a pharmacy' }));
+    expect(await screen.findByText('When do you need your order ready by?')).toBeInTheDocument();
+    await userEvent.click(screen.getByText('Urgent'));
+    await userEvent.click(screen.getByText('Next'));
+    expect(setOrderPharmacyMock).not.toHaveBeenCalled();
+    expect(await screen.findByText('Select a pharmacy')).toBeInTheDocument();
+    await userEvent.click(screen.getByText('Test Local Pickup Pharmacy'));
+    await userEvent.click(screen.getByText('Select pharmacy'));
+    expect(setOrderPharmacyMock).toHaveBeenCalledWith(
+      'ord_testId777',
+      'phr_testId123',
+      'Urgent',
+      'Today',
+      expect.anything(),
+      true
+    );
+    await waitFor(() => screen.findByText('Preparing order...'), { timeout: 2500 });
+    expect(await screen.findByText('Preparing order...')).toBeInTheDocument();
+  }, 10_000);
+});
+
+const renderApp = (order: Partial<OrderContextType> = {}) => {
+  const memoryRouter = createMemoryRouter(createRoutesFromElements(routeElements), {
+    initialEntries: ['/']
+  });
+
+  return { render: render(<RouterProvider router={memoryRouter} />), memoryRouter };
+};

--- a/apps/patient/src/Routes.tsx
+++ b/apps/patient/src/Routes.tsx
@@ -1,0 +1,23 @@
+import { Route } from 'react-router-dom';
+import { Main } from './views/Main';
+import { Review } from './views/Review';
+import { ReadyBy } from './views/ReadyBy';
+import { Pharmacy } from './views/Pharmacy';
+import { Status } from './views/Status';
+import { Canceled } from './views/Canceled';
+import { NoMatch } from './views/NoMatch';
+
+export const routeElements = (
+  <Route>
+    <Route path="/" element={<Main />}>
+      <Route path="/review" element={<Review />} />
+      <Route path="/readyBy" element={<ReadyBy />} />
+      <Route path="/pharmacy" element={<Pharmacy />} />
+      <Route path="/status" element={<Status />} />
+      {/* Leaving this here in case we need to roll back */}
+      {/* <Route path="/status" element={<Status />} /> */}
+      <Route path="/canceled" element={<Canceled />} />
+    </Route>
+    <Route path="*" element={<NoMatch />} />
+  </Route>
+);

--- a/apps/patient/src/components/PharmacyInfo.tsx
+++ b/apps/patient/src/components/PharmacyInfo.tsx
@@ -22,7 +22,7 @@ import { useMemo, useState } from 'react';
 import { IoChevronDownOutline, IoChevronUpOutline } from 'react-icons/io5';
 import { formatAddress, formatPrice, titleCase } from '../utils/formatters';
 import { getFulfillmentTrackingLink } from '../utils/fulfillmentsHelpers';
-import { AmazonOffer, BrandedOptionOverrides } from './BrandedOptions';
+import { AmazonOffer, BrandedOptionOverrides } from './pharmacy-card-list/BrandedOptions';
 
 dayjs.extend(customParseFormat);
 

--- a/apps/patient/src/components/index.tsx
+++ b/apps/patient/src/components/index.tsx
@@ -1,5 +1,3 @@
-export * from './BrandedOptions';
-export * from './BrandedPharmacyCard';
 export * from './DemoCtaModal';
 export * from './FixedFooter';
 export * from './LocationModal';

--- a/apps/patient/src/components/pharmacy-card-list/BrandedOptions.tsx
+++ b/apps/patient/src/components/pharmacy-card-list/BrandedOptions.tsx
@@ -1,9 +1,9 @@
 import { Heading, SlideFade, Text, VStack } from '@chakra-ui/react';
 
-import { text as t } from '../utils/text';
+import { text as t } from '../../utils/text';
 import { BrandedPharmacyCard } from './BrandedPharmacyCard';
-import { OfferImpressionTracker } from '../utils/tracking/OfferImpressionTracker';
-import { getPharmacy } from '../views/pharmacy.utils';
+import { OfferImpressionTracker } from '../../utils/tracking/OfferImpressionTracker';
+import { getPharmacy } from '../../views/pharmacy.utils';
 
 interface Props {
   options: string[];

--- a/apps/patient/src/components/pharmacy-card-list/BrandedPharmacyCard.tsx
+++ b/apps/patient/src/components/pharmacy-card-list/BrandedPharmacyCard.tsx
@@ -1,15 +1,15 @@
 import { Card, CardBody } from '@chakra-ui/react';
 
-import capsuleLogo from '../assets/capsule_logo_small_circle.png';
-import amazonPharmacyLogo from '../assets/amazon_pharmacy_logo_small_circle.png';
-import altoLogo from '../assets/alto_logo.svg';
-import costcoLogo from '../assets/costco_logo_small.png';
-import costPlusLogo from '../assets/costplus_logo_small_circle.png';
-import walmartLogo from '../assets/walmart_logo_small_circle.png';
-import novocareLogo from '../assets/novo_circle.png';
+import capsuleLogo from '../../assets/capsule_logo_small_circle.png';
+import amazonPharmacyLogo from '../../assets/amazon_pharmacy_logo_small_circle.png';
+import altoLogo from '../../assets/alto_logo.svg';
+import costcoLogo from '../../assets/costco_logo_small.png';
+import costPlusLogo from '../../assets/costplus_logo_small_circle.png';
+import walmartLogo from '../../assets/walmart_logo_small_circle.png';
+import novocareLogo from '../../assets/novo_circle.png';
 
-import capsulePharmacyIdLookup from '../data/capsulePharmacyIds.json';
-import { PharmacyInfo } from './PharmacyInfo';
+import capsulePharmacyIdLookup from '../../data/capsulePharmacyIds.json';
+import { PharmacyInfo } from '../PharmacyInfo';
 import { BrandedOptionOverrides } from './BrandedOptions';
 
 interface Props {

--- a/apps/patient/src/components/pharmacy-card-list/index.ts
+++ b/apps/patient/src/components/pharmacy-card-list/index.ts
@@ -1,1 +1,3 @@
 export * from './PickupPharmacyCardList';
+export * from './BrandedOptions';
+export * from './BrandedPharmacyCard';

--- a/apps/patient/src/setupTests.ts
+++ b/apps/patient/src/setupTests.ts
@@ -37,3 +37,5 @@ if (typeof window !== 'undefined' && !('IntersectionObserver' in window)) {
   // eslint-disable-next-line no-undef
   global.IntersectionObserver = IntersectionObserver;
 }
+
+vi.stubGlobal('scrollTo', vi.fn());

--- a/apps/patient/src/test-utils/generators.ts
+++ b/apps/patient/src/test-utils/generators.ts
@@ -40,6 +40,29 @@ export const generateFill = (treatmentName: string): Order['fills'][number] => (
   }
 });
 
+type Fulfillment = Order['fulfillments'][number];
+export const generateFulfillment = (overrides: Partial<Fulfillment> = {}): Fulfillment => ({
+  id: `ful_testIdDefault`,
+  state: 'READY',
+  exceptions: [],
+  prescription: generatePrescription(),
+  ...overrides
+});
+
+type Prescription = Fulfillment['prescription'];
+export const generatePrescription = (): Prescription => ({
+  id: `rx_testIdDefault`,
+  dispenseQuantity: 0,
+  dispenseUnit: '',
+  expirationDate: undefined,
+  fillsAllowed: 0,
+  treatment: {
+    __typename: undefined,
+    id: '',
+    name: ''
+  }
+});
+
 export const generateFlattenedFill = (override: Partial<FillWithCount>): FillWithCount => ({
   id: `fil_testIdDefault`,
   count: 1,

--- a/apps/patient/src/utils/general.ts
+++ b/apps/patient/src/utils/general.ts
@@ -60,17 +60,14 @@ export const getFulfillmentType = (
 export type FillWithCount = Fill & { count: number };
 export const countFillsAndRemoveDuplicates = (fills: (Fill | FillWithCount)[]): FillWithCount[] => {
   // First, count the occurrences of each treatment.id
-  const counts = fills.reduce(
-    (acc, fill) => {
-      const id = fill.treatment.id;
-      if (!(id in acc)) {
-        acc[id] = 0;
-      }
-      acc[id] += 'count' in fill ? fill.count : 1;
-      return acc;
-    },
-    {} as Record<string, number>
-  );
+  const counts = fills.reduce((acc, fill) => {
+    const id = fill.treatment.id;
+    if (!(id in acc)) {
+      acc[id] = 0;
+    }
+    acc[id] += 'count' in fill ? fill.count : 1;
+    return acc;
+  }, {} as Record<string, number>);
 
   // Then, create a map of distinct fills with updated counts
   const distinctFills = fills.reduce((acc: Map<string, FillWithCount>, fill) => {

--- a/apps/patient/src/utils/general.ts
+++ b/apps/patient/src/utils/general.ts
@@ -7,10 +7,15 @@ import utc from 'dayjs/plugin/utc';
 import costcoLogo from '../assets/costco_logo_small.png';
 import walgreensLogo from '../assets/walgreens_logo_small_circle.png';
 import { COMMON_COURIER_PHARMACY_IDS } from '../data/courierPharmacys';
-import { EnrichedPharmacy, Fill, OrderFulfillment, Pharmacy } from './models';
-import { ExtendedFulfillmentType } from './models';
+import {
+  EnrichedPharmacy,
+  ExtendedFulfillmentType,
+  Fill,
+  OrderFulfillment,
+  Pharmacy
+} from './models';
 import { PharmacyCloseEvent, PharmacyEvent, PharmacyOpenEvent } from '../__generated__/graphql';
-import { PHARMACY_BRANDING } from '../components';
+import { PHARMACY_BRANDING } from '../components/pharmacy-card-list';
 
 dayjs.extend(utc);
 dayjs.extend(timezone);
@@ -55,14 +60,17 @@ export const getFulfillmentType = (
 export type FillWithCount = Fill & { count: number };
 export const countFillsAndRemoveDuplicates = (fills: (Fill | FillWithCount)[]): FillWithCount[] => {
   // First, count the occurrences of each treatment.id
-  const counts = fills.reduce((acc, fill) => {
-    const id = fill.treatment.id;
-    if (!(id in acc)) {
-      acc[id] = 0;
-    }
-    acc[id] += 'count' in fill ? fill.count : 1;
-    return acc;
-  }, {} as Record<string, number>);
+  const counts = fills.reduce(
+    (acc, fill) => {
+      const id = fill.treatment.id;
+      if (!(id in acc)) {
+        acc[id] = 0;
+      }
+      acc[id] += 'count' in fill ? fill.count : 1;
+      return acc;
+    },
+    {} as Record<string, number>
+  );
 
   // Then, create a map of distinct fills with updated counts
   const distinctFills = fills.reduce((acc: Map<string, FillWithCount>, fill) => {

--- a/apps/patient/src/views/Canceled.test.tsx
+++ b/apps/patient/src/views/Canceled.test.tsx
@@ -11,6 +11,14 @@ vi.mock('../components', () => ({
   PrescriptionsList: () => <div>Mock Prescriptions List</div>
 }));
 
+vi.mock('../api', () => ({
+  geocode: vi.fn().mockResolvedValue({
+    lat: 40.7128,
+    lng: -74.006,
+    address: '123 Main St, New York, NY 10001'
+  })
+}));
+
 describe('Canceled', () => {
   const testOrder = generateOrder({
     patient: generatePatient({ name: { full: 'Jane Doe' } })

--- a/apps/patient/src/views/Main.tsx
+++ b/apps/patient/src/views/Main.tsx
@@ -121,8 +121,6 @@ export const Main = () => {
 
   const handleOrderResponse = useCallback(
     (newOrder: Order, currentPharmacy?: Pharmacy) => {
-      console.log('handleOrderResponse', newOrder);
-
       // This is weird, but it's necessary to show the selected pharmacy
       // when the user goes from selection to the status page
       setOrder({

--- a/apps/patient/src/views/Main.tsx
+++ b/apps/patient/src/views/Main.tsx
@@ -9,12 +9,12 @@ import {
   useSearchParams
 } from 'react-router-dom';
 
-import { AUTH_HEADER_ERRORS, getOrder } from '../api/internal';
+import { AUTH_HEADER_ERRORS, getOrder } from '../api';
 import { Nav } from '../components';
 import { setAuthHeader } from '../configs/graphqlClient';
 import theme from '../configs/theme';
 import { demoOrder } from '../data/demoOrder';
-import { FillWithCount, countFillsAndRemoveDuplicates } from '../utils/general';
+import { countFillsAndRemoveDuplicates, FillWithCount } from '../utils/general';
 import { Order } from '../utils/models';
 import { Pharmacy } from '../__generated__/graphql';
 import { FAQModal } from '../components/FAQModal';

--- a/apps/patient/src/views/Pharmacy.test.tsx
+++ b/apps/patient/src/views/Pharmacy.test.tsx
@@ -24,7 +24,8 @@ vi.mock('../api', () => ({
   rerouteOrder: vi.fn(),
   setOrderPharmacy: vi.fn(),
   setPreferredPharmacy: vi.fn(),
-  triggerDemoNotification: vi.fn()
+  triggerDemoNotification: vi.fn(),
+  getOffers: vi.fn().mockResolvedValue([])
 }));
 
 vi.mock('../components', () => ({

--- a/apps/patient/src/views/Pharmacy.tsx
+++ b/apps/patient/src/views/Pharmacy.tsx
@@ -19,15 +19,7 @@ import ReactGA from 'react-ga4';
 import { Helmet } from 'react-helmet';
 import { FiCheck, FiMapPin } from 'react-icons/fi';
 import { useNavigate, useSearchParams } from 'react-router-dom';
-import {
-  AmazonOffer,
-  BrandedOptionOverrides,
-  BrandedOptions,
-  CouponModal,
-  FixedFooter,
-  LocationModal,
-  PoweredBy
-} from '../components';
+import { CouponModal, FixedFooter, LocationModal, PoweredBy } from '../components';
 import * as TOAST_CONFIG from '../configs/toast';
 import { preparePharmacy } from '../utils/general';
 import { Pharmacy as EnrichedPharmacy } from '../utils/models';
@@ -51,7 +43,12 @@ import { GetPharmaciesByLocationQuery } from '../__generated__/graphql';
 import { getOrgMailOrderPharms } from '@client/settings';
 import { fetchOffers, getPharmacy } from './pharmacy.utils';
 import _ from 'lodash';
-import { PickupPharmacyCardList } from '../components/pharmacy-card-list';
+import {
+  AmazonOffer,
+  BrandedOptionOverrides,
+  BrandedOptions,
+  PickupPharmacyCardList
+} from '../components/pharmacy-card-list';
 import { formatAddress } from '../utils/formatters';
 import { usePageAnalytics } from '../hooks/usePageAnalytics';
 import { patientAnalytics } from '../configs/analytics';

--- a/apps/patient/src/views/ReadyBy.test.tsx
+++ b/apps/patient/src/views/ReadyBy.test.tsx
@@ -33,7 +33,7 @@ describe('ReadyBy', () => {
     vi.clearAllMocks();
   });
 
-  test('renders the canceled order heading', async () => {
+  test('renders the page and buttons', async () => {
     renderReadyBy({ order: testOrder });
     expect(
       await screen.findByRole('heading', { name: 'When do you need your order ready by?' })

--- a/apps/patient/src/views/ReadyBy.test.tsx
+++ b/apps/patient/src/views/ReadyBy.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from '@testing-library/react';
+import { ChakraProvider } from '@chakra-ui/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import { ReadyBy } from './ReadyBy';
+import { OrderContext, OrderContextType } from './Main';
+import { Order } from '../utils/models';
+import { generateOrder, generatePatient } from '../test-utils/generators';
+import userEvent from '@testing-library/user-event';
+
+vi.mock('../components', () => ({
+  PrescriptionsList: () => <div>Mock Prescriptions List</div>,
+  FixedFooter: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="fixed-footer">{children}</div>
+  ),
+  PoweredBy: () => <div data-testid="powered-by">Powered By</div>
+}));
+
+vi.mock('../api', () => ({
+  geocode: vi.fn().mockResolvedValue({
+    lat: 40.7128,
+    lng: -74.006,
+    address: '123 Main St, New York, NY 10001'
+  })
+}));
+
+describe('ReadyBy', () => {
+  const testOrder = generateOrder({
+    patient: generatePatient({ name: { full: 'Jane Doe' } })
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('renders the canceled order heading', async () => {
+    renderReadyBy({ order: testOrder });
+    expect(
+      await screen.findByRole('heading', { name: 'When do you need your order ready by?' })
+    ).toBeInTheDocument();
+
+    await userEvent.click(screen.getByText('Urgent'));
+    await userEvent.click(screen.getByText('Next'));
+  });
+});
+
+const renderReadyBy = (orderContextValueOverride: Partial<OrderContextType> = {}) => {
+  const orderContextValue: OrderContextType = {
+    fetchOrder(currentPharmacy: Order['pharmacy'] | undefined): void {},
+    flattenedFills: [],
+    isDemo: false,
+    logo: undefined,
+    order: generateOrder(),
+    setFaqModalIsOpen(isOpen: boolean): void {},
+    setOrder(order: Order): void {},
+    ...orderContextValueOverride
+  };
+  return render(
+    <MemoryRouter>
+      <ChakraProvider>
+        <OrderContext.Provider value={orderContextValue}>
+          <ReadyBy />
+        </OrderContext.Provider>
+      </ChakraProvider>
+    </MemoryRouter>
+  );
+};

--- a/apps/patient/src/views/ReadyBy.tsx
+++ b/apps/patient/src/views/ReadyBy.tsx
@@ -107,7 +107,7 @@ export const ReadyBy = () => {
   useEffect(() => {
     if (selectedTime) {
       // Scroll to bottom to make sure selection isn't hidden by footer
-      window.scrollTo({ top: document.getElementById('root')!.scrollHeight, behavior: 'smooth' });
+      window.scrollTo({ top: document.getElementById('root')?.scrollHeight, behavior: 'smooth' });
     }
   }, [selectedTime]);
 

--- a/apps/patient/src/views/pharmacy.utils.tsx
+++ b/apps/patient/src/views/pharmacy.utils.tsx
@@ -1,7 +1,6 @@
-import { getOffers } from '../api/internal';
-import { AmazonOffer } from '../components';
-import { EnrichedPharmacy, Order } from '../utils/models';
-import { ExtendedFulfillmentType } from '../utils/models';
+import { getOffers } from '../api';
+import { AmazonOffer } from '../components/pharmacy-card-list';
+import { EnrichedPharmacy, ExtendedFulfillmentType, Order } from '../utils/models';
 import { Pharmacy as PharmacyType } from '../__generated__/graphql';
 
 import capsulePharmacyIdLookup from '../data/capsulePharmacyIds.json';

--- a/package-lock.json
+++ b/package-lock.json
@@ -15770,9 +15770,12 @@
       }
     },
     "node_modules/@zag-js/dom-query": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-0.31.1.tgz",
-      "integrity": "sha512-oiuohEXAXhBxpzzNm9k2VHGEOLC1SXlXSbRPcfBZ9so5NRQUA++zCE7cyQJqGLTZR0t3itFLlZqDbYEXRrefwg=="
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-1.21.1.tgz",
+      "integrity": "sha512-O4db9iYvKeHPjBOtE92p01WXKHngzRRsR7Y5p1cNZ4cbBq15PH2lICcWwUyIxx5zjADZHx6HIv3E+Mg/KCauKA==",
+      "dependencies": {
+        "@zag-js/types": "1.21.1"
+      }
     },
     "node_modules/@zag-js/element-size": {
       "version": "0.31.1",
@@ -15780,11 +15783,19 @@
       "integrity": "sha512-4T3yvn5NqqAjhlP326Fv+w9RqMIBbNN9H72g5q2ohwzhSgSfZzrKtjL4rs9axY/cw9UfMfXjRjEE98e5CMq7WQ=="
     },
     "node_modules/@zag-js/focus-visible": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@zag-js/focus-visible/-/focus-visible-0.31.1.tgz",
-      "integrity": "sha512-dbLksz7FEwyFoANbpIlNnd3bVm0clQSUsnP8yUVQucStZPsuWjCrhL2jlAbGNrTrahX96ntUMXHb/sM68TibFg==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@zag-js/focus-visible/-/focus-visible-1.21.1.tgz",
+      "integrity": "sha512-kHt2SR6vq0RIlLFEiWkw7/X8f5kEoizqUEnDrB93IUVXfaianQx3+NYD3AFoLsY8zBh8IkifZaQ+rAuCqwzvvw==",
       "dependencies": {
-        "@zag-js/dom-query": "0.31.1"
+        "@zag-js/dom-query": "1.21.1"
+      }
+    },
+    "node_modules/@zag-js/types": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@zag-js/types/-/types-1.21.1.tgz",
+      "integrity": "sha512-KbKMwJnrj6wmi4FOcaIMwqBVPz4KZRAn0D7Il8QjvAaJc5SdqkK18lcxQz4/v02EmQ4uOrHgKchcnB+ZHcBFCw==",
+      "dependencies": {
+        "csstype": "3.1.3"
       }
     },
     "node_modules/@zkochan/js-yaml": {

--- a/package.json
+++ b/package.json
@@ -174,5 +174,10 @@
   },
   "optionalDependencies": {
     "@rollup/rollup-linux-x64-gnu": "^4.37.0"
+  },
+  "overrides": {
+    "@chakra-ui/react": {
+      "@zag-js/focus-visible": "^1.18.0"
+    }
   }
 }


### PR DESCRIPTION
* add navigation test for current patient app navigation (`review` -> `readyAt` -> `pharmacy[search]` -> `status`)
  * uses a journey testing pattern
* Extract routes to separate file so that a test can import them and use a MemoryRouter
* Move more pharmacy list components (Branded) out of `components` to enable more fine-grained vi.mocks

Preparing for [notion ticket](https://www.notion.so/Move-requested-pick-up-time-after-a-local-pharmacy-is-selected-2398bfbbf4ec809d87d7e846bbbccca3?source=copy_link)