### PR TITLE
Remove Status page Copy If we can't get ready by time

### DIFF
--- a/apps/patient/src/components/status/Header.tsx
+++ b/apps/patient/src/components/status/Header.tsx
@@ -137,7 +137,7 @@ function subheaderText(props: OrderStatusHeaderProps) {
     return 'Your order is out for delivery';
   }
   if (props.status === 'RECEIVED') {
-    return 'Your pharmacy has received your order. We weren’t able to get a ready time.';
+    return 'Your pharmacy has received your order.';
   }
   if (props.status === 'PROCESSING') {
     if (props.pharmacyEstimatedReadyAt) {


### PR DESCRIPTION
https://www.notion.so/photons/Remove-We-couldn-t-get-a-ready-time-from-the-status-page-for-orders-we-don-t-call-on-2488bfbbf4ec80e0a143f45ffceca266?v=22b8bfbbf4ec80af8e2d000c73a7556b&source=copy_link