### PR TITLE
Optimistically update order context w new pharmacy and exceptions resolved on reroute

### DIFF
--- a/apps/patient/package.json
+++ b/apps/patient/package.json
@@ -2,6 +2,9 @@
   "name": "patient",
   "version": "0.1.0",
   "private": true,
+  "scripts": {
+    "test": "vitest"
+  },
   "dependencies": {
     "@rudderstack/analytics-js": "^3.22.0",
     "chakra-react-select": "^4.6.0",

--- a/apps/patient/src/Reroute.test.tsx
+++ b/apps/patient/src/Reroute.test.tsx
@@ -1,0 +1,167 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, vi } from 'vitest';
+import { createMemoryRouter, createRoutesFromElements, RouterProvider } from 'react-router-dom';
+import {
+  generateFill,
+  generateFulfillment,
+  generateId,
+  generateOrder,
+  generatePatient,
+  generatePharmacy
+} from './test-utils/generators';
+import { routeElements } from './Routes';
+import userEvent from '@testing-library/user-event';
+import { text } from './utils/text';
+
+vi.mock('./api', () => ({
+  geocode: vi.fn().mockResolvedValue({
+    lat: 40.7128,
+    lng: -74.006,
+    address: '123 Main St, New York, NY 10001'
+  }),
+  getOrder: vi.fn(),
+  getPharmacies: vi.fn().mockResolvedValue({ pharmaciesByLocation: [] }),
+  getOffers: vi.fn().mockResolvedValue([]),
+  rerouteOrder: vi.fn().mockReturnValue(Promise.resolve(true)),
+  setOrderPharmacy: vi.fn(),
+  setPreferredPharmacy: vi.fn(),
+  triggerDemoNotification: vi.fn(),
+  AUTH_HEADER_ERRORS: []
+}));
+
+vi.mock('./configs/graphqlClient', () => ({
+  setAuthHeader: vi.fn(),
+  graphQLClient: {
+    request: vi.fn().mockResolvedValue({})
+  },
+  gqlSerializer: {
+    parse: vi.fn(),
+    stringify: vi.fn()
+  }
+}));
+
+vi.mock('@datadog/browser-rum');
+vi.mock('./configs/analytics');
+vi.mock('./hooks/usePageAnalytics');
+vi.mock('react-ga4');
+
+vi.mock('./components', async () => {
+  const mod = await vi.importActual('./components');
+  return {
+    ...mod,
+    CouponModal: () => <div data-testid="coupon-modal">Coupon Modal</div>,
+    FixedFooter: ({ children }: { children: React.ReactNode }) => (
+      <div data-testid="fixed-footer">{children}</div>
+    ),
+    LocationModal: () => <div data-testid="location-modal">Location Modal</div>,
+    PoweredBy: () => <div data-testid="powered-by">Powered By</div>,
+    Nav: () => <div>Nav</div>,
+    PrescriptionsList: () => <div>PrescriptionsList</div>,
+    DemoCtaModal: () => <div data-testid="demo-cta-modal">Demo Cta Modal</div>,
+    Coupons: () => <div data-testid="coupons">Coupons</div>
+  };
+});
+
+describe('Rerouting', () => {
+  const testFirstPharmacy = generatePharmacy({
+    id: generateId('phr_'),
+    name: 'The Original Pharmacy'
+  });
+  const testSecondPharmacy = generatePharmacy({ id: generateId('phr_'), name: 'The New Pharmacy' });
+
+  const testPatient = generatePatient({ name: { full: 'Jane Doe' } });
+  const testFill = generateFill('test-treatment');
+  const testFulfillment = generateFulfillment({ state: 'PROCESSING' });
+  const testOrder = generateOrder({
+    id: 'ord_testId777',
+    state: 'PLACED',
+    patient: testPatient,
+    fills: [testFill],
+    fulfillments: [testFulfillment],
+    pharmacy: testFirstPharmacy,
+    isReroutable: true,
+    exceptions: [
+      {
+        exceptionType: 'ORDER_ERROR'
+      }
+    ]
+  });
+  testOrder.organization.settings = {
+    brandColor: '#af349d',
+    patientUx: {
+      enablePatientRerouting: true
+    }
+  };
+
+  beforeAll(async () => {
+    const { getPharmacies, setOrderPharmacy, getOrder } = await import('./api');
+
+    const getOrderMock = vi.mocked(getOrder);
+    getOrderMock.mockResolvedValue(testOrder);
+
+    const getPharmaciesMock = vi.mocked(getPharmacies);
+    getPharmaciesMock.mockResolvedValue({
+      pharmaciesByLocation: [testFirstPharmacy, testSecondPharmacy]
+    });
+
+    const setOrderPharmacyMock = vi.mocked(setOrderPharmacy);
+    setOrderPharmacyMock.mockResolvedValue(true);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('Navigates to pharmacy selection, chooses a new pharmacy to reroute to, and goes to the status page with new pharmacy info and order exceptions optimistically updated', async () => {
+    renderApp();
+
+    // shows the current order error status
+    expect(await screen.findByText(/order error/i)).toBeInTheDocument();
+
+    // has ability to reroute
+    const rerouteButton = await screen.findByText(/change pharmacy/i);
+    expect(rerouteButton).toBeInTheDocument();
+    await userEvent.click(rerouteButton);
+
+    // moves to pharmacy selection page
+    expect(await screen.findByText(text.changePharmacy)).toBeInTheDocument();
+
+    // shows the current pharmacy with current pharmacy tag
+    const pharmacyInfos = await screen.findAllByTestId('pharmacy-info');
+    for (const pharmacyInfo of pharmacyInfos) {
+      const pharmacyName = pharmacyInfo.querySelector(`[data-testid="pharmacy-info-name"]`);
+      const currentPharmacyTag = pharmacyInfo.querySelector(
+        `[data-testid="pharmacy-info-current-pharmacy"]`
+      );
+      if (pharmacyName?.textContent?.includes(testFirstPharmacy.name)) {
+        expect(currentPharmacyTag).toBeInTheDocument();
+      } else {
+        expect(currentPharmacyTag).toBeNull();
+      }
+    }
+    expect(await screen.findByText(testFirstPharmacy.name)).toBeInTheDocument();
+
+    // shows the select pharmacy button after clicking on a pharmacy option
+    const newPharmacyOption = await screen.findByText(testSecondPharmacy.name);
+    expect(newPharmacyOption).toBeInTheDocument();
+    await userEvent.click(newPharmacyOption);
+    const selectPharmacyButton = await screen.findByText(text.selectPharmacy);
+    expect(selectPharmacyButton).toBeVisible();
+
+    // loads and shows a thank you message
+    await userEvent.click(selectPharmacyButton);
+    await waitFor(() => screen.findByText(text.thankYou), { timeout: 3000 });
+
+    // returns to the status page with the updated pharmacy and cleared exceptions
+    await waitFor(() => screen.findByText(/preparing order/i), { timeout: 3000 });
+    expect(await screen.findByText(testSecondPharmacy.name)).toBeInTheDocument();
+  });
+});
+
+const renderApp = () => {
+  const memoryRouter = createMemoryRouter(createRoutesFromElements(routeElements), {
+    initialEntries: ['/status']
+  });
+
+  return { render: render(<RouterProvider router={memoryRouter} />), memoryRouter };
+};

--- a/apps/patient/src/components/LocationModal.tsx
+++ b/apps/patient/src/components/LocationModal.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import {
   Alert,
@@ -38,9 +38,6 @@ const formatLocationOptions = (p: any[]) => {
   return options;
 };
 
-const autocompleteService = new google.maps.places.AutocompleteService();
-const geocoder = new google.maps.Geocoder();
-
 interface LocationModalProps {
   isOpen: boolean;
   onClose: (args: { loc?: string; lat?: number; lng?: number }) => void;
@@ -48,6 +45,9 @@ interface LocationModalProps {
 
 export const LocationModal = ({ isOpen, onClose }: LocationModalProps) => {
   const [gettingCurrentLocation, setGettingCurrentLocation] = useState<boolean>(false);
+
+  const autocompleteService = useMemo(() => new google.maps.places.AutocompleteService(), []);
+  const geocoder = useMemo(() => new google.maps.Geocoder(), []);
 
   const { order } = useOrderContext();
 

--- a/apps/patient/src/components/PharmacyInfo.tsx
+++ b/apps/patient/src/components/PharmacyInfo.tsx
@@ -295,7 +295,7 @@ export const PharmacyInfo = ({
   const taglineOverride = showNovocareTagline || showAmazonTagline;
 
   return (
-    <VStack align="start" w="full">
+    <VStack data-testid="pharmacy-info" align="start" w="full">
       <HStack w="full" justify="space-between">
         <VStack w="full">
           <HStack w="full">
@@ -310,7 +310,11 @@ export const PharmacyInfo = ({
                 />
               </Box>
             ) : null}
-            <Text fontSize="md" fontWeight={boldPharmacyName ? 'bold' : 'medium'}>
+            <Text
+              data-testid="pharmacy-info-name"
+              fontSize="md"
+              fontWeight={boldPharmacyName ? 'bold' : 'medium'}
+            >
               {whiteLabelDeliveryPharmacy ? 'Free Express Delivery' : pharmacy.name}
             </Text>
           </HStack>
@@ -417,7 +421,9 @@ export const PharmacyInfo = ({
           borderWidth="1px"
           mb={1}
         >
-          <TagLabel fontWeight="bold">Current Pharmacy</TagLabel>
+          <TagLabel data-testid="pharmacy-info-current-pharmacy" fontWeight="bold">
+            Current Pharmacy
+          </TagLabel>
         </Tag>
       ) : null}
       {trackingLink && (

--- a/apps/patient/src/test-utils/generators.ts
+++ b/apps/patient/src/test-utils/generators.ts
@@ -2,6 +2,8 @@ import { Order } from '../utils/models';
 import { FillWithCount } from '../utils/general';
 import { type Offer, type Pharmacy } from '../__generated__/graphql';
 
+export const generateId = (prefix?: string) => `${prefix}${Math.random().toString(16).slice(2)}`;
+
 export const generateOrder = (overrides: Partial<Order> = {}): Order => ({
   id: 'ord_test_defaultId',
   patient: generatePatient(),

--- a/apps/patient/src/views/Canceled.test.tsx
+++ b/apps/patient/src/views/Canceled.test.tsx
@@ -47,7 +47,9 @@ describe('Canceled', () => {
 
 const renderCanceled = (orderContextValueOverride: Partial<OrderContextType> = {}) => {
   const orderContextValue: OrderContextType = {
-    fetchOrder(currentPharmacy: Order['pharmacy'] | undefined): void {},
+    fetchOrder(currentPharmacy: Order['pharmacy'] | undefined) {
+      return Promise.resolve(undefined);
+    },
     flattenedFills: [],
     isDemo: false,
     logo: undefined,

--- a/apps/patient/src/views/Main.tsx
+++ b/apps/patient/src/views/Main.tsx
@@ -26,7 +26,7 @@ export interface OrderContextType {
   setOrder: (order: Order) => void;
   logo: any;
   isDemo: boolean;
-  fetchOrder: (currentPharmacy?: Pharmacy) => void;
+  fetchOrder: (currentPharmacy?: Pharmacy) => Promise<Order | undefined>;
   setFaqModalIsOpen: (isOpen: boolean) => void;
 }
 export const OrderContext = createContext<OrderContextType | null>(null);
@@ -151,6 +151,7 @@ export const Main = () => {
         if (result) {
           handleOrderResponse(result, currentPharmacy);
         }
+        return result;
       } catch (e: any) {
         const error = e as any;
         console.log(error.response);

--- a/apps/patient/src/views/Pharmacy.test.tsx
+++ b/apps/patient/src/views/Pharmacy.test.tsx
@@ -211,7 +211,9 @@ describe('Pharmacy Component', async () => {
 const renderPharmacy = async (orderContextValueOverride: Partial<OrderContextType> = {}) => {
   let component;
   const orderContextValue: OrderContextType = {
-    fetchOrder(currentPharmacy: Order['pharmacy'] | undefined): void {},
+    fetchOrder(currentPharmacy: Order['pharmacy'] | undefined) {
+      return Promise.resolve(undefined);
+    },
     flattenedFills: [],
     isDemo: false,
     logo: undefined,

--- a/apps/patient/src/views/Pharmacy.tsx
+++ b/apps/patient/src/views/Pharmacy.tsx
@@ -651,14 +651,20 @@ export const Pharmacy = () => {
 
             handleSubmitSuccessAnalytics(selectedPharmacy);
 
-            setOrder({
-              ...order,
-              isReroutable: !isReroute,
-              discountCards: []
-            });
-
             // necessary to ensure the order is updated with the new coupon before navigating
-            await fetchOrder(selectedPharmacy);
+            const updatedOrder = await fetchOrder(selectedPharmacy);
+
+            if (updatedOrder) {
+              setOrder({
+                ...updatedOrder,
+                isReroutable: !isReroute,
+                exceptions: updatedOrder.exceptions.map((exception) => ({
+                  ...exception,
+                  resolvedAt: new Date().toISOString()
+                })),
+                pharmacy: selectedPharmacy
+              });
+            }
 
             const query = queryString.stringify({ orderId: order.id, token, type });
             return navigate(`/status?${query}`);

--- a/apps/patient/src/views/ReadyBy.test.tsx
+++ b/apps/patient/src/views/ReadyBy.test.tsx
@@ -46,7 +46,9 @@ describe('ReadyBy', () => {
 
 const renderReadyBy = (orderContextValueOverride: Partial<OrderContextType> = {}) => {
   const orderContextValue: OrderContextType = {
-    fetchOrder(currentPharmacy: Order['pharmacy'] | undefined): void {},
+    fetchOrder(currentPharmacy: Order['pharmacy'] | undefined) {
+      return Promise.resolve(undefined);
+    },
     flattenedFills: [],
     isDemo: false,
     logo: undefined,


### PR DESCRIPTION
After rerouting, the status page was still showing the old pharmacy and its exceptions. we need to optimistically update the state locally while updates occur in the event system


This ticket: https://www.notion.so/photons/Status-page-needs-to-update-after-reroute-24c8bfbbf4ec80c18647ed89558dc29a?v=22b8bfbbf4ec80af8e2d000c73a7556b&source=copy_link



https://github.com/user-attachments/assets/69276560-ddb4-4202-8572-78556c41cb38

