### PR TITLE
Gate the Message Support button for only orders that are not noshore

### DIFF
--- a/apps/patient/src/components/FAQModal.tsx
+++ b/apps/patient/src/components/FAQModal.tsx
@@ -14,7 +14,15 @@ import {
 import { Card } from './Card';
 import { FAQContents } from './FAQ';
 
-export const FAQModal = ({ isOpen, onClose }: { isOpen: boolean; onClose: () => void }) => {
+export const FAQModal = ({
+  isOpen,
+  onClose,
+  allowMessageSupport = true
+}: {
+  isOpen: boolean;
+  onClose: () => void;
+  allowMessageSupport?: boolean;
+}) => {
   const handleClose = () => {
     onClose();
   };
@@ -34,29 +42,31 @@ export const FAQModal = ({ isOpen, onClose }: { isOpen: boolean; onClose: () => 
                 <FAQContents />
               </VStack>
 
-              <VStack w="full" alignItems="stretch" spacing={4}>
-                <Heading as="h4" size="md">
-                  Still need help?
-                </Heading>
-                <Card>
-                  <VStack spacing={1} w="full">
-                    <Box>
-                      If you have other pharmacy related questions, we are available 24/7 for
-                      support. We typically respond within 30 minutes.
-                    </Box>
-                    <Button
-                      as="a"
-                      variant="outline"
-                      color="blue.500"
-                      href={`sms:${process.env.REACT_APP_TWILIO_SMS_NUMBER}`}
-                      w="full"
-                      onClick={handleMessageSupport}
-                    >
-                      Message support
-                    </Button>
-                  </VStack>
-                </Card>
-              </VStack>
+              {allowMessageSupport && (
+                <VStack w="full" alignItems="stretch" spacing={4}>
+                  <Heading as="h4" size="md">
+                    Still need help?
+                  </Heading>
+                  <Card>
+                    <VStack spacing={1} w="full">
+                      <Box>
+                        If you have other pharmacy related questions, we are available 24/7 for
+                        support. We typically respond within 30 minutes.
+                      </Box>
+                      <Button
+                        as="a"
+                        variant="outline"
+                        color="blue.500"
+                        href={`sms:${process.env.REACT_APP_TWILIO_SMS_NUMBER}`}
+                        w="full"
+                        onClick={handleMessageSupport}
+                      >
+                        Message support
+                      </Button>
+                    </VStack>
+                  </Card>
+                </VStack>
+              )}
             </VStack>
           </Container>
         </ModalBody>

--- a/apps/patient/src/graphql/queries.ts
+++ b/apps/patient/src/graphql/queries.ts
@@ -63,6 +63,7 @@ export const GET_ORDER = gql`
           brandLogo
           priorAuthorizationExceptionMessage
           patientUx {
+            enableAutomatedOps
             enablePatientRerouting
             enablePatientDeliveryPharmacies
             patientFeaturedPharmacyName

--- a/apps/patient/src/views/Main.tsx
+++ b/apps/patient/src/views/Main.tsx
@@ -248,13 +248,19 @@ export const Main = () => {
     setFaqModalIsOpen
   };
 
+  const isAutomatedOrder = order.organization.settings?.patientUx.enableAutomatedOps;
+
   return (
     <ChakraProvider theme={theme({ accentColor: settings?.brandColor })}>
       <OrderContext.Provider value={orderContextValue}>
         <ScrollRestoration />
         <Nav />
         <Outlet />
-        <FAQModal isOpen={faqModalIsOpen} onClose={() => setFaqModalIsOpen(false)} />
+        <FAQModal
+          isOpen={faqModalIsOpen}
+          onClose={() => setFaqModalIsOpen(false)}
+          allowMessageSupport={!isAutomatedOrder}
+        />
       </OrderContext.Provider>
     </ChakraProvider>
   );


### PR DESCRIPTION
Hiding `Message Support` button for noshore orders since we won't be handling patient inbound 

Related to this ticket:
https://www.notion.so/photons/Change-the-Message-Support-Functionality-for-No-Shore-orders-22b8bfbbf4ec808c84d0df9997ef53d5?v=22b8bfbbf4ec80af8e2d000c73a7556b&source=copy_link


https://github.com/user-attachments/assets/f14206d1-1945-4725-97d4-ffe695ec95c5

