### PR TITLE
Change the "Text us" copy on the /no-match page to not be mislseading in case we don't accept texts for an order.

### DIFF
--- a/apps/patient/src/utils/text.tsx
+++ b/apps/patient/src/utils/text.tsx
@@ -97,13 +97,9 @@ export const text = {
   pricesCanChange:
     'Prices subject to change without notice and may change based on supply and demand. If there’s a huge price discrepancy, please message us.',
   quantity: 'Quantity',
-  questionVerb: 'If you have any questions, please text us at ',
+  questionVerb: 'If you have any questions, please contact support',
   questionsPhoneNumber: '+1 (513) 866 3212',
-  reachOut: (
-    <>
-      If you have any questions, please <PhoneLink>text us</PhoneLink> or reach out to your provider
-    </>
-  ),
+  reachOut: 'If you have any questions, please reach out to your provider',
   readyBy: 'Ready by',
   readyByOptions: {
     Today: [

--- a/apps/patient/src/views/NoMatch.tsx
+++ b/apps/patient/src/views/NoMatch.tsx
@@ -1,6 +1,6 @@
 import { Center, Heading, Text, VStack, ChakraProvider } from '@chakra-ui/react';
 import { MdSearch } from 'react-icons/md';
-import { text as t, PhoneLink } from '../utils/text';
+import { text as t } from '../utils/text';
 import theme from '../configs/theme';
 import { patientAnalytics } from '../configs/analytics';
 
@@ -15,10 +15,7 @@ export const NoMatch = () => {
           <Heading as="h4" size="md" textAlign="center">
             {t.noMatch}
           </Heading>
-          <Text textAlign="center">
-            {t.questionVerb}
-            <PhoneLink />
-          </Text>
+          <Text textAlign="center">{t.questionVerb}</Text>
         </VStack>
       </Center>
     </ChakraProvider>


### PR DESCRIPTION
"Reach out to provider" for canceled, "Reach out to support" for 404


<img width="1600" height="1032" alt="Screenshot 2025-08-25 at 3 22 35 PM" src="https://github.com/user-attachments/assets/c23eb716-a7aa-48c1-8fc8-4f85483493ff" />
