### PR TITLE
Standardize rx writtenAt date between clinical app and sdk components package

### DIFF
--- a/packages/components/src/utils/formatDate.ts
+++ b/packages/components/src/utils/formatDate.ts
@@ -3,11 +3,5 @@ export default function formatDate(dateString: string): string {
     return '';
   }
 
-  const date = new Date(dateString);
-  const month = date.getMonth() + 1;
-  const day = date.getDate();
-  const year = date.getFullYear();
-
-  const formattedDate = `${month}/${day}/${year}`;
-  return formattedDate;
+  return new Date(dateString).toLocaleDateString('en-US', { timeZone: 'UTC' });
 }


### PR DESCRIPTION
# Backstory
Blueberry reported seeing a different date in the med history table than what's on the prescription page. This is because the med history table was using a different `formatDate` which converted the date into local time rather than keeping it in UTC. The prescription details page uses the formatDate function defined as:
<img width="621" height="203" alt="Screenshot 2025-08-25 at 5 40 11 PM" src="https://github.com/user-attachments/assets/fe546f7e-609a-4c00-8f9a-b3d176dd8315" />
https://github.com/Photon-Health/client/blob/boson/apps/app/src/utils.ts#L16

This lives in the `app` directory so I imagine that's why it's not being imported to the `packages/components` directory(import boundaries and such). So I'm just updating the implementation in components package to use the same UTC formatting. 


## Before the change
<img width="554" height="259" alt="Screenshot 2025-08-25 at 5 51 15 PM" src="https://github.com/user-attachments/assets/6c2da2ab-17d6-46f5-b933-fdc2e757b6b0" />
<img width="589" height="373" alt="Screenshot 2025-08-25 at 5 51 46 PM" src="https://github.com/user-attachments/assets/fb6a2385-0fa5-4eba-b8e9-62ef05b9a492" />


## After the change
<img width="554" height="259" alt="Screenshot 2025-08-25 at 5 51 15 PM" src="https://github.com/user-attachments/assets/9efa8591-0052-4dd5-85b1-f622a209e980" />

<img width="592" height="365" alt="Screenshot 2025-08-25 at 5 52 29 PM" src="https://github.com/user-attachments/assets/c5b2f12d-220a-4f78-bd76-01542937d54f" />

