### PR TITLE
Improve datadog resource logs

### DIFF
--- a/apps/app/src/index.tsx
+++ b/apps/app/src/index.tsx
@@ -1,31 +1,13 @@
 import { createRoot } from 'react-dom/client';
 import { ChakraProvider } from '@chakra-ui/react';
-import { datadogRum } from '@datadog/browser-rum';
-import { beforeSendHandler } from './instrumentation';
 import reportWebVitals from './reportWebVitals';
 import * as serviceWorker from './serviceWorker';
 import theme from './configs/theme';
 import { App } from './App';
-import pkg from '../package.json';
 import '@photonhealth/elements';
+import { initializeInstrumentation } from './instrumentation';
 
-datadogRum.init({
-  applicationId: process.env.REACT_APP_DATADOG_RUM_APPLICATION_ID as string,
-  clientToken: process.env.REACT_APP_DATADOG_RUM_CLIENT_TOKEN as string,
-  site: 'datadoghq.com',
-  service: pkg.name,
-  env: process.env.REACT_APP_ENV_NAME,
-  version: __COMMIT_HASH__,
-  sessionSampleRate: 100,
-  sessionReplaySampleRate: 100,
-  trackUserInteractions: true,
-  trackResources: true,
-  trackLongTasks: true,
-  defaultPrivacyLevel: 'mask-user-input',
-  beforeSend: beforeSendHandler
-});
-
-datadogRum.startSessionReplayRecording();
+initializeInstrumentation();
 
 const container = document.getElementById('root')!;
 const root = createRoot(container); // createRoot(container!) if you use TypeScript

--- a/apps/app/src/index.tsx
+++ b/apps/app/src/index.tsx
@@ -1,14 +1,11 @@
 import { createRoot } from 'react-dom/client';
 import { ChakraProvider } from '@chakra-ui/react';
-
 import { datadogRum } from '@datadog/browser-rum';
-
+import { beforeSendHandler } from './instrumentation';
 import reportWebVitals from './reportWebVitals';
 import * as serviceWorker from './serviceWorker';
-
 import theme from './configs/theme';
 import { App } from './App';
-
 import pkg from '../package.json';
 import '@photonhealth/elements';
 
@@ -24,7 +21,8 @@ datadogRum.init({
   trackUserInteractions: true,
   trackResources: true,
   trackLongTasks: true,
-  defaultPrivacyLevel: 'mask-user-input'
+  defaultPrivacyLevel: 'mask-user-input',
+  beforeSend: beforeSendHandler
 });
 
 datadogRum.startSessionReplayRecording();

--- a/apps/app/src/instrumentation/beforeSendHandler.ts
+++ b/apps/app/src/instrumentation/beforeSendHandler.ts
@@ -1,0 +1,67 @@
+import type {
+  RumEvent,
+  RumEventDomainContext,
+  RumFetchResourceEventDomainContext
+} from '@datadog/browser-rum';
+
+const photonApiHostnames = [
+  process.env.REACT_APP_GRAPHQL_URI as string,
+  process.env.REACT_APP_CLINICAL_GRAPHQL_URI as string
+].map(getHostnameFromUrl);
+
+export const beforeSendHandler = (event: RumEvent, context: RumEventDomainContext) => {
+  if (
+    isResourceFetch(event, context) &&
+    hasRequestBody(context) &&
+    isPhotonApiRequest(context.requestInput)
+  ) {
+    addGraphqlAttributesToContext(event, context);
+  }
+  // allow log to be sent to datadog by returning true
+  return true;
+};
+
+function isResourceFetch(
+  event: RumEvent,
+  context: RumEventDomainContext
+): context is RumFetchResourceEventDomainContext {
+  return event.type === 'resource' && event.resource.type === 'fetch';
+}
+
+function hasRequestBody(
+  context: RumFetchResourceEventDomainContext
+): context is RumFetchResourceEventDomainContextWithRequestInit {
+  return !!context.requestInit?.body;
+}
+
+function isPhotonApiRequest(requestInput: RequestInfo): boolean {
+  const url = typeof requestInput === 'string' ? requestInput : requestInput.url;
+  const isPhoton = photonApiHostnames.includes(getHostnameFromUrl(url));
+  return isPhoton;
+}
+
+function addGraphqlAttributesToContext(
+  event: RumEvent,
+  context: RumFetchResourceEventDomainContextWithRequestInit
+) {
+  if (!event.context) return;
+
+  try {
+    const requestBody = JSON.parse(context.requestInit.body);
+    event.context.operationName = requestBody.operationName;
+    event.context.variables = requestBody.variables;
+    event.context.query = requestBody.query;
+  } catch (e) {
+    console.warn('Error parsing request body:', e);
+  }
+}
+
+function getHostnameFromUrl(url: string): string {
+  const urlObj = new URL(url);
+  return urlObj.hostname;
+}
+
+interface RumFetchResourceEventDomainContextWithRequestInit
+  extends RumFetchResourceEventDomainContext {
+  requestInit: RequestInit & { body: string };
+}

--- a/apps/app/src/instrumentation/beforeSendHandler.ts
+++ b/apps/app/src/instrumentation/beforeSendHandler.ts
@@ -36,8 +36,7 @@ function hasRequestBody(
 
 function isPhotonApiRequest(requestInput: RequestInfo): boolean {
   const url = typeof requestInput === 'string' ? requestInput : requestInput.url;
-  const isPhoton = photonApiHostnames.includes(getHostnameFromUrl(url));
-  return isPhoton;
+  return photonApiHostnames.includes(getHostnameFromUrl(url));
 }
 
 function addGraphqlAttributesToContext(

--- a/apps/app/src/instrumentation/index.ts
+++ b/apps/app/src/instrumentation/index.ts
@@ -1,1 +1,23 @@
-export { beforeSendHandler } from './beforeSendHandler';
+import { datadogRum } from '@datadog/browser-rum';
+import { beforeSendHandler } from './beforeSendHandler';
+import pkg from '../../package.json';
+
+export const initializeInstrumentation = () => {
+  datadogRum.init({
+    applicationId: process.env.REACT_APP_DATADOG_RUM_APPLICATION_ID as string,
+    clientToken: process.env.REACT_APP_DATADOG_RUM_CLIENT_TOKEN as string,
+    site: 'datadoghq.com',
+    service: pkg.name,
+    env: process.env.REACT_APP_ENV_NAME,
+    version: __COMMIT_HASH__,
+    sessionSampleRate: 100,
+    sessionReplaySampleRate: 100,
+    trackUserInteractions: true,
+    trackResources: true,
+    trackLongTasks: true,
+    defaultPrivacyLevel: 'mask-user-input',
+    beforeSend: beforeSendHandler
+  });
+
+  datadogRum.startSessionReplayRecording();
+};

--- a/apps/app/src/instrumentation/index.ts
+++ b/apps/app/src/instrumentation/index.ts
@@ -1,0 +1,1 @@
+export { beforeSendHandler } from './beforeSendHandler';

--- a/apps/app/src/instrumentation/setInstrumentationUserContext.tsx
+++ b/apps/app/src/instrumentation/setInstrumentationUserContext.tsx
@@ -1,0 +1,15 @@
+import { datadogRum } from '@datadog/browser-rum';
+
+export function setInstrumentationUserContext(user: {
+  org_id: string;
+  email: string;
+  name: string;
+}) {
+  datadogRum.setGlobalContextProperty('org', {
+    orgId: user.org_id
+  });
+  datadogRum.setUser({
+    email: user.email,
+    name: user.name
+  });
+}

--- a/apps/app/src/views/routes/Main.tsx
+++ b/apps/app/src/views/routes/Main.tsx
@@ -1,6 +1,5 @@
-import { Outlet, useLocation, Navigate, useNavigate } from 'react-router-dom';
-import { Center, CircularProgress, Box } from '@chakra-ui/react';
-
+import { Navigate, Outlet, useLocation, useNavigate } from 'react-router-dom';
+import { Box, Center, CircularProgress } from '@chakra-ui/react';
 import { usePhoton } from '@photonhealth/react';
 import { useEffect, useState } from 'react';
 import { Nav } from '../components/Nav';
@@ -9,7 +8,7 @@ import { addAlert } from '../../stores/alert';
 import { auth0Config } from '../../configs/auth';
 import useQueryParams from '../../hooks/useQueryParams';
 import { Env } from '@photonhealth/sdk';
-import { datadogRum } from '@datadog/browser-rum';
+import { setInstrumentationUserContext } from '../../instrumentation/setInstrumentationUserContext';
 
 declare global {
   namespace JSX {
@@ -41,14 +40,7 @@ export const Main = () => {
       setPreviouslyAuthed(false);
     }
     if (isAuthenticated && !isLoading) {
-      // global context to the datadog RUM session
-      datadogRum.setGlobalContextProperty('org', {
-        orgId: user.org_id
-      });
-      datadogRum.setUser({
-        email: user.email,
-        name: user.name
-      });
+      setInstrumentationUserContext(user);
     }
   }, [isAuthenticated, isLoading]);
 


### PR DESCRIPTION
* Clinical App DataDogRUM configuration now includes graphQL attributes (operationName, query, and variables) to resource logs
* Refactor: move parts of our datadog code into an `instrumentation` folder

[Notion ticket](https://www.notion.so/photons/Identify-what-is-causing-the-most-performance-issues-for-embed-2568bfbbf4ec8082bd15ce8b4217e2ea?source=copy_link)

<img width="4064" height="2334" alt="image" src="https://github.com/user-attachments/assets/ca9437e4-2a59-455a-ae7c-7f5ed89d55e6" />
