### PR TITLE
Fix login page auto-redirecting

### DIFF
--- a/apps/app/e2e/auth.setup.ts
+++ b/apps/app/e2e/auth.setup.ts
@@ -10,7 +10,9 @@ setup('authenticate', async ({ page }) => {
   await page.getByRole('button', { name: 'Log in' }).click();
   await expect(page.getByText('Log in to continue to Photon Clinical App')).toBeVisible();
   await page.getByLabel('Username').fill(process.env.PLAYWRIGHT_E2E_ACCOUNT_USERNAME);
-  await page.getByLabel('Password').fill(process.env.PLAYWRIGHT_E2E_ACCOUNT_PASSWORD);
+  await page
+    .getByRole('textbox', { name: 'Password' })
+    .fill(process.env.PLAYWRIGHT_E2E_ACCOUNT_PASSWORD);
   await page.getByRole('button', { name: 'Continue', exact: true }).click();
   await page.waitForURL(process.env.PLAYWRIGHT_BASE_URL, { timeout: 60_000 });
   await expect(page.getByRole('heading', { name: 'Prescriptions' })).toBeVisible();

--- a/apps/app/src/views/components/Auth.tsx
+++ b/apps/app/src/views/components/Auth.tsx
@@ -1,4 +1,4 @@
-import { Button, Stack } from '@chakra-ui/react';
+import { Button } from '@chakra-ui/react';
 import { usePhoton } from '@photonhealth/react';
 
 interface AuthProps {
@@ -6,24 +6,9 @@ interface AuthProps {
 }
 
 export const Auth = ({ returnTo = '/' }: AuthProps) => {
-  const { isLoading, isAuthenticated, login, logout } = usePhoton();
+  const { isLoading, login } = usePhoton();
 
   if (isLoading) return <Button isLoading loadingText="Loading" colorScheme="gray" />;
-
-  if (isAuthenticated)
-    return (
-      <Stack direction="row" spacing={4}>
-        <Button
-          colorScheme="brand"
-          onClick={() => {
-            localStorage.removeItem('previouslyAuthed');
-            logout({ returnTo: window.location.origin });
-          }}
-        >
-          Log out
-        </Button>
-      </Stack>
-    );
 
   return (
     <Button colorScheme="blue" onClick={() => login({ appState: { returnTo } })}>

--- a/apps/app/src/views/components/Auth.tsx
+++ b/apps/app/src/views/components/Auth.tsx
@@ -1,30 +1,12 @@
 import { Button, Stack } from '@chakra-ui/react';
-
 import { usePhoton } from '@photonhealth/react';
-import { graphql } from 'apps/app/src/gql';
-import { useQuery } from '@apollo/client';
 
 interface AuthProps {
   returnTo?: string;
 }
 
-const orgSettingsQuery = graphql(/* GraphQL */ `
-  query AuthComponentOrgSettingsQuery {
-    organization {
-      settings {
-        providerUx {
-          federatedAuth
-        }
-      }
-    }
-  }
-`);
-
-export const Auth = (props: AuthProps) => {
-  const { returnTo } = props;
-  const { clinicalClient, isLoading, isAuthenticated, login, logout } = usePhoton();
-  const { data } = useQuery(orgSettingsQuery, { client: clinicalClient });
-  const federated = data?.organization?.settings?.providerUx?.federatedAuth ?? false;
+export const Auth = ({ returnTo = '/' }: AuthProps) => {
+  const { isLoading, isAuthenticated, login, logout } = usePhoton();
 
   if (isLoading) return <Button isLoading loadingText="Loading" colorScheme="gray" />;
 
@@ -35,7 +17,7 @@ export const Auth = (props: AuthProps) => {
           colorScheme="brand"
           onClick={() => {
             localStorage.removeItem('previouslyAuthed');
-            logout({ returnTo: window.location.origin, federated });
+            logout({ returnTo: window.location.origin });
           }}
         >
           Log out
@@ -49,5 +31,3 @@ export const Auth = (props: AuthProps) => {
     </Button>
   );
 };
-
-Auth.defaultProps = { returnTo: '/' };

--- a/apps/app/src/views/routes/Login.tsx
+++ b/apps/app/src/views/routes/Login.tsx
@@ -56,7 +56,6 @@ export const Login = () => {
             {query.get('orgs') === '0' ? (
               <Alert status="warning">
                 <AlertIcon />
-                {/* the text below, but left aligned */}
                 <VStack>
                   <Text textAlign="left">
                     You tried logging in with an account not associated with any organizations.


### PR DESCRIPTION
* Remove api call for `federated` org setting that checked token and re-directed the page
  * The `<Auth>` component is not reachable for situations where `federated` logout is relevant. Only for users authenticated with 0 organizations is it relevant.
  * This PR does not touch the Federated logout of our app's main logout button, in the `<Nav>` component
* Remove unreachable logout button. This was unreachable because the parent component `<Login>` does not render the `<Auth>` component when `isAuthenticated` is true.
* Fix e2e test due to recent Auth0 login page change 

[notion ticket](https://www.notion.so/photons/Fix-auto-redirect-from-login-pages-to-Auth0-portal-2698bfbbf4ec80e6b686c4f5a8e88044?source=copy_link)