### PR TITLE
Use boolean OR instead of nullish coalescing for empty pa exception message default

### DIFF
--- a/apps/patient/src/components/order-summary/OrderSummary.tsx
+++ b/apps/patient/src/components/order-summary/OrderSummary.tsx
@@ -81,11 +81,10 @@ const MESSAGE: { [key in ExceptionData['exceptionType']]: (order: Order) => stri
   BACKORDERED: () =>
     `The pharmacy can’t order the medication. Contact your provider for alternatives or change your pharmacy.`,
   PA_REQUIRED: ({ organization }) => {
-    const paExceptionMessage = organization.settings?.priorAuthorizationExceptionMessage;
-    return (
-      paExceptionMessage ??
-      'Your insurance needs information from your provider to cover this medication. Contact your provider for alternatives or pay the cash price.'
-    );
+    const paExceptionMessage = organization.settings?.priorAuthorizationExceptionMessage?.trim();
+    const defaultPaExceptionMessage =
+      'Your insurance needs information from your provider to cover this medication. Contact your provider for alternatives or pay the cash price.';
+    return paExceptionMessage || defaultPaExceptionMessage;
   },
   REFILL_TOO_SOON: () =>
     `Your insurance informed the pharmacy that it's too soon for a refill. You can wait, or you can pay cash or use a discount card if you need it sooner.`,


### PR DESCRIPTION
The field defaults to null, however if someone decides to remove their custom pa exception message, then it will be an empty string. Using boolean OR gate to show a default message rather than nullish coalescing. Also trimming whitespace just in case.

<img width="1248" height="335" alt="Screenshot 2025-10-03 at 10 53 48 AM" src="https://github.com/user-attachments/assets/1bd2fb01-7213-42a4-b4ba-46832d2d232e" />


## Before

<img width="608" height="247" alt="Screenshot 2025-10-03 at 10 53 41 AM" src="https://github.com/user-attachments/assets/63e374d4-2992-42e2-b0c1-152f378e938a" />


## After

<img width="585" height="283" alt="Screenshot 2025-10-03 at 10 53 56 AM" src="https://github.com/user-attachments/assets/88d15dec-adda-4ad3-949a-56c37ccbf641" />
