### PR TITLE
count refills off of fills linked to the order

### DIFF
--- a/apps/patient/src/views/Status.test.tsx
+++ b/apps/patient/src/views/Status.test.tsx
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { computeNumRefillsForPrescription } from './Status';
+
+describe('computeNumRefillsForPrescription', () => {
+  it('returns correct refills for a single prescription (fills count - 1)', () => {
+    const rxId = 'rx-1';
+    const orderFills = [{ prescription: { id: rxId } }, { prescription: { id: rxId } }];
+    // 2 fills for rx-1 => refills = 2 - 1 = 1
+    expect(computeNumRefillsForPrescription(orderFills, rxId)).toBe(1);
+  });
+
+  it('handles multiple prescriptions and counts fills per prescription (minus one)', () => {
+    const rx1 = 'rx-1';
+    const rx2 = 'rx-2';
+    const rx3 = 'rx-3';
+    const orderFills = [
+      { prescription: { id: rx1 } },
+      { prescription: { id: rx1 } },
+      { prescription: { id: rx2 } },
+      { prescription: { id: rx2 } },
+      { prescription: { id: rx2 } },
+      { prescription: { id: rx3 } }
+    ];
+
+    // rx1: 2 fills -> 1 refill
+    expect(computeNumRefillsForPrescription(orderFills, rx1)).toBe(1);
+    // rx2: 3 fills -> 2 refills
+    expect(computeNumRefillsForPrescription(orderFills, rx2)).toBe(2);
+    // rx3: 1 fill -> 0 refills (floored at 0)
+    expect(computeNumRefillsForPrescription(orderFills, rx3)).toBe(0);
+  });
+});

--- a/apps/patient/src/views/Status.test.tsx
+++ b/apps/patient/src/views/Status.test.tsx
@@ -1,3 +1,14 @@
+import { vi } from 'vitest';
+
+vi.mock('../api', () => ({
+  triggerDemoNotification: vi.fn(),
+  geocode: vi.fn().mockResolvedValue({
+    lat: 0,
+    lng: 0,
+    address: 'mocked address'
+  })
+}));
+
 import { computeNumRefillsForPrescription } from './Status';
 
 describe('computeNumRefillsForPrescription', () => {

--- a/apps/patient/src/views/Status.test.tsx
+++ b/apps/patient/src/views/Status.test.tsx
@@ -1,4 +1,3 @@
-import { describe, it, expect } from 'vitest';
 import { computeNumRefillsForPrescription } from './Status';
 
 describe('computeNumRefillsForPrescription', () => {

--- a/apps/patient/src/views/Status.tsx
+++ b/apps/patient/src/views/Status.tsx
@@ -25,6 +25,15 @@ import { formatAddress } from '../utils/formatters';
 import { usePageAnalytics } from '../hooks/usePageAnalytics';
 import { patientAnalytics } from '../configs/analytics';
 
+export const computeNumRefillsForPrescription = (
+  orderFills: Array<{ prescription?: { id?: string } } | null | undefined> | undefined,
+  prescriptionId: string | undefined
+): number => {
+  if (!prescriptionId) return 0;
+  const fillsForRx = orderFills?.filter((fill) => fill?.prescription?.id === prescriptionId).length;
+  return Math.max(0, (fillsForRx ?? 0) - 1);
+};
+
 export const Status = () => {
   const navigate = useNavigate();
   const { order, setOrder, isDemo, setFaqModalIsOpen } = useOrderContext();
@@ -175,11 +184,7 @@ export const Status = () => {
     rxName: fulfillment.prescription.treatment.name,
     quantity: `${fulfillment.prescription?.dispenseQuantity} ${fulfillment.prescription?.dispenseUnit}`,
     daysSupply: fulfillment.prescription?.daysSupply ?? 0,
-    numRefills: Math.max(
-      0,
-      (order.fills?.filter((fill) => fill?.prescription?.id === fulfillment.prescription?.id)
-        .length ?? 0) - 1
-    ),
+    numRefills: computeNumRefillsForPrescription(order.fills, fulfillment.prescription?.id),
     expiresAt: fulfillment.prescription?.expirationDate ?? new Date()
   }));
 

--- a/apps/patient/src/views/Status.tsx
+++ b/apps/patient/src/views/Status.tsx
@@ -175,7 +175,10 @@ export const Status = () => {
     rxName: f.prescription.treatment.name,
     quantity: `${f.prescription?.dispenseQuantity} ${f.prescription?.dispenseUnit}`,
     daysSupply: f.prescription?.daysSupply ?? 0,
-    numRefills: Math.max(0, (order.fills?.length ?? 0) - 1),
+    numRefills: Math.max(
+      0,
+      (order.fills?.filter((of) => of?.prescription?.id === f.prescription?.id).length ?? 0) - 1
+    ),
     expiresAt: f.prescription?.expirationDate ?? new Date()
   }));
 

--- a/apps/patient/src/views/Status.tsx
+++ b/apps/patient/src/views/Status.tsx
@@ -171,15 +171,16 @@ export const Status = () => {
     exceptions: f.exceptions.filter((e) => e.resolvedAt == null)
   }));
 
-  const prescriptions = fulfillments.map((f) => ({
-    rxName: f.prescription.treatment.name,
-    quantity: `${f.prescription?.dispenseQuantity} ${f.prescription?.dispenseUnit}`,
-    daysSupply: f.prescription?.daysSupply ?? 0,
+  const prescriptions = fulfillments.map((fulfillment) => ({
+    rxName: fulfillment.prescription.treatment.name,
+    quantity: `${fulfillment.prescription?.dispenseQuantity} ${fulfillment.prescription?.dispenseUnit}`,
+    daysSupply: fulfillment.prescription?.daysSupply ?? 0,
     numRefills: Math.max(
       0,
-      (order.fills?.filter((of) => of?.prescription?.id === f.prescription?.id).length ?? 0) - 1
+      (order.fills?.filter((fill) => fill?.prescription?.id === fulfillment.prescription?.id)
+        .length ?? 0) - 1
     ),
-    expiresAt: f.prescription?.expirationDate ?? new Date()
+    expiresAt: fulfillment.prescription?.expirationDate ?? new Date()
   }));
 
   const primaryButtonStyle = {

--- a/apps/patient/src/views/Status.tsx
+++ b/apps/patient/src/views/Status.tsx
@@ -175,7 +175,7 @@ export const Status = () => {
     rxName: f.prescription.treatment.name,
     quantity: `${f.prescription?.dispenseQuantity} ${f.prescription?.dispenseUnit}`,
     daysSupply: f.prescription?.daysSupply ?? 0,
-    numRefills: f.prescription?.fillsAllowed ? f.prescription.fillsAllowed - 1 : 0,
+    numRefills: Math.max(0, (order.fills?.length ?? 0) - 1),
     expiresAt: f.prescription?.expirationDate ?? new Date()
   }));
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -46730,7 +46730,7 @@
     },
     "packages/elements": {
       "name": "@photonhealth/elements",
-      "version": "0.16.12",
+      "version": "0.16.14",
       "license": "ISC",
       "dependencies": {
         "@photonhealth/components": "*",


### PR DESCRIPTION
the idea is that you could have two different orders with different number of fills but the same prescription
so order 1 has 1 fill, order 2 has 2 fills from a RX that has 3 total fills
if you open order one it should say 0 refills
if you open order 2 it should say 1 refill


https://www.notion.so/photons/Update-Prescription-Fills-on-Orders-in-Admin-Patient-UI-Fills-sent-in-the-web-app-27f8bfbbf4ec80058a33f186a154b30d?source=copy_link