### PR TITLE
Add analytics to external URL click

### DIFF
--- a/apps/patient/src/components/coupons/CouponCardList.tsx
+++ b/apps/patient/src/components/coupons/CouponCardList.tsx
@@ -34,7 +34,7 @@ export const CouponCardList = () => {
         Coupon Card
       </Heading>
       {discountCardToShow.externalUrl ? (
-        <ExternalLinkCouponCard coupon={discountCardToShow} />
+        <ExternalLinkCouponCard coupon={discountCardToShow} order={order} />
       ) : (
         <EmbeddedCouponCard coupon={discountCardToShow} />
       )}

--- a/apps/patient/src/components/coupons/ExternalLinkCouponCard.tsx
+++ b/apps/patient/src/components/coupons/ExternalLinkCouponCard.tsx
@@ -3,9 +3,12 @@ import { DiscountCard } from '../../__generated__/graphql';
 import { CouponSourceLogo } from './CouponSourceLogo';
 import { formatPrice } from '../../utils/formatters';
 import { Card } from '../Card';
+import { patientAnalytics } from '../../configs/analytics';
+import { Order } from '../../utils/models';
 
 interface ExternalLinkCouponCardProps {
   coupon: ExternalLinkCoupon;
+  order: Order;
 }
 
 export type ExternalLinkCoupon = Pick<
@@ -15,6 +18,18 @@ export type ExternalLinkCoupon = Pick<
 
 export const ExternalLinkCouponCard = (props: ExternalLinkCouponCardProps) => {
   const { price, externalUrl, source, retailPrice } = props.coupon;
+  const { order } = props;
+
+  const handleGetCouponClick = () => {
+    patientAnalytics.track('Click External Offer Link', order, {
+      source,
+      externalUrl,
+      price,
+      retailPrice
+    });
+    window.open(externalUrl, '_blank', 'noopener,noreferrer');
+  };
+
   return (
     <>
       <Box p={3} bgColor="blue.100" borderRadius="lg">
@@ -33,11 +48,8 @@ export const ExternalLinkCouponCard = (props: ExternalLinkCouponCardProps) => {
           </Text>
         ) : null}
         <Button
-          as="a"
+          onClick={handleGetCouponClick}
           role="link"
-          href={externalUrl}
-          target="_blank"
-          rel="noopener noreferrer"
           w="full"
           variant="solid"
           bg="blue.600"

--- a/apps/patient/src/configs/analytics.ts
+++ b/apps/patient/src/configs/analytics.ts
@@ -167,12 +167,24 @@ function mapOrderToContextData(order: Order): ContextData {
     })
   );
 
+  const contextDataDiscountCards = order.discountCards.map((discountCard) => ({
+    id: discountCard.id,
+    externalUrl: discountCard.externalUrl,
+    price: discountCard.price,
+    retailPrice: discountCard.retailPrice,
+    source: discountCard.source,
+    memberId: discountCard.memberId,
+    bin: discountCard.bin,
+    pcn: discountCard.pcn
+  }));
+
   return {
     order: contextDataOrder,
     patient: contextDataPatient,
     organization: contextDataOrganization,
     pharmacy: contextDataPharmacy,
     fulfillments: contextDataFulfillments,
+    discountCards: contextDataDiscountCards,
     medications
   };
 }

--- a/apps/patient/src/views/Status.test.tsx
+++ b/apps/patient/src/views/Status.test.tsx
@@ -2,6 +2,7 @@ import { vi } from 'vitest';
 import { createMemoryRouter, createRoutesFromElements, RouterProvider } from 'react-router-dom';
 import { routeElements } from '../Routes';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import {
   generateDiscountCard,
   generateFill,
@@ -43,7 +44,15 @@ describe('Status page Coupon cards', () => {
     expect(await screen.findByText('Order is likely ready')).toBeInTheDocument();
 
     const couponButton = await screen.findByRole('link', { name: /get coupon/i });
-    expect(couponButton).toHaveAttribute('href', 'coupon-card-test-url');
+
+    window.open = vi.fn();
+    await userEvent.click(couponButton);
+    expect(window.open).toHaveBeenCalledWith(
+      'coupon-card-test-url',
+      '_blank',
+      'noopener,noreferrer'
+    );
+    vi.mocked(window.open).mockRestore();
   });
 
   test('shows coupon details when there is no external URL', async () => {


### PR DESCRIPTION
This will help us track analytics around who clicks on the new "Get coupon" external URL.