### PR TITLE
Block Medications in catalog for Form

### DIFF
--- a/packages/elements/index.html
+++ b/packages/elements/index.html
@@ -46,7 +46,7 @@
           enable-coverage-check="true"
           enable-send-to-patient="true"
           enable-local-pickup="true"
-          disable-list='[{"ndcs": ["00169-4525-14"], "reason": "Not covered by patient insurance"}]'
+          disable-list='[{"treatmentIds": ["treatment_12345"], "reason": "Not covered by patient insurance"}]'
           id="one"
         ></photon-prescribe-workflow>
       </div>

--- a/packages/elements/index.html
+++ b/packages/elements/index.html
@@ -46,7 +46,7 @@
           enable-coverage-check="true"
           enable-send-to-patient="true"
           enable-local-pickup="true"
-          disable-list='[{"treatmentIds": ["med_01J6ZE5RSPDRXZRX7SEFHJSMDB"], "reason": "Not covered by patient insurance"}]'
+          disable-list='[{"treatmentIds": ["med_01J6ZE5RSPDRXZRX7SEFHJSMDB"], "reason": "Not covered by patient insurance"}, {"treatmentIds": ["med_01J6ZE5RTEB5FK0CES2DDQWYV2"], "reason": "Too expensive"}]'
           id="one"
         ></photon-prescribe-workflow>
       </div>

--- a/packages/elements/index.html
+++ b/packages/elements/index.html
@@ -46,7 +46,7 @@
           enable-coverage-check="true"
           enable-send-to-patient="true"
           enable-local-pickup="true"
-          disable-list='[{"treatmentIds": ["treatment_12345"], "reason": "Not covered by patient insurance"}]'
+          disable-list='[{"treatmentIds": ["med_01J6ZE5RSPDRXZRX7SEFHJSMDB"], "reason": "Not covered by patient insurance"}]'
           id="one"
         ></photon-prescribe-workflow>
       </div>

--- a/packages/elements/index.html
+++ b/packages/elements/index.html
@@ -46,6 +46,7 @@
           enable-coverage-check="true"
           enable-send-to-patient="true"
           enable-local-pickup="true"
+          disable-list='[{"ndcs": ["00169-4525-14"], "reason": "Not covered by patient insurance"}]'
           id="one"
         ></photon-prescribe-workflow>
       </div>

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@photonhealth/elements",
-  "version": "0.16.14",
+  "version": "0.16.15",
   "description": "",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/elements/src/photon-medication-search/photon-medication-search-component.tsx
+++ b/packages/elements/src/photon-medication-search/photon-medication-search-component.tsx
@@ -192,22 +192,29 @@ function displayTreatment(
 function displayPrescriptionTemplate(
   t: PrescriptionTemplate,
   showFormattedMedicationName: boolean,
-  searchText: string
+  searchText: string,
+  disableList?: DisableList
 ) {
+  const treatmentId = t.treatment.id;
+  const { disabled, reason } = isTreatmentDisabled(treatmentId, disableList);
+
   if (showFormattedMedicationName) {
     const refills = t.fillsAllowed ? t.fillsAllowed - 1 : 0;
 
     return (
-      <div class="my-1">
-        <div class="text-sm whitespace-normal font-medium mb-1">
+      <div class={`my-1 ${disabled ? 'opacity-50 cursor-not-allowed' : ''}`}>
+        <div
+          class={`text-sm whitespace-normal font-medium mb-1 ${disabled ? 'text-gray-500' : ''}`}
+        >
           {t.name ? <span class="text-blue-600">({boldSubstring(t.name, searchText)}): </span> : ''}
           {boldSubstring(t.treatment.name, searchText)}
         </div>
-        <div class="text-xs text-gray-500 truncate">
+        <div class={`text-xs truncate ${disabled ? 'text-gray-400' : 'text-gray-500'}`}>
           {t.dispenseQuantity} {t.dispenseUnit}, {t.daysSupply}{' '}
           {t.daysSupply === 1 ? 'day' : 'days'} supply, {refills}{' '}
           {refills === 1 ? 'refill' : 'refills'}, {t.instructions}
         </div>
+        {disabled && reason && <p class="text-xs text-red-500 mt-1 italic">Disabled: {reason}</p>}
       </div>
     );
   }
@@ -310,7 +317,8 @@ const Component = (props: ComponentProps) => {
       return displayPrescriptionTemplate(
         t as PrescriptionTemplate,
         showFormattedMedicationName,
-        props.searchText
+        props.searchText,
+        props.disableList
       );
     }
     return displayTreatment(
@@ -330,8 +338,18 @@ const Component = (props: ComponentProps) => {
         const selectedItem = e.detail.data;
 
         // Check if the selected item is disabled
-        if ('id' in selectedItem) {
-          const { disabled } = isTreatmentDisabled(selectedItem.id, props.disableList);
+        let treatmentId: string | undefined;
+
+        if ('treatment' in selectedItem) {
+          // This is a PrescriptionTemplate - check the treatment ID
+          treatmentId = selectedItem.treatment.id;
+        } else if ('id' in selectedItem) {
+          // This is a Treatment or TreatmentOption - use the ID directly
+          treatmentId = selectedItem.id;
+        }
+
+        if (treatmentId) {
+          const { disabled } = isTreatmentDisabled(treatmentId, props.disableList);
           if (disabled) {
             // Don't dispatch selection event for disabled items
             return;

--- a/packages/elements/src/photon-medication-search/photon-medication-search-component.tsx
+++ b/packages/elements/src/photon-medication-search/photon-medication-search-component.tsx
@@ -23,22 +23,18 @@ import gql from 'graphql-tag';
 
 // Utility Functions
 
-function isNdcDisabled(
-  ndc: string | undefined,
+function isTreatmentDisabled(
+  treatmentId: string | undefined,
   disableList: DisableList | undefined
 ): { disabled: boolean; reason?: string } {
-  if (!ndc || !disableList || disableList.length === 0) {
+  if (!treatmentId || !disableList || disableList.length === 0) {
     return { disabled: false };
   }
 
-  // Normalize NDC by removing hyphens for comparison
-  const normalizedNdc = ndc.replace(/-/g, '');
-
   for (const item of disableList) {
-    if (item.ndcs) {
-      for (const disabledNdc of item.ndcs) {
-        const normalizedDisabledNdc = disabledNdc.replace(/-/g, '');
-        if (normalizedNdc === normalizedDisabledNdc) {
+    if (item.treatmentIds) {
+      for (const disabledTreatmentId of item.treatmentIds) {
+        if (treatmentId === disabledTreatmentId) {
           return { disabled: true, reason: item.reason };
         }
       }
@@ -84,9 +80,6 @@ const SearchTreatmentOptionsQuery = gql`
       __typename
       id
       name
-      ... on Medication {
-        ndc
-      }
     }
   }
 `;
@@ -179,8 +172,8 @@ function displayTreatment(
   searchText: string,
   disableList?: DisableList
 ) {
-  const ndc = 'ndc' in t ? t.ndc : undefined;
-  const { disabled, reason } = isNdcDisabled(ndc, disableList);
+  const treatmentId = t.id;
+  const { disabled, reason } = isTreatmentDisabled(treatmentId, disableList);
 
   if (showFormattedMedicationName) {
     return (
@@ -337,8 +330,8 @@ const Component = (props: ComponentProps) => {
         const selectedItem = e.detail.data;
 
         // Check if the selected item is disabled
-        if ('ndc' in selectedItem) {
-          const { disabled } = isNdcDisabled(selectedItem.ndc, props.disableList);
+        if ('id' in selectedItem) {
+          const { disabled } = isTreatmentDisabled(selectedItem.id, props.disableList);
           if (disabled) {
             // Don't dispatch selection event for disabled items
             return;

--- a/packages/elements/src/photon-medication-search/photon-medication-search-component.tsx
+++ b/packages/elements/src/photon-medication-search/photon-medication-search-component.tsx
@@ -1,6 +1,6 @@
 // Solid
 import { customElement } from 'solid-element';
-import { createEffect, createSignal, onMount, Show } from 'solid-js';
+import { createEffect, createMemo, createSignal, onMount, Show } from 'solid-js';
 
 // Photon
 import { usePhoton } from '@photonhealth/components';
@@ -23,22 +23,34 @@ import gql from 'graphql-tag';
 
 // Utility Functions
 
+function createBlockedMedsMap(disableList: DisableList | undefined) {
+  if (!disableList || disableList.length === 0) {
+    return {} as Record<string, string | undefined>;
+  }
+
+  return disableList.reduce((acc, cur) => {
+    // Only skip if treatmentIds is missing - reason is optional
+    if (!cur.treatmentIds) return acc;
+
+    for (const treatmentId of cur.treatmentIds) {
+      acc[treatmentId] = cur.reason; // reason can be undefined
+    }
+    return acc;
+  }, {} as Record<string, string | undefined>);
+}
+
 function isTreatmentDisabled(
   treatmentId: string | undefined,
-  disableList: DisableList | undefined
+  blockedMedsMap: Record<string, string | undefined>
 ): { disabled?: boolean; disableReason?: string } {
-  if (!treatmentId || !disableList || disableList.length === 0) {
+  if (!treatmentId) {
     return { disabled: false };
   }
 
-  const disableListsByReason = disableList.reduce((acc, cur) => {
-    if (!cur.reason || !cur.treatmentIds) return acc;
-    acc[cur.reason] = new Set(cur.treatmentIds);
-    return acc;
-  }, {} as Record<string, Set<string>>);
-
-  for (const [reason, disabledTreatments] of Object.entries(disableListsByReason)) {
-    if (disabledTreatments.has(treatmentId)) return { disabled: true, disableReason: reason };
+  // Check if treatment ID exists in the map (regardless of reason value)
+  if (treatmentId in blockedMedsMap) {
+    // Treatment is blocked - reason may be undefined (no reason provided)
+    return { disabled: true, disableReason: blockedMedsMap[treatmentId] };
   }
 
   return { disabled: false };
@@ -170,10 +182,10 @@ function displayTreatment(
   t: Treatment | TreatmentOption,
   showFormattedMedicationName: boolean,
   searchText: string,
-  disableList?: DisableList
+  blockedMedsMap: Record<string, string | undefined>
 ) {
   const treatmentId = t.id;
-  const { disabled, disableReason } = isTreatmentDisabled(treatmentId, disableList);
+  const { disabled, disableReason } = isTreatmentDisabled(treatmentId, blockedMedsMap);
 
   if (showFormattedMedicationName) {
     return (
@@ -195,10 +207,10 @@ function displayPrescriptionTemplate(
   t: PrescriptionTemplate,
   showFormattedMedicationName: boolean,
   searchText: string,
-  disableList?: DisableList
+  blockedMedsMap: Record<string, string | undefined>
 ) {
   const treatmentId = t.treatment.id;
-  const { disabled, disableReason } = isTreatmentDisabled(treatmentId, disableList);
+  const { disabled, disableReason } = isTreatmentDisabled(treatmentId, blockedMedsMap);
 
   if (showFormattedMedicationName) {
     const refills = t.fillsAllowed ? t.fillsAllowed - 1 : 0;
@@ -217,7 +229,7 @@ function displayPrescriptionTemplate(
           {refills === 1 ? 'refill' : 'refills'}, {t.instructions}
         </div>
         {disabled && disableReason && (
-          <p class="text-xs text-red-500 mt-1 italic">Disabled: {disableReason}</p>
+          <p class="text-xs text-red-500 mt-1 italic">{disableReason}</p>
         )}
       </div>
     );
@@ -281,6 +293,8 @@ const Component = (props: ComponentProps) => {
   const [loadingTreatmentOptions, setLoadingTreatmentOptions] = createSignal<boolean>(false);
   const [showFullWidthSearch, setShowFullWidthSearch] = createSignal<boolean>(false);
 
+  const blockedMedsMap = createMemo(() => createBlockedMedsMap(props.disableList));
+
   onMount(async () => {
     if (props.catalogId) {
       await actions.getCatalog(client!.getSDK(), props.catalogId);
@@ -322,14 +336,14 @@ const Component = (props: ComponentProps) => {
         t as PrescriptionTemplate,
         showFormattedMedicationName,
         props.searchText,
-        props.disableList
+        blockedMedsMap()
       );
     }
     return displayTreatment(
       t as Treatment | TreatmentOption,
       showFormattedMedicationName,
       props.searchText,
-      props.disableList
+      blockedMedsMap()
     );
   };
 
@@ -353,7 +367,7 @@ const Component = (props: ComponentProps) => {
         }
 
         if (treatmentId) {
-          const { disabled } = isTreatmentDisabled(treatmentId, props.disableList);
+          const { disabled } = isTreatmentDisabled(treatmentId, blockedMedsMap());
           if (disabled) {
             // Don't dispatch selection event for disabled items
             return;

--- a/packages/elements/src/photon-medication-search/photon-medication-search-component.tsx
+++ b/packages/elements/src/photon-medication-search/photon-medication-search-component.tsx
@@ -16,11 +16,37 @@ import {
   TreatmentOption
 } from '@photonhealth/sdk/dist/types';
 import { CatalogStore } from '../stores/catalog';
+import { DisableList } from '../photon-multirx-form/photon-prescribe-workflow';
 
 import { ApolloClient } from '@apollo/client';
 import gql from 'graphql-tag';
 
 // Utility Functions
+
+function isNdcDisabled(
+  ndc: string | undefined,
+  disableList: DisableList | undefined
+): { disabled: boolean; reason?: string } {
+  if (!ndc || !disableList || disableList.length === 0) {
+    return { disabled: false };
+  }
+
+  // Normalize NDC by removing hyphens for comparison
+  const normalizedNdc = ndc.replace(/-/g, '');
+
+  for (const item of disableList) {
+    if (item.ndcs) {
+      for (const disabledNdc of item.ndcs) {
+        const normalizedDisabledNdc = disabledNdc.replace(/-/g, '');
+        if (normalizedNdc === normalizedDisabledNdc) {
+          return { disabled: true, reason: item.reason };
+        }
+      }
+    }
+  }
+
+  return { disabled: false };
+}
 
 function triggerCustomEvent(ref: any, eventName: string, detail?: any) {
   const event = new CustomEvent(eventName, {
@@ -58,6 +84,9 @@ const SearchTreatmentOptionsQuery = gql`
       __typename
       id
       name
+      ... on Medication {
+        ndc
+      }
     }
   }
 `;
@@ -147,13 +176,24 @@ export const boldSubstring = (inputString: string, substring: string) => {
 function displayTreatment(
   t: Treatment | TreatmentOption,
   showFormattedMedicationName: boolean,
-  searchText: string
+  searchText: string,
+  disableList?: DisableList
 ) {
-  return showFormattedMedicationName ? (
-    <p class="text-sm whitespace-normal leading-snug my-1">{boldSubstring(t.name, searchText)}</p>
-  ) : (
-    t.name || ''
-  );
+  const ndc = 'ndc' in t ? t.ndc : undefined;
+  const { disabled, reason } = isNdcDisabled(ndc, disableList);
+
+  if (showFormattedMedicationName) {
+    return (
+      <div class={`my-1 ${disabled ? 'opacity-50 cursor-not-allowed' : ''}`}>
+        <p class={`text-sm whitespace-normal leading-snug ${disabled ? 'text-gray-500' : ''}`}>
+          {boldSubstring(t.name, searchText)}
+        </p>
+        {disabled && reason && <p class="text-xs text-red-500 mt-1 italic">{reason}</p>}
+      </div>
+    );
+  }
+
+  return t.name || '';
 }
 
 function displayPrescriptionTemplate(
@@ -226,6 +266,7 @@ interface ComponentProps {
   selected?: Treatment | PrescriptionTemplate | TreatmentOption;
   offCatalogOption?: Medication;
   searchText: string;
+  disableList?: DisableList;
 }
 
 const Component = (props: ComponentProps) => {
@@ -282,7 +323,8 @@ const Component = (props: ComponentProps) => {
     return displayTreatment(
       t as Treatment | TreatmentOption,
       showFormattedMedicationName,
-      props.searchText
+      props.searchText,
+      props.disableList
     );
   };
 
@@ -292,12 +334,23 @@ const Component = (props: ComponentProps) => {
     <div
       ref={ref}
       on:photon-data-selected={(e: any) => {
-        dispatchTreatmentSelected(ref, e.detail.data, store.catalog.data?.id || '');
+        const selectedItem = e.detail.data;
 
-        if ('treatment' in e.detail.data) {
-          dispatchSearchTextChanged(ref, e.detail.data.treatment.name);
+        // Check if the selected item is disabled
+        if ('ndc' in selectedItem) {
+          const { disabled } = isNdcDisabled(selectedItem.ndc, props.disableList);
+          if (disabled) {
+            // Don't dispatch selection event for disabled items
+            return;
+          }
+        }
+
+        dispatchTreatmentSelected(ref, selectedItem, store.catalog.data?.id || '');
+
+        if ('treatment' in selectedItem) {
+          dispatchSearchTextChanged(ref, selectedItem.treatment.name);
         } else {
-          dispatchSearchTextChanged(ref, e.detail.data.name);
+          dispatchSearchTextChanged(ref, selectedItem.name);
         }
       }}
       on:photon-data-unselected={() => {
@@ -412,7 +465,8 @@ customElement(
     formName: undefined,
     selected: undefined,
     offCatalogOption: undefined,
-    searchText: ''
+    searchText: '',
+    disableList: undefined
   },
   Component
 );

--- a/packages/elements/src/photon-medication-search/photon-medication-search-component.tsx
+++ b/packages/elements/src/photon-medication-search/photon-medication-search-component.tsx
@@ -26,19 +26,19 @@ import gql from 'graphql-tag';
 function isTreatmentDisabled(
   treatmentId: string | undefined,
   disableList: DisableList | undefined
-): { disabled: boolean; reason?: string } {
+): { disabled?: boolean; disableReason?: string } {
   if (!treatmentId || !disableList || disableList.length === 0) {
     return { disabled: false };
   }
 
-  for (const item of disableList) {
-    if (item.treatmentIds) {
-      for (const disabledTreatmentId of item.treatmentIds) {
-        if (treatmentId === disabledTreatmentId) {
-          return { disabled: true, reason: item.reason };
-        }
-      }
-    }
+  const disableListsByReason = disableList.reduce((acc, cur) => {
+    if (!cur.reason || !cur.treatmentIds) return acc;
+    acc[cur.reason] = new Set(cur.treatmentIds);
+    return acc;
+  }, {} as Record<string, Set<string>>);
+
+  for (const [reason, disabledTreatments] of Object.entries(disableListsByReason)) {
+    if (disabledTreatments.has(treatmentId)) return { disabled: true, disableReason: reason };
   }
 
   return { disabled: false };
@@ -173,7 +173,7 @@ function displayTreatment(
   disableList?: DisableList
 ) {
   const treatmentId = t.id;
-  const { disabled, reason } = isTreatmentDisabled(treatmentId, disableList);
+  const { disabled, disableReason } = isTreatmentDisabled(treatmentId, disableList);
 
   if (showFormattedMedicationName) {
     return (
@@ -181,7 +181,9 @@ function displayTreatment(
         <p class={`text-sm whitespace-normal leading-snug ${disabled ? 'text-gray-500' : ''}`}>
           {boldSubstring(t.name, searchText)}
         </p>
-        {disabled && reason && <p class="text-xs text-red-500 mt-1 italic">{reason}</p>}
+        {disabled && disableReason && (
+          <p class="text-xs text-red-500 mt-1 italic">{disableReason}</p>
+        )}
       </div>
     );
   }
@@ -196,7 +198,7 @@ function displayPrescriptionTemplate(
   disableList?: DisableList
 ) {
   const treatmentId = t.treatment.id;
-  const { disabled, reason } = isTreatmentDisabled(treatmentId, disableList);
+  const { disabled, disableReason } = isTreatmentDisabled(treatmentId, disableList);
 
   if (showFormattedMedicationName) {
     const refills = t.fillsAllowed ? t.fillsAllowed - 1 : 0;
@@ -214,7 +216,9 @@ function displayPrescriptionTemplate(
           {t.daysSupply === 1 ? 'day' : 'days'} supply, {refills}{' '}
           {refills === 1 ? 'refill' : 'refills'}, {t.instructions}
         </div>
-        {disabled && reason && <p class="text-xs text-red-500 mt-1 italic">Disabled: {reason}</p>}
+        {disabled && disableReason && (
+          <p class="text-xs text-red-500 mt-1 italic">Disabled: {disableReason}</p>
+        )}
       </div>
     );
   }

--- a/packages/elements/src/photon-medication-search/photon-medication-search-component.tsx
+++ b/packages/elements/src/photon-medication-search/photon-medication-search-component.tsx
@@ -182,11 +182,9 @@ function displayTreatment(
   t: Treatment | TreatmentOption,
   showFormattedMedicationName: boolean,
   searchText: string,
-  blockedMedsMap: Record<string, string | undefined>
+  disabled = false,
+  disableReason?: string
 ) {
-  const treatmentId = t.id;
-  const { disabled, disableReason } = isTreatmentDisabled(treatmentId, blockedMedsMap);
-
   if (showFormattedMedicationName) {
     return (
       <div class={`my-1 ${disabled ? 'opacity-50 cursor-not-allowed' : ''}`}>
@@ -207,11 +205,9 @@ function displayPrescriptionTemplate(
   t: PrescriptionTemplate,
   showFormattedMedicationName: boolean,
   searchText: string,
-  blockedMedsMap: Record<string, string | undefined>
+  disabled = false,
+  disableReason?: string
 ) {
-  const treatmentId = t.treatment.id;
-  const { disabled, disableReason } = isTreatmentDisabled(treatmentId, blockedMedsMap);
-
   if (showFormattedMedicationName) {
     const refills = t.fillsAllowed ? t.fillsAllowed - 1 : 0;
 
@@ -331,19 +327,23 @@ const Component = (props: ComponentProps) => {
     t: Treatment | PrescriptionTemplate | TreatmentOption,
     showFormattedMedicationName: boolean
   ) => {
+    const treatmentId = 'treatment' in t ? t.treatment.id : t.id;
+    const { disabled, disableReason } = isTreatmentDisabled(treatmentId, blockedMedsMap());
     if (t && '__typename' in t && t.__typename == 'PrescriptionTemplate') {
       return displayPrescriptionTemplate(
         t as PrescriptionTemplate,
         showFormattedMedicationName,
         props.searchText,
-        blockedMedsMap()
+        disabled,
+        disableReason
       );
     }
     return displayTreatment(
       t as Treatment | TreatmentOption,
       showFormattedMedicationName,
       props.searchText,
-      blockedMedsMap()
+      disabled,
+      disableReason
     );
   };
 

--- a/packages/elements/src/photon-multirx-form/components/AddPrescriptionCard.tsx
+++ b/packages/elements/src/photon-multirx-form/components/AddPrescriptionCard.tsx
@@ -25,6 +25,7 @@ import { createEffect, createSignal, onMount, Show } from 'solid-js';
 import clearForm from '../util/clearForm';
 import repopulateForm from '../util/repopulateForm';
 import { TryCreatePrescriptionTemplateOptions } from '@photonhealth/components/src/systems/PrescribeProvider';
+import { DisableList } from '../photon-prescribe-workflow';
 
 setBasePath('https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.4.0/dist/');
 
@@ -59,6 +60,7 @@ export const AddPrescriptionCard = (props: {
   catalogId?: string;
   allowOffCatalogSearch?: boolean;
   enableOrder: boolean;
+  disableList?: DisableList;
 }) => {
   const prescribeContext = usePrescribe();
   if (!prescribeContext) {

--- a/packages/elements/src/photon-multirx-form/components/AddPrescriptionCard.tsx
+++ b/packages/elements/src/photon-multirx-form/components/AddPrescriptionCard.tsx
@@ -212,6 +212,7 @@ export const AddPrescriptionCard = (props: {
             help-text={props.store.treatment?.error}
             off-catalog-option={offCatalog()}
             search-text={searchText()}
+            disable-list={props.disableList}
             on:photon-treatment-selected={(e: any) => {
               if (e.detail.data.__typename === 'PrescriptionTemplate') {
                 repopulateForm(props.actions, {

--- a/packages/elements/src/photon-multirx-form/photon-prescribe-workflow-component.tsx
+++ b/packages/elements/src/photon-multirx-form/photon-prescribe-workflow-component.tsx
@@ -67,6 +67,7 @@ const Component = (props: PrescribeProps) => {
             externalOrderId={props.externalOrderId}
             catalogId={props.catalogId}
             allowOffCatalogSearch={props.allowOffCatalogSearch}
+            disableList={props.disableList}
           />
         </PrescribeProvider>
       </RecentOrders>
@@ -104,7 +105,8 @@ customElement(
     externalOrderId: undefined,
     catalogId: undefined,
     allowOffCatalogSearch: true,
-    enableCoverageCheck: false
+    enableCoverageCheck: false,
+    disableList: undefined
   },
   Component
 );

--- a/packages/elements/src/photon-multirx-form/photon-prescribe-workflow.tsx
+++ b/packages/elements/src/photon-multirx-form/photon-prescribe-workflow.tsx
@@ -50,6 +50,13 @@ export type Address = {
   country?: string;
 };
 
+export interface DisabledItem {
+  ndcs?: string[];
+  reason?: string;
+}
+
+export type DisableList = DisabledItem[];
+
 export type PrescribeProps = {
   patientId?: string;
   templateIds?: string;
@@ -82,6 +89,7 @@ export type PrescribeProps = {
   externalOrderId?: string;
   catalogId?: string;
   allowOffCatalogSearch?: boolean;
+  disableList?: DisableList;
 };
 
 export const ScreenDraftedPrescriptionsQuery = gql`
@@ -644,6 +652,7 @@ export function PrescribeWorkflow(props: PrescribeProps) {
                       catalogId={props.catalogId}
                       allowOffCatalogSearch={props.allowOffCatalogSearch}
                       enableOrder={props.enableOrder}
+                      disableList={props.disableList}
                     />
                   </div>
                 </Show>

--- a/packages/elements/src/photon-multirx-form/photon-prescribe-workflow.tsx
+++ b/packages/elements/src/photon-multirx-form/photon-prescribe-workflow.tsx
@@ -51,7 +51,7 @@ export type Address = {
 };
 
 export interface DisabledItem {
-  ndcs?: string[];
+  treatmentIds?: string[];
   reason?: string;
 }
 


### PR DESCRIPTION
I ended up using treatment Ids because we don't get NDC on the lambdas model, but we do in Services. The great thing is we can extend this with `ndcs`, `categories`, `templates`

``` html
<photon-prescribe-workflow
  disable-list='[
    {
      "treatmentIds": ["med_01J6ZE5RSPDRXZRX7SEFHJSMDB"],
      "reason": "Not covered by patient insurance"
    }
  ]'
```

Passing a med id will block out templates, catalogs and meds in the general search that meet this criteria:

<img width="337" height="732" alt="Screenshot 2025-10-15 at 3 36 58 PM" src="https://github.com/user-attachments/assets/c1d52483-b6c1-4285-be1e-fd5a74171f4e" />

