### PR TITLE
Sso login by connection

### DIFF
--- a/apps/app/src/App.tsx
+++ b/apps/app/src/App.tsx
@@ -8,6 +8,7 @@ import { PhotonClient, PhotonProvider } from '@photonhealth/react';
 import { useEffect } from 'react';
 import { auth0Config } from './configs/auth';
 import { Login } from './views/routes/Login';
+import { SSOLogin } from './views/routes/SSOLogin';
 import { Logout } from './views/routes/Logout';
 import { Main } from './views/routes/Main';
 import { NewOrder } from './views/routes/NewOrder';
@@ -82,6 +83,7 @@ export const App = () => {
             </Route>
           </Route>
           <Route path="/login" element={<Login />} />
+          <Route path="/sso" element={<SSOLogin />} />
           <Route path="/logout" element={<Logout />} />
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/apps/app/src/views/routes/SSOLogin.tsx
+++ b/apps/app/src/views/routes/SSOLogin.tsx
@@ -1,4 +1,4 @@
-import { Container, Heading, Stack, useBreakpointValue } from '@chakra-ui/react';
+import { CircularProgress, Container, Heading, Stack, useBreakpointValue } from '@chakra-ui/react';
 import { useSearchParams } from 'react-router-dom';
 
 import { usePhoton } from '@photonhealth/react';
@@ -14,21 +14,18 @@ export const SSOLogin = () => {
   const connection = searchParams.get('connection') ?? undefined;
 
   useEffect(() => {
-    (async () => {
-      await login({
-        organizationId: orgId,
-        connection
-      });
-    })();
+    login({
+      organizationId: orgId,
+      connection
+    });
   });
 
   return (
     <Container maxW="md" py={{ base: '12', md: '24' }}>
-      <Stack spacing="8">
-        <Stack spacing="6" margin="auto">
-          <Logo bgIsWhite margin="auto" />
-          <Heading size={breakpoint}>Signing in...</Heading>
-        </Stack>
+      <Stack spacing="8" textAlign="center">
+        <Logo bgIsWhite margin="auto" />
+        <Heading size={breakpoint}>Signing in...</Heading>
+        <CircularProgress isIndeterminate color="green.300" margin="auto" />
       </Stack>
     </Container>
   );

--- a/apps/app/src/views/routes/SSOLogin.tsx
+++ b/apps/app/src/views/routes/SSOLogin.tsx
@@ -1,0 +1,45 @@
+import { Container, Heading, Stack, useBreakpointValue } from '@chakra-ui/react';
+import { Navigate, useSearchParams } from 'react-router-dom';
+
+import { usePhoton } from '@photonhealth/react';
+import { Logo } from '../components/Logo';
+import { useEffect, useRef } from 'react';
+
+export const SSOLogin = () => {
+  const breakpoint = useBreakpointValue({ base: 'xs', md: 'sm' });
+  const { isAuthenticated, login } = usePhoton();
+
+  const [searchParams] = useSearchParams();
+  const orgId = searchParams.get('orgId') ?? undefined;
+  const connection = searchParams.get('connection');
+  const shouldLogin = useRef(true);
+
+  useEffect(() => {
+    if (connection && shouldLogin.current) {
+      shouldLogin.current = false;
+      (async () => {
+        if (connection) {
+          login({
+            organizationId: orgId,
+            connection
+          });
+        }
+      })();
+    }
+  });
+
+  if (isAuthenticated) {
+    return <Navigate to="/" replace />;
+  }
+
+  return (
+    <Container maxW="md" py={{ base: '12', md: '24' }}>
+      <Stack spacing="8">
+        <Stack spacing="6">
+          <Logo bgIsWhite margin="auto" />
+          <Heading size={breakpoint}>Signing in...</Heading>
+        </Stack>
+      </Stack>
+    </Container>
+  );
+};

--- a/apps/app/src/views/routes/SSOLogin.tsx
+++ b/apps/app/src/views/routes/SSOLogin.tsx
@@ -1,41 +1,31 @@
 import { Container, Heading, Stack, useBreakpointValue } from '@chakra-ui/react';
-import { Navigate, useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router-dom';
 
 import { usePhoton } from '@photonhealth/react';
 import { Logo } from '../components/Logo';
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 
 export const SSOLogin = () => {
   const breakpoint = useBreakpointValue({ base: 'xs', md: 'sm' });
-  const { isAuthenticated, login } = usePhoton();
-
+  const { login } = usePhoton();
   const [searchParams] = useSearchParams();
+
   const orgId = searchParams.get('orgId') ?? undefined;
-  const connection = searchParams.get('connection');
-  const shouldLogin = useRef(true);
+  const connection = searchParams.get('connection') ?? undefined;
 
   useEffect(() => {
-    if (connection && shouldLogin.current) {
-      shouldLogin.current = false;
-      (async () => {
-        if (connection) {
-          login({
-            organizationId: orgId,
-            connection
-          });
-        }
-      })();
-    }
+    (async () => {
+      await login({
+        organizationId: orgId,
+        connection
+      });
+    })();
   });
-
-  if (isAuthenticated) {
-    return <Navigate to="/" replace />;
-  }
 
   return (
     <Container maxW="md" py={{ base: '12', md: '24' }}>
       <Stack spacing="8">
-        <Stack spacing="6">
+        <Stack spacing="6" margin="auto">
           <Logo bgIsWhite margin="auto" />
           <Heading size={breakpoint}>Signing in...</Heading>
         </Stack>

--- a/packages/react/src/provider.tsx
+++ b/packages/react/src/provider.tsx
@@ -740,15 +740,18 @@ export const PhotonProvider = (opts: {
   const login = ({
     organizationId,
     invitation,
+    connection,
     appState
   }: {
     organizationId?: string;
     invitation?: string;
+    connection?: string;
     appState?: object;
   } = {}) => {
     return client.authentication.login({
       organizationId,
       invitation,
+      connection,
       appState
     });
   };

--- a/packages/sdk/src/auth.ts
+++ b/packages/sdk/src/auth.ts
@@ -34,6 +34,7 @@ export interface AuthManagerOptions {
 export interface LoginOptions {
   organizationId?: string;
   invitation?: string;
+  connection?: string;
   appState?: object;
 }
 
@@ -87,11 +88,16 @@ export class AuthManager {
    * @param config - Login configuration
    * @returns
    */
-  public async login({ organizationId, invitation, appState }: LoginOptions): Promise<void> {
+  public async login({
+    organizationId,
+    invitation,
+    connection,
+    appState
+  }: LoginOptions): Promise<void> {
     const opts: RedirectLoginOptions<any> = {
       authorizationParams: {
         ...(this.audience ? { audience: this.audience } : {}),
-        ...(this.connection ? { connection: this.connection } : {}),
+        ...(connection || this.connection ? { connection: connection || this.connection } : {}),
         ...(organizationId || this.organization
           ? { organization: organizationId || this.organization }
           : {}),


### PR DESCRIPTION
This will allow deeplinking into the Photon webapp via SSO URLs such as these:

```
# FakeCustomer Org (boson) w/ OIDC
http://localhost:3000/sso?connection=fakecustomer&orgId=org_m5ravTy58yyDaEAV
https://app.boson.health/sso?connection=fakecustomer&orgId=org_m5ravTy58yyDaEAV

# Photon Test Org (boson) w/ Google OAuth
http://localhost:3000/sso?connection=google-oauth2&orgId=org_KzSVZBQixLRkqj5d
https://app.boson.health/sso?connection=google-oauth2&orgId=org_KzSVZBQixLRkqj5d
```

Using SSO Login to attempt to sign into orgs you're not in fails correctly. Errors will be one of these:
```
Something went wrong
the connection is not enabled

Something went wrong
user google-oauth2|106921013256529022919 is not part of the org_IEUd3sWLUv5xeNCz organization
```

# Demo:

Note: In this demo, the FakeCustomer user is not invited to Photon via our standard invite-to-org flow. They're auto-added to the organization in the URL without permissions. And so, the user does not have permissions set yet (e.g. `read:prescription`). We'll need to set up a way to auto-set these permissions outside the invite flow for specific organization. We also plan to remove the `orgId` from the SSO URL for certain partners so that each user is created into their own organization programmatically.

https://github.com/user-attachments/assets/2e63e437-bdae-4a51-ae02-e5ca8b040d75


