### PR TITLE
Adjust mail order modal formatting

### DIFF
--- a/apps/patient/src/components/mail-order-select/MailOrderSelectCard.tsx
+++ b/apps/patient/src/components/mail-order-select/MailOrderSelectCard.tsx
@@ -34,11 +34,20 @@ export function MailOrderSelectCard({
     >
       <HStack>
         {mailOrderPharmacyOption.logo && (
-          <Box h="8" w="8" borderRadius="full" overflow="clip">
+          <Box minWidth="8" w="8" borderRadius="full" overflow="clip">
             <Image src={mailOrderPharmacyOption.logo} />
           </Box>
         )}
-        <Text fontSize="md" fontWeight="medium">
+        <Text
+          as="span"
+          fontSize="md"
+          fontWeight="medium"
+          whiteSpace="nowrap"
+          overflow="hidden"
+          textOverflow="ellipsis"
+          display="inline-block"
+          title={mailOrderPharmacyOption.name}
+        >
           {mailOrderPharmacyOption.name}
         </Text>
       </HStack>

--- a/apps/patient/src/components/mail-order-select/MailOrderSelectModal.tsx
+++ b/apps/patient/src/components/mail-order-select/MailOrderSelectModal.tsx
@@ -75,11 +75,13 @@ export function MailOrderSelectModal({ onConfirm, ...modalProps }: MailOrderSele
           top="0"
           zIndex="10"
         >
-          Mail Order Pharmacies
+          <Text maxWidth="xl" marginX="auto">
+            Mail Order Pharmacies
+          </Text>
         </ModalHeader>
         <ModalCloseButton marginTop="54px" zIndex="10" position="fixed" />
         <ModalBody padding="3" rowGap="4" backgroundColor="gray.50">
-          <VStack rowGap="4">
+          <VStack rowGap="4" paddingBottom="32" marginX="auto" maxWidth="xl">
             <Text
               paddingX="3"
               paddingY="2"
@@ -113,6 +115,8 @@ export function MailOrderSelectModal({ onConfirm, ...modalProps }: MailOrderSele
             <VStack w="full" rowGap="3">
               <Button
                 w="full"
+                maxWidth="xl"
+                marginX="auto"
                 variant="brand"
                 padding="4"
                 h="auto"


### PR DESCRIPTION
## Adjust padding at the bottom to prevent the fixed footer from hiding any items
### Before

https://github.com/user-attachments/assets/c3bd68e9-56f4-4b89-9a0e-abf234dde6b9

### After (ignore the missing logos, it's local)

https://github.com/user-attachments/assets/fd6a01e0-61f3-4c75-86e1-7e210f6c1b05


## Prevent text wrapping to keep consistent heights, show full name on hover
<img width="269" height="88" alt="Screenshot 2025-10-28 at 10 41 37 AM" src="https://github.com/user-attachments/assets/c105e48e-d66c-4475-b0b4-06bcd4a5c2f6" />

