### PR TITLE
Add fix on the patient side to allow reroutes

### DIFF
--- a/apps/patient/src/components/PharmacyInfo.tsx
+++ b/apps/patient/src/components/PharmacyInfo.tsx
@@ -298,7 +298,7 @@ export const PharmacyInfo = ({
     <VStack data-testid="pharmacy-info" align="start" w="full">
       <HStack w="full" justify="space-between">
         <VStack w="full">
-          <HStack w="full">
+          <HStack w="full" paddingBottom="2">
             {pharmacy?.logo && !whiteLabelDeliveryPharmacy ? (
               <Box boxSize="32px" overflow="hidden">
                 <Image

--- a/apps/patient/src/graphql/queries.ts
+++ b/apps/patient/src/graphql/queries.ts
@@ -85,6 +85,7 @@ export const GET_ORDER = gql`
       pharmacy {
         id
         name
+        logo
         integrated
         address {
           street1

--- a/apps/patient/src/views/Status.tsx
+++ b/apps/patient/src/views/Status.tsx
@@ -12,12 +12,7 @@ import { OrderDetailsModal } from '../components/order-details/OrderDetailsModal
 import { OrderSummary } from '../components/order-summary/OrderSummary';
 import { OrderStatusHeader } from '../components/status/Header';
 import { deriveOrderStatus, getLatestReadyTime } from '../utils/fulfillmentsHelpers';
-import {
-  getFulfillmentType,
-  isDelivery,
-  isRerouteablePharmacy,
-  preparePharmacy
-} from '../utils/general';
+import { getFulfillmentType, isDelivery, preparePharmacy } from '../utils/general';
 import { InsuranceAlert } from '../components/InsuranceAlert';
 import { text as t } from '../utils/text';
 import { useOrderContext } from './Main';
@@ -140,8 +135,6 @@ export const Status = () => {
     : undefined;
 
   const isDeliveryPharmacy = isDelivery({ pharmacy, fulfillmentType });
-
-  const isRerouteable = isRerouteablePharmacy({ pharmacy });
 
   if (!order) {
     console.error('No order found');
@@ -321,11 +314,7 @@ export const Status = () => {
                         !isDeliveryPharmacy &&
                         exception &&
                         callPharmacyButton(true)}
-                      {/* right now mail order (aka delivery pharmacies) are considered to not be re-routable but this will eventually change*/}
-                      {(!isDeliveryPharmacy || isRerouteable) &&
-                        displayPharmacy &&
-                        canOrderReroute &&
-                        rerouteButton}
+                      {displayPharmacy && canOrderReroute && rerouteButton}
                     </VStack>
                   </VStack>
                 </Card>


### PR DESCRIPTION
For mail orders, patients are still reporting not being able to reroute due to our blanketed approach on the fulfillment type

Fixed:
<img width="478" height="765" alt="Screenshot 2025-10-29 at 6 24 03 PM" src="https://github.com/user-attachments/assets/ca5e591f-c553-4f26-b52b-85a764d5be30" />
