### PR TITLE
Hide the mail orer modal link button when there are no options, fetch pharmacy data outside for now until we iron this out

### DIFF
--- a/apps/patient/src/components/mail-order-select/MailOrderSelectModal.tsx
+++ b/apps/patient/src/components/mail-order-select/MailOrderSelectModal.tsx
@@ -13,20 +13,23 @@ import {
   VStack
 } from '@chakra-ui/react';
 import { useEffect, useState } from 'react';
-import { getPharmacies } from '../../api';
 import { PoweredBy } from '../PoweredBy';
 import { MailOrderSelectList } from './MailOrderSelectList';
 import { MailOrderPharmacyOption } from './MailOrderSelectCard';
 import { datadogRum } from '@datadog/browser-rum';
 
 type MailOrderSelectModalProps = Omit<ModalProps, 'children'> & {
+  options?: MailOrderPharmacyOption[];
   onConfirm: (val: MailOrderPharmacyOption) => unknown;
 };
 
-export function MailOrderSelectModal({ onConfirm, ...modalProps }: MailOrderSelectModalProps) {
+export function MailOrderSelectModal({
+  options,
+  onConfirm,
+  ...modalProps
+}: MailOrderSelectModalProps) {
   const [confirming, setConfirming] = useState<boolean>(false);
   const [selectedOption, setSelectedOption] = useState<MailOrderPharmacyOption | undefined>();
-  const [pharmacyOptions, setPharmacyOptions] = useState<MailOrderPharmacyOption[] | undefined>();
 
   const handleOptionSelect = (val: MailOrderPharmacyOption) => {
     const newSelection = val.id !== selectedOption?.id;
@@ -51,21 +54,6 @@ export function MailOrderSelectModal({ onConfirm, ...modalProps }: MailOrderSele
       setConfirming(false);
     }
   };
-
-  useEffect(() => {
-    // load all the pharmacy options on mount
-    async function loadMailOrderPharmacies() {
-      const { pharmacies } = await getPharmacies({
-        limit: 50,
-        offset: 0,
-        fulfillmentType: 'MAIL_ORDER',
-        integrated: false
-      });
-      setPharmacyOptions(pharmacies);
-    }
-
-    loadMailOrderPharmacies();
-  }, []);
 
   useEffect(() => {
     // clear out the selected option when the modal closes
@@ -114,9 +102,9 @@ export function MailOrderSelectModal({ onConfirm, ...modalProps }: MailOrderSele
             >
               If you can't find your pharmacy, please reach out to your provider.
             </Text>
-            {pharmacyOptions && (
+            {options && (
               <MailOrderSelectList
-                options={pharmacyOptions}
+                options={options}
                 selectedId={selectedOption?.id}
                 onSelect={handleOptionSelect}
               />

--- a/apps/patient/src/views/Pharmacy.tsx
+++ b/apps/patient/src/views/Pharmacy.tsx
@@ -29,6 +29,7 @@ import { useOrderContext } from './Main';
 
 import {
   geocode,
+  getPharmacies,
   getPharmaciesByLocation,
   rerouteOrder,
   setOrderPharmacy,
@@ -60,6 +61,7 @@ import { usePageAnalytics } from '../hooks/usePageAnalytics';
 import { patientAnalytics } from '../configs/analytics';
 import { OffersList } from '../components/offers/OffersList';
 import { MailOrderSelectModal } from '../components/mail-order-select/MailOrderSelectModal';
+import { MailOrderPharmacyOption } from '../components/mail-order-select/MailOrderSelectCard';
 
 const GET_PHARMACIES_COUNT = 5; // Number of pharmacies to fetch at a time
 const COSTCO_PHARMACY_RADIUS = 30; // miles
@@ -177,6 +179,11 @@ export const Pharmacy = () => {
     }
     return combined.map((combinedItem) => preparePharmacy(combinedItem));
   }, [isDemo, pharmacyResults, topRankedPharmacies]);
+
+  // Non-integrated patient mail order pharmacies
+  const [patientMailOrderOptions, setPatientMailOrderOptions] = useState<
+    MailOrderPharmacyOption[] | undefined
+  >();
 
   // capsule
   const isCapsuleTerritory =
@@ -542,6 +549,21 @@ export const Pharmacy = () => {
     toast,
     initialLoad
   ]);
+
+  useEffect(() => {
+    // load all the pharmacy options on mount
+    async function loadMailOrderPharmacies() {
+      const { pharmacies } = await getPharmacies({
+        limit: 50,
+        offset: 0,
+        fulfillmentType: 'MAIL_ORDER',
+        integrated: false
+      });
+      setPatientMailOrderOptions(pharmacies);
+    }
+
+    loadMailOrderPharmacies();
+  }, []);
 
   const handleShowMore = async () => {
     setLoadingPharmacies(true);
@@ -1060,6 +1082,7 @@ export const Pharmacy = () => {
         isOpen={mailOrderModalOpen}
         onClose={() => setMailOrderModalOpen(false)}
         onConfirm={handleSubmit}
+        options={patientMailOrderOptions}
       />
 
       <Box bgColor="white">
@@ -1144,18 +1167,20 @@ export const Pharmacy = () => {
                   }
                 />
               )}
-              <HStack
-                w="full"
-                justifyContent="space-between"
-                background="Background"
-                padding="2"
-                borderRadius="md"
-              >
-                <Text fontSize="sm">Don't see your pharmacy?</Text>
-                <Link as="button" onClick={() => setMailOrderModalOpen(true)} fontSize="sm">
-                  See all mail orders
-                </Link>
-              </HStack>
+              {patientMailOrderOptions?.length && (
+                <HStack
+                  w="full"
+                  justifyContent="space-between"
+                  background="Background"
+                  padding="2"
+                  borderRadius="md"
+                >
+                  <Text fontSize="sm">Don't see your pharmacy?</Text>
+                  <Link as="button" onClick={() => setMailOrderModalOpen(true)} fontSize="sm">
+                    See all mail orders
+                  </Link>
+                </HStack>
+              )}
               {pickupPharmacyOptions(patientLocation)}
             </VStack>
           </VStack>


### PR DESCRIPTION
Making this change so that we can temporarily hide the modal while we mark these as pickup again for a short bit, regroup and rethink on the admin/clinical side, then we'll re-release by marking these as mail orders again
