### PR TITLE
SSO redirect query param simplification

### DIFF
--- a/apps/app/src/views/routes/SSOLogin.tsx
+++ b/apps/app/src/views/routes/SSOLogin.tsx
@@ -39,6 +39,7 @@ export const SSOLogin = () => {
 function isCurrentOriginAllowed(): boolean {
   const allowedDomains = [
     'http://localhost:3000',
+    'https://app.boson.health',
     'https://app.neutron.health',
     'https://app.photon.health'
   ];

--- a/apps/app/src/views/routes/SSOLogin.tsx
+++ b/apps/app/src/views/routes/SSOLogin.tsx
@@ -14,8 +14,10 @@ export const SSOLogin = () => {
   const returnTo = searchParams.get('returnTo') ?? undefined;
 
   useEffect(() => {
-    if (isAllowedReturnTo(returnTo)) {
-      localStorage.setItem('authReturnTo', returnTo);
+    if (isCurrentOriginAllowed()) {
+      if (returnTo) {
+        localStorage.setItem('authReturnTo', returnTo);
+      }
     }
 
     login({
@@ -34,18 +36,17 @@ export const SSOLogin = () => {
   );
 };
 
-function isAllowedReturnTo(returnTo: string | undefined): returnTo is string {
-  if (!returnTo) return false;
-
+function isCurrentOriginAllowed(): boolean {
   const allowedDomains = [
     'http://localhost:3000',
-    'https://doximity.dev.doximity.cloud',
-    'https://doximity.partners.doximity-staging.services'
+    'https://app.neutron.health',
+    'https://app.photon.health'
   ];
 
   try {
+    const currentOrigin = window.location.origin;
     return allowedDomains.some((domain) => {
-      return returnTo.startsWith(domain);
+      return currentOrigin === domain;
     });
   } catch {
     return false;


### PR DESCRIPTION
We were expecting the origin in the `returnTo`, this makes that not necessary.

http://localhost:3000/sso?connection=fakecustomer&returnTo=%2Fpatients%2Fnew

Also works in neutron and photon now