### PR TITLE
Logout user before attempting SSO login

### DIFF
--- a/apps/app/src/views/routes/SSOLogin.tsx
+++ b/apps/app/src/views/routes/SSOLogin.tsx
@@ -7,13 +7,19 @@ import { useEffect } from 'react';
 
 export const SSOLogin = () => {
   const breakpoint = useBreakpointValue({ base: 'xs', md: 'sm' });
-  const { login } = usePhoton();
+  const { login, logout, isAuthenticated, isLoading } = usePhoton();
   const [searchParams] = useSearchParams();
 
   const connection = searchParams.get('connection') ?? undefined;
   const returnTo = searchParams.get('returnTo') ?? undefined;
 
   useEffect(() => {
+    if (isLoading) return;
+    if (isAuthenticated) {
+      logout({ federated: false, returnTo: window.location.href });
+      return;
+    }
+
     if (isCurrentOriginAllowed()) {
       if (returnTo) {
         localStorage.setItem('authReturnTo', returnTo);
@@ -23,7 +29,7 @@ export const SSOLogin = () => {
     login({
       connection
     });
-  });
+  }, [isLoading, isAuthenticated, login, logout, connection, returnTo]);
 
   return (
     <Container maxW="md" py={{ base: '12', md: '24' }}>

--- a/apps/app/src/views/routes/SSOLogin.tsx
+++ b/apps/app/src/views/routes/SSOLogin.tsx
@@ -16,6 +16,8 @@ export const SSOLogin = () => {
   useEffect(() => {
     if (isLoading) return;
     if (isAuthenticated) {
+      // logout before attempting a login, in case user has existing session with another org
+      // that doesn't use the SSO connection
       logout({ federated: false, returnTo: window.location.href });
       return;
     }


### PR DESCRIPTION
* Handles issue for SSO users who are logged into another organization seeing the  "connection is not enabled" error when trying to use the SSO connection:
<img width="493" height="335" alt="image" src="https://github.com/user-attachments/assets/bc34a392-74a7-4952-8714-c79bf7d76283" />


[notion ticket](https://www.notion.so/photons/Doximity-Provider-can-signup-if-they-re-already-signed-into-another-Photon-org-account-2a88bfbbf4ec80f09bafe3082b6e635e?source=copy_link)