### PR TITLE
Patient address required in New Patient form

### DIFF
--- a/apps/app/e2e/create_prescription.spec.ts
+++ b/apps/app/e2e/create_prescription.spec.ts
@@ -14,6 +14,11 @@ test('user can login and create patient', async ({ page }) => {
   await page.getByLabel('Mobile Number').fill('8886543210');
   await page.getByLabel('Sex at Birth').click();
   await page.getByRole('menuitem', { name: 'MALE', exact: true }).click();
+  await page.getByLabel('Street 1').fill('1 E2E Test St.');
+  await page.getByLabel('City').fill('e2e-test-city');
+  await page.getByLabel('State').click();
+  await page.getByRole('menuitem', { name: 'AL', exact: true }).click();
+  await page.getByLabel('Zip Code').fill('12345');
 
   await page.getByRole('button', { name: 'Save', exact: true }).click();
 

--- a/apps/app/src/App.tsx
+++ b/apps/app/src/App.tsx
@@ -16,7 +16,7 @@ import { NotFound } from './views/routes/NotFound';
 import { Order } from './views/routes/Order';
 import { Orders } from './views/routes/Orders';
 import { Patient } from './views/routes/PatientDetails';
-import { PatientForm } from './views/routes/PatientForm';
+import { PatientForm } from './views/routes/NewPatient/PatientForm';
 import { Patients } from './views/routes/Patients';
 import { Playground } from './views/routes/Playground';
 import { Prescription } from './views/routes/Prescription';

--- a/apps/app/src/views/routes/NewPatient/PatientForm.tsx
+++ b/apps/app/src/views/routes/NewPatient/PatientForm.tsx
@@ -1,4 +1,4 @@
-import { useRef, MutableRefObject, useEffect } from 'react';
+import { MutableRefObject, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 declare global {

--- a/package-lock.json
+++ b/package-lock.json
@@ -46730,7 +46730,7 @@
     },
     "packages/elements": {
       "name": "@photonhealth/elements",
-      "version": "0.16.15",
+      "version": "0.17.1",
       "license": "ISC",
       "dependencies": {
         "@photonhealth/components": "*",

--- a/packages/elements/src/photon-patient-dialog/photon-patient-dialog-component.tsx
+++ b/packages/elements/src/photon-patient-dialog/photon-patient-dialog-component.tsx
@@ -1,9 +1,7 @@
 import { customElement } from 'solid-element';
 import { createSignal, Show } from 'solid-js';
-import { size, string } from 'superstruct';
 import { Button, usePhoton } from '@photonhealth/components';
 import { PhotonFormWrapper } from '../photon-form-wrapper';
-import { message } from '../validators';
 import photonStyles from '@photonhealth/components/dist/style.css?inline';
 
 type PatientDialogProps = {
@@ -59,33 +57,18 @@ const Component = (props: PatientDialogProps) => {
     setGlobalError(undefined);
     setIsCreatePrescription(createPrescription);
     setLoading(true);
-    let keys: string[] = ['firstName', 'lastName', 'dateOfBirth', 'phone', 'sex', 'email'];
-
-    if (
-      store['address_street1']?.value !== undefined ||
-      store['address_city']?.value !== undefined ||
-      store['address_state']?.value !== undefined ||
-      store['address_zip']?.value !== undefined
-    ) {
-      actions.registerValidator({
-        key: 'address_street1',
-        validator: message(size(string(), 1, Infinity), 'Please enter a valid Street 1..')
-      });
-      actions.registerValidator({
-        key: 'address_city',
-        validator: message(size(string(), 1, Infinity), 'Please enter a valid City..')
-      });
-      actions.registerValidator({
-        key: 'address_state',
-        validator: message(size(string(), 2, 2), 'Please enter a valid State..')
-      });
-      keys = [...keys, 'address_zip', 'address_street1', 'address_city', 'address_state'];
-    } else {
-      const keysToRemove = ['address_street1', 'address_city', 'address_state'];
-      for (const key of keysToRemove) {
-        actions.unRegisterValidator(key);
-      }
-    }
+    const keys = [
+      'firstName',
+      'lastName',
+      'dateOfBirth',
+      'phone',
+      'sex',
+      'email',
+      'address_street1',
+      'address_city',
+      'address_state',
+      'address_zip'
+    ];
 
     actions.validate(keys);
     if (actions.hasErrors(keys)) {

--- a/packages/elements/src/photon-patient-dialog/photon-patient-dialog-component.tsx
+++ b/packages/elements/src/photon-patient-dialog/photon-patient-dialog-component.tsx
@@ -1,8 +1,7 @@
 import { customElement } from 'solid-element';
 import { createSignal, Show } from 'solid-js';
 import { size, string } from 'superstruct';
-import { Button } from '@photonhealth/components';
-import { usePhoton } from '@photonhealth/components';
+import { Button, usePhoton } from '@photonhealth/components';
 import { PhotonFormWrapper } from '../photon-form-wrapper';
 import { message } from '../validators';
 import photonStyles from '@photonhealth/components/dist/style.css?inline';

--- a/packages/elements/src/photon-patient-dialog/photon-patient-dialog-component.tsx
+++ b/packages/elements/src/photon-patient-dialog/photon-patient-dialog-component.tsx
@@ -105,7 +105,7 @@ const Component = (props: PatientDialogProps) => {
         last: store['lastName']!.value
       },
       gender: store['gender']!.value,
-      email: store['email']!.value,
+      email: store['email']!.value ? store['email']!.value : undefined,
       phone: store['phone']!.value,
       dateOfBirth: store['dateOfBirth']!.value,
       sex: store['sex']!.value,

--- a/packages/elements/src/photon-patient-form/photon-patient-form-component.tsx
+++ b/packages/elements/src/photon-patient-form/photon-patient-form-component.tsx
@@ -1,26 +1,24 @@
 import { customElement } from 'solid-element';
 import { createEffect, createMemo, onCleanup, onMount, Show } from 'solid-js';
 import { enums, size, string, union } from 'superstruct';
-import { Spinner, PharmacySearch, Card } from '@photonhealth/components';
-import { usePhoton } from '@photonhealth/components';
+import { Card, PharmacySearch, Spinner, usePhoton } from '@photonhealth/components';
 import { createFormStore } from '../stores/form';
 import { PatientStore } from '../stores/patient';
 import tailwind from '../tailwind.css?inline';
 import photonStyles from '@photonhealth/components/dist/style.css?inline';
-import { email, empty, message, zipString, notFutureDate } from '../validators';
+import { email, empty, message, notFutureDate, zipString } from '../validators';
 
 //Shoelace
 import '@shoelace-style/shoelace/dist/components/spinner/spinner';
 import { setBasePath } from '@shoelace-style/shoelace/dist/utilities/base-path.js';
-
-setBasePath('https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.4.0/dist/');
-
 import shoelaceLightStyles from '@shoelace-style/shoelace/dist/themes/light.css?inline';
 import shoelaceDarkStyles from '@shoelace-style/shoelace/dist/themes/dark.css?inline';
 import { isZip } from '../utils';
-import { sexes } from '../photon-sex-input/photon-sex-input-component';
+import { sexes } from '../photon-sex-input';
 import { PhotonAuthorized } from '../photon-authorized';
 import { PharmacyOption } from '@photonhealth/components/dist/packages/components/src/systems/PharmacySearch/PharmacySearch';
+
+setBasePath('https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.4.0/dist/');
 
 const getPatientAddress = (pStore: any, store: any) => {
   const patientAddress = pStore.selectedPatient.data?.address;

--- a/packages/elements/src/photon-patient-form/photon-patient-form-component.tsx
+++ b/packages/elements/src/photon-patient-form/photon-patient-form-component.tsx
@@ -80,9 +80,22 @@ const PatientForm = (props: { patientId: string }) => {
     key: 'email',
     validator: message(union([email(), empty()]), 'Please enter a valid email.')
   });
+
+  actions.registerValidator({
+    key: 'address_street1',
+    validator: message(size(string(), 1, Infinity), 'Please enter a valid Street 1.')
+  });
+  actions.registerValidator({
+    key: 'address_city',
+    validator: message(size(string(), 1, Infinity), 'Please enter a valid City.')
+  });
+  actions.registerValidator({
+    key: 'address_state',
+    validator: message(size(string(), 2, 2), 'Please enter a valid State.')
+  });
   actions.registerValidator({
     key: 'address_zip',
-    validator: message(union([zipString(), empty()]), 'Please enter a valid zip code...')
+    validator: message(zipString(), 'Please enter a valid zip code.')
   });
 
   onMount(() => {
@@ -343,6 +356,7 @@ const PatientForm = (props: { patientId: string }) => {
                   invalid={store['address_street1']?.error}
                   help-text={store['address_street1']?.error}
                   label="Street 1"
+                  required="true"
                   on:photon-input-changed={async (e: any) => {
                     actions.updateFormValue({
                       key: 'address_street1',
@@ -374,6 +388,7 @@ const PatientForm = (props: { patientId: string }) => {
                   invalid={store['address_city']?.error}
                   help-text={store['address_city']?.error}
                   label="City"
+                  required="true"
                   on:photon-input-changed={async (e: any) => {
                     actions.updateFormValue({
                       key: 'address_city',
@@ -386,7 +401,7 @@ const PatientForm = (props: { patientId: string }) => {
                   <photon-state-input
                     class="flex-grow min-w-[40%]"
                     label="State"
-                    required="false"
+                    required="true"
                     help-text={store['address_state']?.error}
                     invalid={store['address_state']?.error !== undefined}
                     on:photon-state-selected={(e: any) => {
@@ -403,6 +418,7 @@ const PatientForm = (props: { patientId: string }) => {
                     invalid={store['address_zip']?.error}
                     help-text={store['address_zip']?.error}
                     label="Zip Code"
+                    required="true"
                     on:photon-input-changed={async (e: any) => {
                       actions.updateFormValue({
                         key: 'address_zip',


### PR DESCRIPTION
* Always require address for Add/Update patient (not just update)
* Fix adding and clearing email field not allowing save (was triggered backend validation error)

[notion ticket](https://www.notion.so/photons/As-a-provider-in-Clinical-App-I-am-forced-to-fill-in-the-Address-fields-on-patient-creation-2a78bfbbf4ec80e9a8e2c0b109520c25?source=copy_link)