### PR TITLE
update copy for self signup

### DIFF
--- a/apps/app/src/views/routes/SelfSignup/views/SelfSignupPage.tsx
+++ b/apps/app/src/views/routes/SelfSignup/views/SelfSignupPage.tsx
@@ -124,7 +124,7 @@ export const SelfSignupPage = () => {
                     </FormControl>
                     <Text fontSize="sm" color="gray">
                       Photon will use this email to contact you if issues arise with your
-                      prescriptions
+                      prescriptions.
                     </Text>
 
                     <FormControl isRequired isInvalid={!!errors.npi && touched.npi}>

--- a/apps/app/src/views/routes/SelfSignup/views/SelfSignupPage.tsx
+++ b/apps/app/src/views/routes/SelfSignup/views/SelfSignupPage.tsx
@@ -90,10 +90,19 @@ export const SelfSignupPage = () => {
 
                   <Heading size={useBreakpointValue({ base: 'xs' })}>
                     Create Your Prescriber Account
-                    <Text fontSize="md" color="gray">
-                      Please confirm your details:
-                    </Text>
                   </Heading>
+                  <Alert status="info">
+                    <AlertIcon />
+                    <VStack alignItems="start">
+                      <Text fontSize="sm">
+                        Please note that your NPI, Phone, and Address will be required. Pharmacies
+                        use this information to ensure safe and compliant prescription fulfillment.
+                      </Text>
+                    </VStack>
+                  </Alert>
+                  <Text fontSize="md" color="gray">
+                    Please confirm your details:
+                  </Text>
 
                   <Stack>
                     <FormControl isRequired isInvalid={!!errors.firstName && touched.firstName}>
@@ -113,6 +122,10 @@ export const SelfSignupPage = () => {
                       <Field as={Input} id="email" name="email" type="email" autoComplete="email" />
                       <ErrorMessage name="email" component={FormErrorMessage} />
                     </FormControl>
+                    <Text fontSize="sm" color="gray">
+                      Photon will use this email to contact you if issues arise with your
+                      prescriptions
+                    </Text>
 
                     <FormControl isRequired isInvalid={!!errors.npi && touched.npi}>
                       <FormLabel htmlFor="npi">NPI</FormLabel>
@@ -149,6 +162,10 @@ export const SelfSignupPage = () => {
                       />
                       <ErrorMessage name="fax" component={FormErrorMessage} />
                     </FormControl>
+                    <Text fontSize="sm" color="gray">
+                      Pharmacies may use this fax number to reach you if there are questions or
+                      issues with your prescriptions.
+                    </Text>
                   </Stack>
                 </Stack>
                 <Stack spacing="4">

--- a/apps/app/src/views/routes/SelfSignup/views/SelfSignupPage.tsx
+++ b/apps/app/src/views/routes/SelfSignup/views/SelfSignupPage.tsx
@@ -92,7 +92,7 @@ export const SelfSignupPage = () => {
                   <Alert status="warning">
                     <AlertIcon />
                     <VStack alignItems="start">
-                      <Text fontWeight="bold" color="yellow.600">
+                      <Text fontWeight="medium" color="yellow.600">
                         Required before writing prescriptions
                       </Text>
                     </VStack>

--- a/apps/app/src/views/routes/SelfSignup/views/SelfSignupPage.tsx
+++ b/apps/app/src/views/routes/SelfSignup/views/SelfSignupPage.tsx
@@ -9,8 +9,15 @@ import {
   FormErrorMessage,
   FormLabel,
   Heading,
+  HStack,
+  IconButton,
   Input,
   Link,
+  Popover,
+  PopoverBody,
+  PopoverContent,
+  PopoverTrigger,
+  Portal,
   Stack,
   Text,
   useBreakpointValue,
@@ -22,6 +29,7 @@ import { auth0Config } from '../../../../configs/auth';
 import { Logo } from '../../../components/Logo';
 import { FormikStateSelect } from '../../Settings/components/utils/States';
 import { SignupFormData, signupFormSchema } from './form';
+import { FaInfoCircle } from 'react-icons/fa';
 
 export const SelfSignupPage = () => {
   const [searchParams] = useSearchParams();
@@ -84,25 +92,24 @@ export const SelfSignupPage = () => {
                   <Alert status="warning">
                     <AlertIcon />
                     <VStack alignItems="start">
-                      <Text fontWeight="bold">Required before writing prescriptions</Text>
-                    </VStack>
-                  </Alert>
-
-                  <Heading size={useBreakpointValue({ base: 'xs' })}>
-                    Create Your Prescriber Account
-                  </Heading>
-                  <Alert status="info">
-                    <AlertIcon />
-                    <VStack alignItems="start">
-                      <Text fontSize="sm">
-                        Please note that your NPI, Phone, and Address will be required. Pharmacies
-                        use this information to ensure safe and compliant prescription fulfillment.
+                      <Text fontWeight="bold" color="yellow.600">
+                        Required before writing prescriptions
                       </Text>
                     </VStack>
                   </Alert>
-                  <Text fontSize="md" color="gray">
-                    Please confirm your details:
-                  </Text>
+
+                  <VStack alignItems="start">
+                    <Heading size={useBreakpointValue({ base: 'xs' })}>
+                      Create Your Prescriber Account
+                    </Heading>
+                    <Text fontSize="md" color="gray">
+                      Please note that your NPI, Phone, and Address will be required. Pharmacies use
+                      this information to ensure safe and compliant prescription fulfillment.
+                    </Text>
+                    <Text fontSize="md" color="gray">
+                      Please confirm your details:
+                    </Text>
+                  </VStack>
 
                   <Stack>
                     <FormControl isRequired isInvalid={!!errors.firstName && touched.firstName}>
@@ -118,14 +125,34 @@ export const SelfSignupPage = () => {
                     </FormControl>
 
                     <FormControl isRequired isInvalid={!!errors.email && touched.email}>
-                      <FormLabel htmlFor="email">Email</FormLabel>
+                      <HStack spacing="0" alignItems="center">
+                        <FormLabel htmlFor="email" marginRight="0" marginBottom="0">
+                          Email
+                        </FormLabel>
+                        <Popover placement={'top-start'}>
+                          <PopoverTrigger>
+                            <IconButton
+                              variant="ghost"
+                              color="gray"
+                              size="xs"
+                              aria-label="Why is email required?"
+                              icon={<FaInfoCircle />}
+                            />
+                          </PopoverTrigger>
+                          <Portal>
+                            <PopoverContent>
+                              <PopoverBody>
+                                Photon will use this email to contact you if issues arise with your
+                                prescriptions.
+                              </PopoverBody>
+                            </PopoverContent>
+                          </Portal>
+                        </Popover>
+                      </HStack>
+
                       <Field as={Input} id="email" name="email" type="email" autoComplete="email" />
                       <ErrorMessage name="email" component={FormErrorMessage} />
                     </FormControl>
-                    <Text fontSize="sm" color="gray">
-                      Photon will use this email to contact you if issues arise with your
-                      prescriptions.
-                    </Text>
 
                     <FormControl isRequired isInvalid={!!errors.npi && touched.npi}>
                       <FormLabel htmlFor="npi">NPI</FormLabel>
@@ -152,7 +179,30 @@ export const SelfSignupPage = () => {
                     </FormControl>
 
                     <FormControl isInvalid={!!errors.fax && touched.fax}>
-                      <FormLabel htmlFor="fax">Fax</FormLabel>
+                      <HStack spacing="0" alignItems="center">
+                        <FormLabel htmlFor="fax" marginRight="0" marginBottom="0">
+                          Fax
+                        </FormLabel>
+                        <Popover placement={'top-start'}>
+                          <PopoverTrigger>
+                            <IconButton
+                              variant="ghost"
+                              color="gray"
+                              size="xs"
+                              aria-label="Why provide my fax?"
+                              icon={<FaInfoCircle />}
+                            />
+                          </PopoverTrigger>
+                          <Portal>
+                            <PopoverContent>
+                              <PopoverBody>
+                                Pharmacies may use this fax number to reach you if there are
+                                questions or issues with your prescriptions.
+                              </PopoverBody>
+                            </PopoverContent>
+                          </Portal>
+                        </Popover>
+                      </HStack>
                       <Field
                         as={Input}
                         id="fax"
@@ -162,10 +212,6 @@ export const SelfSignupPage = () => {
                       />
                       <ErrorMessage name="fax" component={FormErrorMessage} />
                     </FormControl>
-                    <Text fontSize="sm" color="gray">
-                      Pharmacies may use this fax number to reach you if there are questions or
-                      issues with your prescriptions.
-                    </Text>
                   </Stack>
                 </Stack>
                 <Stack spacing="4">


### PR DESCRIPTION

* Add helpful text below page title
* Fix yellow banner styling
* Add popover tips for Email and Fax inputs

[Thread in slack](https://photonhealth.slack.com/archives/C0302SQME1K/p1764020910822509) on design.

[notion ticket](https://www.notion.so/photons/Account-creation-page-copy-updates-2b28bfbbf4ec806aadd8ef034e875ceb?source=copy_link)


https://github.com/user-attachments/assets/c8fce158-4ac3-4e2b-8487-b19d41b5bb96

