### PR TITLE
Patient and Prescription form improvements

### DIFF
--- a/apps/app/e2e/create_prescription.spec.ts
+++ b/apps/app/e2e/create_prescription.spec.ts
@@ -4,7 +4,7 @@ test('user can login and create patient', async ({ page }) => {
   await page.goto('/');
 
   await page.getByRole('link', { name: /Patients/ }).click();
-  await page.getByRole('link', { name: /New Patient/ }).click();
+  await page.getByRole('link', { name: /New patient/ }).click();
 
   const patientNumber = getRandomInt(0, 100_000_000);
 

--- a/apps/app/e2e/create_prescription.spec.ts
+++ b/apps/app/e2e/create_prescription.spec.ts
@@ -20,7 +20,7 @@ test('user can login and create patient', async ({ page }) => {
   await page.getByRole('menuitem', { name: 'AL', exact: true }).click();
   await page.getByLabel('Zip Code').fill('12345');
 
-  await page.getByRole('button', { name: 'Save', exact: true }).click();
+  await page.getByRole('button', { name: 'Create patient', exact: true }).click();
 
   await expect(page.getByRole('heading', { name: 'Patients' })).toBeVisible();
 });

--- a/apps/app/src/views/routes/NewOrder/components/OrderForm.tsx
+++ b/apps/app/src/views/routes/NewOrder/components/OrderForm.tsx
@@ -235,13 +235,13 @@ export const OrderForm = ({
         validateForm(values);
 
         if (
-          await confirmWrapper('Send Order?', {
+          await confirmWrapper('Send order?', {
             // determine if order is "Send to Patient" by checking if pharmacyId is set
             description: values.pharmacyId
               ? 'This order will be sent immediately to the pharmacy of choice.'
               : 'This order will be sent when the patient chooses a pharmacy.',
-            cancelText: 'Keep Editing',
-            confirmText: 'Yes, Send Order',
+            cancelText: 'Keep editing',
+            confirmText: 'Yes, send order',
             darkMode: colorMode !== 'light'
           })
         ) {

--- a/apps/app/src/views/routes/NewOrder/index.tsx
+++ b/apps/app/src/views/routes/NewOrder/index.tsx
@@ -185,7 +185,7 @@ export const NewOrder = () => {
                 loadingText="Sending"
                 isDisabled={!enablePrescriberOrdering}
               >
-                Send Order
+                Send order
               </Button>
             </Box>
           </Flex>

--- a/apps/app/src/views/routes/Patients.tsx
+++ b/apps/app/src/views/routes/Patients.tsx
@@ -60,7 +60,7 @@ const EditView = (props: EditViewProps) => {
         />
         <MenuList>
           <MenuItem icon={<FiEye fontSize="1.2em" />} as={RouterLink} to={`/patients/${id}`}>
-            View Patient
+            View patient
           </MenuItem>
           <MenuItem
             icon={<FiEdit fontSize="1.2em" />}
@@ -70,21 +70,21 @@ const EditView = (props: EditViewProps) => {
               setDisableScroll(true);
             }}
           >
-            Edit Patient
+            Edit patient
           </MenuItem>
           <MenuItem
             icon={<TbPrescription fontSize="1.2em" />}
             as={RouterLink}
             to={`/prescriptions/new?patientId=${id}`}
           >
-            New Prescription
+            New prescription
           </MenuItem>
           <MenuItem
             icon={<FiShoppingCart fontSize="1.2em" />}
             as={RouterLink}
             to={`/orders/new?patientId=${id}`}
           >
-            New Order
+            New order
           </MenuItem>
         </MenuList>
       </Menu>
@@ -193,7 +193,7 @@ export const Patients = () => {
         columns={columns}
         loading={loading}
         error={error}
-        ctaText="New Patient"
+        ctaText="New patient"
         ctaColor="blue"
         ctaRoute="/patients/new"
         filterText={filterText}

--- a/apps/app/src/views/routes/Prescriptions.tsx
+++ b/apps/app/src/views/routes/Prescriptions.tsx
@@ -1,9 +1,10 @@
-import { Link as RouterLink, useLocation, useSearchParams, useNavigate } from 'react-router-dom';
+import { Link as RouterLink, useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 
 import {
-  Select,
   HStack,
   IconButton,
+  Link,
+  Select,
   Skeleton,
   SkeletonCircle,
   SkeletonText,
@@ -11,8 +12,7 @@ import {
   Tag,
   Text,
   Tooltip,
-  useToast,
-  Link
+  useToast
 } from '@chakra-ui/react';
 import { FiInfo, FiShoppingCart } from 'react-icons/fi';
 import { useEffect, useRef, useState } from 'react';
@@ -422,7 +422,7 @@ export const Prescriptions = () => {
         columns={columns}
         loading={loading}
         error={error}
-        ctaText="New Prescription"
+        ctaText="New prescription"
         ctaColor="blue"
         ctaRoute="/prescriptions/new"
         filterText={filterText}

--- a/apps/app/src/views/routes/SelfSignup/views/SelfSignupPage.tsx
+++ b/apps/app/src/views/routes/SelfSignup/views/SelfSignupPage.tsx
@@ -106,7 +106,7 @@ export const SelfSignupPage = () => {
                       Please note that your NPI, Phone, and Address will be required. Pharmacies use
                       this information to ensure safe and compliant prescription fulfillment.
                     </Text>
-                    <Text fontSize="md" color="gray">
+                    <Text fontSize="md" marginTop="4">
                       Please confirm your details:
                     </Text>
                   </VStack>
@@ -289,7 +289,7 @@ export const SelfSignupPage = () => {
                   </FormControl>
 
                   <Button type="submit" isLoading={isSubmitting}>
-                    Create Account
+                    Submit
                   </Button>
                 </Stack>
               </Stack>

--- a/apps/app/src/views/routes/Settings/components/templates/TemplateForm/components/CtaButtons.tsx
+++ b/apps/app/src/views/routes/Settings/components/templates/TemplateForm/components/CtaButtons.tsx
@@ -28,7 +28,7 @@ export const CtaButtons = ({
       isLoading={loading || isSubmitting}
       loadingText="Saving template"
     >
-      {edit ? 'Save Changes' : 'Create Template'}
+      {edit ? 'Save changes' : 'Create template'}
     </Button>
   </HStack>
 );

--- a/packages/components/src/particles/Button/index.tsx
+++ b/packages/components/src/particles/Button/index.tsx
@@ -1,12 +1,14 @@
 import { clsx } from 'clsx';
-import { JSX, Show, mergeProps, splitProps, createMemo } from 'solid-js';
+import { createMemo, JSX, mergeProps, Show, splitProps } from 'solid-js';
 import Spinner from '../Spinner';
 
 export type ButtonVariant = 'primary' | 'secondary' | 'danger' | 'tertiary' | 'naked';
 export type ButtonSize = 'xl' | 'lg' | 'md' | 'sm' | 'xs';
+export type ButtonColor = 'blue' | 'gray' | 'red';
 
 export interface ButtonProps extends JSX.ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: ButtonVariant;
+  color?: ButtonColor;
   size?: ButtonSize;
   iconLeft?: JSX.Element;
   loading?: boolean;
@@ -17,13 +19,20 @@ export default function Button(props: ButtonProps) {
   const [otherProps, buttonProps] = splitProps(merged, [
     'variant',
     'size',
+    'color',
     'children',
     'iconLeft',
     'loading'
   ]);
 
-  const buttonClasses = createMemo(() =>
-    clsx(
+  const buttonClasses = createMemo(() => {
+    const color = otherProps.color || 'gray';
+    const secondaryClasses =
+      otherProps.variant === 'secondary' && otherProps.color
+        ? `rounded bg-white text-${color}-600 shadow-sm ring-1 ring-inset ring-${color}-500 hover:bg-${color}-50`
+        : '';
+
+    return clsx(
       'font-semibold flex justify-center inline-flex items-center gap-x-1',
       {
         'shadow-sm': otherProps.variant !== 'naked',
@@ -39,7 +48,7 @@ export default function Button(props: ButtonProps) {
         'text-white bg-blue-500 hover:bg-blue-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2':
           otherProps.variant === 'primary',
         'rounded bg-white text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50':
-          otherProps.variant === 'secondary',
+          otherProps.variant === 'secondary' && !otherProps.color,
         'text-white bg-red-500 hover:bg-red-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2':
           otherProps.variant === 'danger',
         'bg-blue-50 text-blue-600 hover:bg-blue-100': otherProps.variant === 'tertiary',
@@ -47,9 +56,10 @@ export default function Button(props: ButtonProps) {
           otherProps.variant === 'naked',
         'opacity-50 cursor-not-allowed': buttonProps.disabled || otherProps.loading
       },
+      secondaryClasses,
       props?.class
-    )
-  );
+    );
+  });
 
   return (
     <button

--- a/packages/components/src/systems/AddressForm/index.tsx
+++ b/packages/components/src/systems/AddressForm/index.tsx
@@ -87,7 +87,7 @@ export default function AddressForm(props: AddressFormProps) {
       <div class="flex items-center justify-between">
         <Text color="gray">Patient Address</Text>
         <Button type="submit" form="patient-address" disabled={submitting()} loading={submitting()}>
-          Save Address
+          Save address
         </Button>
       </div>
       <div>

--- a/packages/components/src/systems/ScreeningAlerts/ScreeningAlertAcknowledgement.tsx
+++ b/packages/components/src/systems/ScreeningAlerts/ScreeningAlertAcknowledgement.tsx
@@ -95,7 +95,7 @@ export function ScreeningAlertAcknowledgementDialog(
               ignoreWarningAndCreateAnyway();
             }}
           >
-            Send Order
+            Send order
           </Button>
           <Button
             variant="secondary"

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@photonhealth/elements",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "description": "",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/elements/src/photon-form-wrapper/photon-form-wrapper.tsx
+++ b/packages/elements/src/photon-form-wrapper/photon-form-wrapper.tsx
@@ -82,7 +82,7 @@ export const PhotonFormWrapper = (p: PhotonFormWrapperProps) => {
       </div>
       <Show when={props.footer}>
         <footer class="z-40 fixed bottom-0 w-full bg-white shadow-card px-4 py-4 md:px-8">
-          <div class="flex flex-col md:flex-row-reverse md:justify-start gap-2 items-center w-full sm:w-[600px] xs:mx-auto sm:px-4">
+          <div class="flex flex-col xs:flex-row-reverse xs:justify-start gap-2 items-center w-full sm:w-[600px] xs:mx-auto sm:px-4">
             {props.footer}
           </div>
         </footer>

--- a/packages/elements/src/photon-form-wrapper/photon-form-wrapper.tsx
+++ b/packages/elements/src/photon-form-wrapper/photon-form-wrapper.tsx
@@ -5,7 +5,7 @@ import tailwind from '../tailwind.css?inline';
 export type PhotonFormWrapperProps = {
   closeTitle?: string;
   closeBody?: string;
-  headerRight?: JSX.Element;
+  footer?: JSX.Element;
   title: string;
   titleIconName?: string;
   form?: JSX.Element;
@@ -49,8 +49,8 @@ export const PhotonFormWrapper = (p: PhotonFormWrapperProps) => {
       </photon-dialog>
 
       {/* Wrapper */}
-      <header class="z-40 flex flex-col md:flex-row items-center px-4 py-2 md:px-8 md:py-3 bg-white fixed w-full shadow-card">
-        <div class="flex justify-start md:flex-1 absolute md:static left-4">
+      <header class="z-40 flex items-center px-4 py-2 md:px-8 md:py-3 bg-white fixed w-full shadow-card">
+        <div class="flex justify-start">
           <Button
             variant="naked"
             size="sm"
@@ -67,23 +67,23 @@ export const PhotonFormWrapper = (p: PhotonFormWrapperProps) => {
             </div>
           </Button>
         </div>
-        <div class="mb-2 md:mb-0 flex flex-0 md:flex-1 justify-center md:justify-center items-center">
+        <div class="absolute left-1/2 transform -translate-x-1/2 flex justify-center items-center">
           <Show when={props.titleIconName}>
             <sl-icon name={props.titleIconName} />
           </Show>
-          <p class="ml-1 font-sans text-sm md:text-xl font-medium">{props.title}</p>
-        </div>
-        <div class="flex flex-col md:flex-row flex-1">
-          <Show when={props.headerRight}>
-            <div class="flex-1 flex justify-end">{props.headerRight}</div>
-          </Show>
+          <p class="ml-1 font-sans text-lg md:text-xl font-medium">{props.title}</p>
         </div>
       </header>
-      <div class="z-30 w-full min-h-screen bg-[#F9FAFB] pt-28 xs:pt-28 lg:pt-20">
+      <div class="z-30 w-full min-h-screen bg-[#F9FAFB] pt-14">
         <div class="px-4 pb-40 md:pt-4 md:pb-52 md:px-4 w-full h-full sm:w-[600px] xs:mx-auto">
           {props.form}
         </div>
       </div>
+      <Show when={props.footer}>
+        <footer class="z-40 fixed bottom-0 w-full bg-white shadow-card px-4 py-4 md:px-8">
+          {props.footer}
+        </footer>
+      </Show>
     </div>
   );
 };

--- a/packages/elements/src/photon-form-wrapper/photon-form-wrapper.tsx
+++ b/packages/elements/src/photon-form-wrapper/photon-form-wrapper.tsx
@@ -49,28 +49,31 @@ export const PhotonFormWrapper = (p: PhotonFormWrapperProps) => {
       </photon-dialog>
 
       {/* Wrapper */}
-      <header class="z-40 flex items-center gap-2 px-4 py-2 md:px-8 md:py-3 bg-white fixed w-full shadow-card">
-        <Button
-          variant="naked"
-          size="sm"
-          onClick={() => {
-            if (props.checkShouldWarn()) {
-              onCloseDialogOpen(true);
-            } else {
-              props.onClosed();
-            }
-          }}
-        >
-          <div class="text-black text-xl md:text-3xl">
-            <Icon name="xMark" />
-          </div>
-        </Button>
-        <div class="flex-1 flex justify-center items-center min-w-0">
+      <header class="z-40 flex items-center px-4 py-2 md:px-8 md:py-3 bg-white fixed w-full shadow-card">
+        <div class="flex items-center">
+          <Button
+            variant="naked"
+            size="sm"
+            onClick={() => {
+              if (props.checkShouldWarn()) {
+                onCloseDialogOpen(true);
+              } else {
+                props.onClosed();
+              }
+            }}
+          >
+            <div class="text-black text-xl md:text-3xl">
+              <Icon name="xMark" />
+            </div>
+          </Button>
+        </div>
+        <div class="flex-1 flex justify-center items-center min-w-0 px-2">
           <Show when={props.titleIconName}>
             <sl-icon name={props.titleIconName} class="flex-shrink-0" />
           </Show>
           <p class="ml-1 font-sans text-lg md:text-xl font-medium truncate">{props.title}</p>
         </div>
+        <div class="flex items-center w-[44px]" />
       </header>
       <div class="z-30 w-full min-h-screen bg-[#F9FAFB] pt-14">
         <div class="px-4 pb-40 md:pt-4 md:pb-52 md:px-4 w-full h-full sm:w-[600px] xs:mx-auto">

--- a/packages/elements/src/photon-form-wrapper/photon-form-wrapper.tsx
+++ b/packages/elements/src/photon-form-wrapper/photon-form-wrapper.tsx
@@ -49,29 +49,27 @@ export const PhotonFormWrapper = (p: PhotonFormWrapperProps) => {
       </photon-dialog>
 
       {/* Wrapper */}
-      <header class="z-40 flex items-center px-4 py-2 md:px-8 md:py-3 bg-white fixed w-full shadow-card">
-        <div class="flex justify-start">
-          <Button
-            variant="naked"
-            size="sm"
-            onClick={() => {
-              if (props.checkShouldWarn()) {
-                onCloseDialogOpen(true);
-              } else {
-                props.onClosed();
-              }
-            }}
-          >
-            <div class="text-black text-xl md:text-3xl">
-              <Icon name="xMark" />
-            </div>
-          </Button>
-        </div>
-        <div class="absolute left-1/2 transform -translate-x-1/2 flex justify-center items-center">
+      <header class="z-40 flex items-center gap-2 px-4 py-2 md:px-8 md:py-3 bg-white fixed w-full shadow-card">
+        <Button
+          variant="naked"
+          size="sm"
+          onClick={() => {
+            if (props.checkShouldWarn()) {
+              onCloseDialogOpen(true);
+            } else {
+              props.onClosed();
+            }
+          }}
+        >
+          <div class="text-black text-xl md:text-3xl">
+            <Icon name="xMark" />
+          </div>
+        </Button>
+        <div class="flex-1 flex justify-center items-center min-w-0">
           <Show when={props.titleIconName}>
-            <sl-icon name={props.titleIconName} />
+            <sl-icon name={props.titleIconName} class="flex-shrink-0" />
           </Show>
-          <p class="ml-1 font-sans text-lg md:text-xl font-medium">{props.title}</p>
+          <p class="ml-1 font-sans text-lg md:text-xl font-medium truncate">{props.title}</p>
         </div>
       </header>
       <div class="z-30 w-full min-h-screen bg-[#F9FAFB] pt-14">
@@ -81,7 +79,9 @@ export const PhotonFormWrapper = (p: PhotonFormWrapperProps) => {
       </div>
       <Show when={props.footer}>
         <footer class="z-40 fixed bottom-0 w-full bg-white shadow-card px-4 py-4 md:px-8">
-          {props.footer}
+          <div class="flex flex-col md:flex-row-reverse md:justify-start gap-2 items-center w-full sm:w-[600px] xs:mx-auto sm:px-4">
+            {props.footer}
+          </div>
         </footer>
       </Show>
     </div>

--- a/packages/elements/src/photon-multirx-form-wrapper/photon-multirx-form-wrapper-component.tsx
+++ b/packages/elements/src/photon-multirx-form-wrapper/photon-multirx-form-wrapper-component.tsx
@@ -201,7 +201,7 @@ const Component = (props: {
         footer={
           hideOrderButton() ? null : props.enableOrder ? (
             <Button
-              class="w-full md:w-fit"
+              class="w-full xs:w-fit"
               size="lg"
               loading={triggerSubmit()}
               onClick={handleCreateOrder}
@@ -211,7 +211,7 @@ const Component = (props: {
           ) : (
             <>
               <Button
-                class="w-full md:w-fit"
+                class="w-full xs:w-fit"
                 size="lg"
                 loading={triggerSubmit() && isCreateOrder()}
                 onClick={handleCreateOrder}
@@ -219,7 +219,7 @@ const Component = (props: {
                 Save and create order
               </Button>
               <Button
-                class="w-full md:w-fit"
+                class="w-full xs:w-fit"
                 size="lg"
                 variant="secondary"
                 loading={triggerSubmit() && !isCreateOrder()}

--- a/packages/elements/src/photon-multirx-form-wrapper/photon-multirx-form-wrapper-component.tsx
+++ b/packages/elements/src/photon-multirx-form-wrapper/photon-multirx-form-wrapper-component.tsx
@@ -1,10 +1,9 @@
-import { Button, triggerToast } from '@photonhealth/components';
+import { Button, triggerToast, usePhoton } from '@photonhealth/components';
 import photonStyles from '@photonhealth/components/dist/style.css?inline';
 import { format } from 'date-fns';
 import jwtDecode from 'jwt-decode';
 import { customElement } from 'solid-element';
 import { createSignal, onMount } from 'solid-js';
-import { usePhoton } from '@photonhealth/components';
 import { PhotonFormWrapper } from '../photon-form-wrapper';
 import { PatientStore } from '../stores/patient';
 
@@ -197,17 +196,25 @@ const Component = (props: {
           patientActions.clearSelectedPatient();
         }}
         checkShouldWarn={() => shouldWarn(form)}
-        title="New Prescriptions"
+        title="New prescription"
         titleIconName="prescription"
-        headerRight={
+        footer={
           hideOrderButton() ? null : props.enableOrder ? (
-            <Button size="md" loading={triggerSubmit()} onClick={handleCreateOrder}>
-              Send Order
-            </Button>
-          ) : (
-            <div class="flex flex-row gap-1 lg:gap-2 justify-end items-end">
+            <div class="flex flex-col md:items-center">
               <Button
-                size="md"
+                class="w-full md:w-80"
+                size="lg"
+                loading={triggerSubmit()}
+                onClick={handleCreateOrder}
+              >
+                Send Order
+              </Button>
+            </div>
+          ) : (
+            <div class="flex flex-col gap-2 md:items-center">
+              <Button
+                class="w-full md:w-80"
+                size="lg"
                 variant="secondary"
                 loading={triggerSubmit() && !isCreateOrder()}
                 onClick={handleCreatePrescriptions}
@@ -215,7 +222,8 @@ const Component = (props: {
                 Save prescriptions
               </Button>
               <Button
-                size="md"
+                class="w-full md:w-80"
+                size="lg"
                 loading={triggerSubmit() && isCreateOrder()}
                 onClick={handleCreateOrder}
               >

--- a/packages/elements/src/photon-multirx-form-wrapper/photon-multirx-form-wrapper-component.tsx
+++ b/packages/elements/src/photon-multirx-form-wrapper/photon-multirx-form-wrapper-component.tsx
@@ -167,7 +167,7 @@ const Component = (props: {
         label="Save prescriptions without an order?"
         open={continueSaveOnly()}
         confirm-text="Save and create order"
-        cancel-text="Yes, Save Only"
+        cancel-text="Yes, save only"
         on:photon-dialog-confirmed={() => {
           setContinueSaveOnly(false);
           setIsCreateOrder(true);
@@ -200,20 +200,26 @@ const Component = (props: {
         titleIconName="prescription"
         footer={
           hideOrderButton() ? null : props.enableOrder ? (
-            <div class="flex flex-col md:items-center">
+            <Button
+              class="w-full md:w-fit"
+              size="lg"
+              loading={triggerSubmit()}
+              onClick={handleCreateOrder}
+            >
+              Send order
+            </Button>
+          ) : (
+            <>
               <Button
-                class="w-full md:w-80"
+                class="w-full md:w-fit"
                 size="lg"
-                loading={triggerSubmit()}
+                loading={triggerSubmit() && isCreateOrder()}
                 onClick={handleCreateOrder}
               >
-                Send Order
+                Save and create order
               </Button>
-            </div>
-          ) : (
-            <div class="flex flex-col gap-2 md:items-center">
               <Button
-                class="w-full md:w-80"
+                class="w-full md:w-fit"
                 size="lg"
                 variant="secondary"
                 loading={triggerSubmit() && !isCreateOrder()}
@@ -221,15 +227,7 @@ const Component = (props: {
               >
                 Save prescriptions
               </Button>
-              <Button
-                class="w-full md:w-80"
-                size="lg"
-                loading={triggerSubmit() && isCreateOrder()}
-                onClick={handleCreateOrder}
-              >
-                Save and create order
-              </Button>
-            </div>
+            </>
           )
         }
         form={

--- a/packages/elements/src/photon-multirx-form/components/AddPrescriptionCard.tsx
+++ b/packages/elements/src/photon-multirx-form/components/AddPrescriptionCard.tsx
@@ -470,6 +470,8 @@ export const AddPrescriptionCard = (props: {
                   }
                 }}
                 loading={isLoading()}
+                variant="secondary"
+                color="blue"
               >
                 {props.enableOrder ? 'Add Prescription to Order' : 'Add Prescription to Drafts'}
               </Button>

--- a/packages/elements/src/photon-multirx-form/photon-prescribe-workflow.tsx
+++ b/packages/elements/src/photon-multirx-form/photon-prescribe-workflow.tsx
@@ -702,7 +702,7 @@ export function PrescribeWorkflow(props: PrescribeProps) {
                       </Button>
                     </Show>
                     <Button loading={isLoadingPrefills() || isLoading()} onClick={combineOrSubmit}>
-                      {props.enableOrder ? 'Send Order' : 'Save Prescriptions'}
+                      {props.enableOrder ? 'Send order' : 'Save prescriptions'}
                     </Button>
                   </div>
                 </Show>

--- a/packages/elements/src/photon-patient-dialog/photon-patient-dialog-component.tsx
+++ b/packages/elements/src/photon-patient-dialog/photon-patient-dialog-component.tsx
@@ -158,7 +158,7 @@ const Component = (props: PatientDialogProps) => {
             actions().resetStores();
             props.open = false;
           }}
-          title={props?.patientId ? 'Update Patient' : 'Create Patient'}
+          title={props?.patientId ? 'Update patient' : 'New patient'}
           titleIconName={props?.patientId ? 'pencil-square' : 'person-plus'}
           headerRight={
             <div class="flex flex-row gap-1 lg:gap-2 justify-end items-end">
@@ -170,7 +170,7 @@ const Component = (props: PatientDialogProps) => {
                   loading={loading() && isCreatePrescription()}
                   onClick={() => submitForm(formStore(), actions(), selectedStore(), true)}
                 >
-                  Save and Create Prescription
+                  {props?.patientId ? 'Update' : 'Create'} and start prescription
                 </Button>
               </Show>
               <Button
@@ -179,7 +179,7 @@ const Component = (props: PatientDialogProps) => {
                 loading={loading() && !isCreatePrescription()}
                 onClick={() => submitForm(formStore(), actions(), selectedStore(), false)}
               >
-                Save
+                {props?.patientId ? 'Update' : 'Create'} patient
               </Button>
             </div>
           }

--- a/packages/elements/src/photon-patient-dialog/photon-patient-dialog-component.tsx
+++ b/packages/elements/src/photon-patient-dialog/photon-patient-dialog-component.tsx
@@ -160,11 +160,12 @@ const Component = (props: PatientDialogProps) => {
           }}
           title={props?.patientId ? 'Update patient' : 'New patient'}
           titleIconName={props?.patientId ? 'pencil-square' : 'person-plus'}
-          headerRight={
-            <div class="flex flex-row gap-1 lg:gap-2 justify-end items-end">
+          footer={
+            <div class="flex flex-col gap-2 md:items-center">
               <Show when={!props?.hideCreatePrescription}>
                 <Button
-                  size="sm"
+                  class="w-full md:w-80"
+                  size="lg"
                   variant="secondary"
                   disabled={loading()}
                   loading={loading() && isCreatePrescription()}
@@ -174,7 +175,8 @@ const Component = (props: PatientDialogProps) => {
                 </Button>
               </Show>
               <Button
-                size="sm"
+                class="w-full md:w-80"
+                size="lg"
                 disabled={loading()}
                 loading={loading() && !isCreatePrescription()}
                 onClick={() => submitForm(formStore(), actions(), selectedStore(), false)}

--- a/packages/elements/src/photon-patient-dialog/photon-patient-dialog-component.tsx
+++ b/packages/elements/src/photon-patient-dialog/photon-patient-dialog-component.tsx
@@ -161,21 +161,9 @@ const Component = (props: PatientDialogProps) => {
           title={props?.patientId ? 'Update patient' : 'New patient'}
           titleIconName={props?.patientId ? 'pencil-square' : 'person-plus'}
           footer={
-            <div class="flex flex-col gap-2 md:items-center">
-              <Show when={!props?.hideCreatePrescription}>
-                <Button
-                  class="w-full md:w-80"
-                  size="lg"
-                  variant="secondary"
-                  disabled={loading()}
-                  loading={loading() && isCreatePrescription()}
-                  onClick={() => submitForm(formStore(), actions(), selectedStore(), true)}
-                >
-                  {props?.patientId ? 'Update' : 'Create'} and start prescription
-                </Button>
-              </Show>
+            <Show when={!props?.hideCreatePrescription}>
               <Button
-                class="w-full md:w-80"
+                class="w-full md:w-fit"
                 size="lg"
                 disabled={loading()}
                 loading={loading() && !isCreatePrescription()}
@@ -183,7 +171,17 @@ const Component = (props: PatientDialogProps) => {
               >
                 {props?.patientId ? 'Update' : 'Create'} patient
               </Button>
-            </div>
+              <Button
+                class="w-full md:w-fit"
+                size="lg"
+                variant="secondary"
+                disabled={loading()}
+                loading={loading() && isCreatePrescription()}
+                onClick={() => submitForm(formStore(), actions(), selectedStore(), true)}
+              >
+                {props?.patientId ? 'Update' : 'Create'} and start prescription
+              </Button>
+            </Show>
           }
           form={
             <>

--- a/packages/elements/src/photon-patient-dialog/photon-patient-dialog-component.tsx
+++ b/packages/elements/src/photon-patient-dialog/photon-patient-dialog-component.tsx
@@ -163,7 +163,7 @@ const Component = (props: PatientDialogProps) => {
           footer={
             <Show when={!props?.hideCreatePrescription}>
               <Button
-                class="w-full md:w-fit"
+                class="w-full xs:w-fit"
                 size="lg"
                 disabled={loading()}
                 loading={loading() && !isCreatePrescription()}
@@ -172,7 +172,7 @@ const Component = (props: PatientDialogProps) => {
                 {props?.patientId ? 'Update' : 'Create'} patient
               </Button>
               <Button
-                class="w-full md:w-fit"
+                class="w-full xs:w-fit"
                 size="lg"
                 variant="secondary"
                 disabled={loading()}

--- a/packages/elements/src/photon-patient-form/photon-patient-form-component.tsx
+++ b/packages/elements/src/photon-patient-form/photon-patient-form-component.tsx
@@ -218,7 +218,7 @@ const PatientForm = (props: { patientId: string }) => {
           <div class="flex flex-col gap-8">
             <Card>
               <div>
-                <p class="font-sans text-lg flex-grow">Personal</p>
+                <p class="font-sans text-lg flex-grow">Patient Info</p>
                 <div class="flex flex-col xs:flex-row xs:gap-4">
                   <photon-text-input
                     class="flex-grow min-w-[40%]"
@@ -436,7 +436,11 @@ const PatientForm = (props: { patientId: string }) => {
 
             <Card>
               <div>
-                <p class="font-sans text-lg flex-grow">Preferred Local Pharmacy</p>
+                <div class="flex items-baseline gap-2">
+                  <p class="font-sans text-lg">Preferred Pharmacy</p>
+                  <p class="font-sans text-sm text-gray-500">Optional</p>
+                </div>
+
                 <PharmacySearch
                   address={getPatientAddress(pStore, store)}
                   setPharmacy={(pharmacy: any) => {


### PR DESCRIPTION
* Form wrapper uses a footer to show buttons at the bottom of the page (both mobile and desktop)
* Use better casing (e.g. 'New Patient' -> 'New patient')
* Update patient pharmacy copy; include optional indicator
* Update Add Prescription to Order button to be a secondary blue style

[notion ticket](https://www.notion.so/photons/Create-Update-Patient-copy-button-improvements-2a78bfbbf4ec804c85baf7f2a766d411?source=copy_link)


