### PR TITLE
Put sex input before gender input, make dropdown options title case

### DIFF
--- a/apps/app/e2e/create_prescription.spec.ts
+++ b/apps/app/e2e/create_prescription.spec.ts
@@ -13,7 +13,7 @@ test('user can login and create patient', async ({ page }) => {
   await page.getByLabel('Date of Birth').fill('1980-12-31');
   await page.getByLabel('Mobile Number').fill('8886543210');
   await page.getByLabel('Sex at Birth').click();
-  await page.getByRole('menuitem', { name: 'MALE', exact: true }).click();
+  await page.getByRole('menuitem', { name: 'Male', exact: true }).click();
   await page.getByLabel('Street 1').fill('1 E2E Test St.');
   await page.getByLabel('City').fill('e2e-test-city');
   await page.getByLabel('State').click();

--- a/packages/elements/src/photon-patient-form/photon-patient-form-component.tsx
+++ b/packages/elements/src/photon-patient-form/photon-patient-form-component.tsx
@@ -288,27 +288,6 @@ const PatientForm = (props: { patientId: string }) => {
                 </div>
                 <div class="flex flex-col xs:flex-row justify-between xs:gap-4">
                   <div class="flex-grow w-full xs:min-w-[40%]">
-                    <photon-gender-input
-                      label="Gender"
-                      required="false"
-                      help-text={store['gender']?.error}
-                      invalid={store['gender']?.error !== undefined}
-                      on:photon-gender-selected={(e: any) => {
-                        actions.updateFormValue({
-                          key: 'gender',
-                          value: e.detail.gender
-                        });
-                      }}
-                      on:photon-gender-deselected={() => {
-                        actions.updateFormValue({
-                          key: 'gender',
-                          value: undefined
-                        });
-                      }}
-                      selected={pStore.selectedPatient.data?.gender}
-                    />
-                  </div>
-                  <div class="flex-grow w-full xs:min-w-[40%]">
                     <photon-sex-input
                       label="Sex at Birth"
                       required="true"
@@ -327,6 +306,27 @@ const PatientForm = (props: { patientId: string }) => {
                         });
                       }}
                       selected={pStore.selectedPatient.data?.sex}
+                    />
+                  </div>
+                  <div class="flex-grow w-full xs:min-w-[40%]">
+                    <photon-gender-input
+                      label="Gender"
+                      required="false"
+                      help-text={store['gender']?.error}
+                      invalid={store['gender']?.error !== undefined}
+                      on:photon-gender-selected={(e: any) => {
+                        actions.updateFormValue({
+                          key: 'gender',
+                          value: e.detail.gender
+                        });
+                      }}
+                      on:photon-gender-deselected={() => {
+                        actions.updateFormValue({
+                          key: 'gender',
+                          value: undefined
+                        });
+                      }}
+                      selected={pStore.selectedPatient.data?.gender}
                     />
                   </div>
                 </div>

--- a/packages/elements/src/photon-patient-form/photon-patient-form-component.tsx
+++ b/packages/elements/src/photon-patient-form/photon-patient-form-component.tsx
@@ -70,7 +70,7 @@ const PatientForm = (props: { patientId: string }) => {
   });
   actions.registerValidator({
     key: 'sex',
-    validator: message(enums(sexes.map((s) => s.name)), 'Please enter Sex at Birth.')
+    validator: message(enums(sexes.map((s) => s.name.toUpperCase())), 'Please enter Sex at Birth.')
   });
   actions.registerValidator({
     key: 'phone',

--- a/packages/elements/src/photon-sex-input/photon-sex-input-component.tsx
+++ b/packages/elements/src/photon-sex-input/photon-sex-input-component.tsx
@@ -13,15 +13,15 @@ type Sex = {
 export const sexes: Sex[] = [
   {
     id: '1',
-    name: 'MALE'
+    name: 'Male'
   },
   {
     id: '2',
-    name: 'FEMALE'
+    name: 'Female'
   },
   {
     id: '3',
-    name: 'UNKNOWN'
+    name: 'Unknown'
   }
 ];
 
@@ -41,7 +41,7 @@ const Component = (props: {
       composed: true,
       bubbles: true,
       detail: {
-        sex: sex
+        sex
       }
     });
     ref?.dispatchEvent(event);
@@ -51,7 +51,7 @@ const Component = (props: {
     <div
       ref={ref}
       on:photon-data-selected={(e: any) => {
-        dispatchSexSelected(e.detail.data.name);
+        dispatchSexSelected(e.detail.data.name.toUpperCase());
       }}
     >
       <style>{tailwind}</style>


### PR DESCRIPTION
- **put sex input before gender input in patient form**
- **Make the sex options Titlecase. Make sure it's still caps lock in the db**

<img width="620" height="572" alt="Screenshot 2025-11-25 at 6 02 51 PM" src="https://github.com/user-attachments/assets/c1214a84-8cdc-485f-99f0-68e8aa254d26" />
<img width="572" height="215" alt="Screenshot 2025-11-25 at 6 22 54 PM" src="https://github.com/user-attachments/assets/bffd15e8-3fec-4c07-80af-870cac8119d7" />

### Still updates the db with uppercase.

<img width="784" height="65" alt="Screenshot 2025-11-25 at 7 09 39 PM" src="https://github.com/user-attachments/assets/2791ac80-9b82-470c-8742-ea6736edafdc" />
<img width="829" height="94" alt="Screenshot 2025-11-25 at 7 09 48 PM" src="https://github.com/user-attachments/assets/059bf70d-c872-4c09-bee0-61184650ccdf" />
<img width="827" height="95" alt="Screenshot 2025-11-25 at 7 10 14 PM" src="https://github.com/user-attachments/assets/432c106b-d8f2-45fc-ba97-3aca5be0b325" />
