### PR TITLE
Fix med name clearing on selection in mobile

### DIFF
--- a/packages/elements/src/photon-medication-dropdown-full-width/photon-medication-dropdown-full-width.tsx
+++ b/packages/elements/src/photon-medication-dropdown-full-width/photon-medication-dropdown-full-width.tsx
@@ -297,10 +297,6 @@ export const PhotonMedicationDropdownFullWidth = <
                           inputRef.value = '';
                           debounceSearch('');
                           dispatchSelect((datum as DataItem<T>).data);
-
-                          if (props.onClose) {
-                            props.onClose();
-                          }
                         }
                       }
                     };

--- a/packages/elements/src/photon-medication-search/photon-medication-search-component.tsx
+++ b/packages/elements/src/photon-medication-search/photon-medication-search-component.tsx
@@ -353,6 +353,7 @@ const Component = (props: ComponentProps) => {
     <div
       ref={ref}
       on:photon-data-selected={(e: any) => {
+        setShowFullWidthSearch(false);
         const selectedItem = e.detail.data;
 
         // Check if the selected item is disabled


### PR DESCRIPTION
Fixing an issue found during testing this morning where on mobile screens, the Med Search would autoclear