### PR TITLE
reset med history input after adding new med

### DIFF
--- a/apps/app/README.md
+++ b/apps/app/README.md
@@ -2,10 +2,6 @@
 
 ## Local Development
 
-### Graphql Codegen
-
-`npx graphql-codegen --config='apps/app/codegen.ts'`
-
 ### Run against Boson services
 
 > Runs against remote Boson environment services
@@ -17,6 +13,10 @@
 > Must be running [tau services](https://github.com/Photon-Health/services) locally
 
 `npx nx run app:start:tau`
+
+### Graphql Codegen
+
+`npx graphql-codegen --config='apps/app/codegen.ts'`
 
 ### Playwright e2e Tests
 
@@ -38,7 +38,6 @@ $ npx nx run app:e2e
 # or run within UI popup window
 $ npx nx run app:e2e:ui
 ```
-
 
 ### Tests
 

--- a/packages/elements/README.md
+++ b/packages/elements/README.md
@@ -10,6 +10,8 @@ To run at http://localhost:3000:
 npx nx run elements:start
 ```
 
+This command recompiles components code on change, but does not hot refresh the client. You'll need to refresh the webpage manually to see changes.
+
 To modify the embedded component, edit attributes of element `photon-prescribe-workflow` inside [index.html](index.html)
 
 To view available attributes/options, see [photon-prescribe-workflow-component.tsx](src/photon-multirx-form/photon-prescribe-workflow-component.tsx) or [official docs](https://docs.photon.health/docs/elements#prescribe-element)

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@photonhealth/elements",
-  "version": "0.17.3",
+  "version": "0.17.4",
   "description": "",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/elements/src/photon-add-medication-history-dialog/photon-add-medication-history-dialog-component.tsx
+++ b/packages/elements/src/photon-add-medication-history-dialog/photon-add-medication-history-dialog-component.tsx
@@ -98,6 +98,7 @@ const Component = (props: AddMedicationHistoryDialogProps) => {
   createEffect(() => {
     if (!props.open) {
       setSubmitting(false);
+      setSearchTerm('');
     }
   });
 

--- a/packages/elements/src/photon-multirx-form/components/PatientCard.tsx
+++ b/packages/elements/src/photon-multirx-form/components/PatientCard.tsx
@@ -42,7 +42,6 @@ export const PatientCard = (props: {
   hidePatientCard?: boolean;
 }) => {
   const [newMedication, setNewMedication] = createSignal<Treatment | undefined>();
-  undefined;
   const [showEditPatientView, setShowEditPatientView] = createSignal(false);
   const [showAddMedDialog, setShowAddMedDialog] = createSignal(false);
   const { actions, store } = PatientStore;
@@ -167,7 +166,6 @@ export const PatientCard = (props: {
             hideAddMedicationDialog={() => setShowAddMedDialog(false)}
           />
           <photon-add-medication-history-dialog
-            title="Add Medication History"
             open={showAddMedDialog()}
             on:photon-medication-selected={(e: { detail: { medication: Treatment } }) => {
               setNewMedication(e.detail.medication);


### PR DESCRIPTION
Ticket: https://www.notion.so/ev-2aa8bfbbf4ec80d88295fba3ae2049a1?v=2a88bfbbf4ec80d3b014000c3aa9eede&source=copy_link

Main fix is to clear medication input any time the modal is closed, whether because a new medication was successfully added or provider clicked the Cancel or X buttons.