### PR TITLE
fix copy for Edit patient modal via Create Prescription flow

### DIFF
--- a/apps/app/e2e/create_prescription.spec.ts
+++ b/apps/app/e2e/create_prescription.spec.ts
@@ -20,7 +20,7 @@ test('user can login and create patient', async ({ page }) => {
   await page.getByRole('menuitem', { name: 'AL', exact: true }).click();
   await page.getByLabel('Zip Code').fill('12345');
 
-  await page.getByRole('button', { name: 'Create patient', exact: true }).click();
+  await page.getByRole('button', { name: 'Create', exact: true }).click();
 
   await expect(page.getByRole('heading', { name: 'Patients' })).toBeVisible();
 });

--- a/packages/components/src/systems/PatientInfo/index.tsx
+++ b/packages/components/src/systems/PatientInfo/index.tsx
@@ -111,7 +111,7 @@ export default function PatientInfo(props: PatientInfoProps) {
         <Text color="gray">Patient Info</Text>
         <Show when={props?.editPatient}>
           <Button variant="secondary" size="sm" onClick={props?.editPatient}>
-            Edit Patient
+            Edit patient
           </Button>
         </Show>
       </div>

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@photonhealth/elements",
-  "version": "0.17.4",
+  "version": "0.17.5",
   "description": "",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/elements/src/photon-patient-dialog/photon-patient-dialog-component.tsx
+++ b/packages/elements/src/photon-patient-dialog/photon-patient-dialog-component.tsx
@@ -158,7 +158,7 @@ const Component = (props: PatientDialogProps) => {
             actions().resetStores();
             props.open = false;
           }}
-          title={props?.patientId ? 'Update patient' : 'New patient'}
+          title={props?.patientId ? 'Edit patient' : 'New patient'}
           titleIconName={props?.patientId ? 'pencil-square' : 'person-plus'}
           footer={
             <>
@@ -170,7 +170,7 @@ const Component = (props: PatientDialogProps) => {
                   loading={loading() && isCreatePrescription()}
                   onClick={() => submitForm(formStore(), actions(), selectedStore(), true)}
                 >
-                  {props?.patientId ? 'Update' : 'Create'} and start prescription
+                  {props?.patientId ? 'Save' : 'Create'} and start prescription
                 </Button>
               </Show>
               <Button
@@ -181,7 +181,7 @@ const Component = (props: PatientDialogProps) => {
                 loading={loading() && !isCreatePrescription()}
                 onClick={() => submitForm(formStore(), actions(), selectedStore(), false)}
               >
-                {props?.patientId ? 'Update' : 'Create'} patient
+                {props?.patientId ? 'Save' : 'Create'}
               </Button>
             </>
           }


### PR DESCRIPTION
Ticket: https://www.notion.so/Edit-Patient-UX-via-Create-Prescription-flow-2aa8bfbbf4ec8034b779f7518bd4b901?v=2a88bfbbf4ec80d3b014000c3aa9eede

Button copy fix:
<img width="375" height="311" alt="Screenshot 2025-12-08 at 2 27 59 PM" src="https://github.com/user-attachments/assets/7f975ad3-0e65-451a-9e5f-de2815cd563b" />

Edit patient modal fixes:
<img width="374" height="667" alt="Screenshot 2025-12-08 at 2 28 30 PM" src="https://github.com/user-attachments/assets/bae87034-e3ff-4ea5-b141-fbfa3a2ca0db" />
