### PR TITLE
Add version params to self signup

### DIFF
--- a/apps/app/src/views/routes/SelfSignup/views/SelfSignupPage.tsx
+++ b/apps/app/src/views/routes/SelfSignup/views/SelfSignupPage.tsx
@@ -381,7 +381,11 @@ const buildSignupContinueParams = (state: string, formData: SignupFormData): str
     city: formData.city,
     state_address: formData.state.value,
     postal_code: formData.postalCode,
-    did_accept_tos: formData.didAgreeToTerms.toString()
+    did_accept_tos: formData.didAgreeToTerms.toString(),
+    // these version numbers must match an entry in the attestations table
+    // otherwise an error will occur during signup
+    tos_version: '1.0.0',
+    baa_version: '1.0.0'
   });
 
   if (formData.street2) {


### PR DESCRIPTION
Allowing self signup flow to passup the version, which can be passed to the Attestations insert during self-signup user creation

[notion ticket](https://www.notion.so/photons/As-a-compliance-officer-I-should-be-able-to-audit-when-a-Doximity-User-accepted-the-Terms-of-Servic-2be8bfbbf4ec8084b80fc176db32033a?source=copy_link)