### PR TITLE
add app:dev command to auto rebuild packages files

### DIFF
--- a/apps/app/README.md
+++ b/apps/app/README.md
@@ -2,6 +2,12 @@
 
 ## Local Development
 
+### Run against Boson services with code refresh
+
+Starts the clinical app dev server with hot refresh. Files in `app` dependencies will automatically rebuild, but you'll need to manually refresh the webpage to see your changes.
+
+`npx nx run app:dev`
+
 ### Run against Boson services
 
 > Runs against remote Boson environment services

--- a/apps/app/project.json
+++ b/apps/app/project.json
@@ -13,6 +13,17 @@
       },
       "dependsOn": ["^build"]
     },
+    "dev": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "apps/app",
+        "commands": [
+          "env-cmd -f .env.boson react-app-rewired start",
+          "nx watch --projects=app --includeDependentProjects -- nx run-many -t build --projects=elements,react,sdk"
+        ]
+      },
+      "dependsOn": ["^build"]
+    },
     "start:neutron": {
       "executor": "nx:run-commands",
       "options": {


### PR DESCRIPTION
Instead of having to run `build` commands manually in the terminal whenever you change a file in `packages`, run `npx nx run app:dev` to start the app server and also watch the `packages` folder for changes.

Nx command is

```nx watch --projects=app --includeDependentProjects -- nx run-many -t build --projects=elements,react,sdk```

- Watch for file changes in the `app` folder and its dependencies as specified in package.json
- When a file changes, run the `build` command in the specified projects
  - Tried various ways to not hardcode the project names, but surprisingly there's no easy way to say "run the build command only on `app`'s dependencies
  - Also tried to find a way to only rebuild the specific package instead of all dependencies, but since the dependency graph is app > elements > components, `app` doesn't sense any changes in `components`

Based on nx docs here: https://20.nx.dev/recipes/running-tasks/workspace-watching#workspace-watching
