### PR TITLE
Switch npm to trusted publishing

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -3,7 +3,7 @@ name: Publish Packages
 on:
   push:
     branches:
-      - boson
+      - photon
 
 permissions:
   id-token: write # Required for OIDC trusted publishing
@@ -18,7 +18,7 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v4
         with:
-          ref: boson
+          ref: photon
           fetch-depth: 0
 
       - name: Set up Node.js

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - boson
 
+permissions:
+  id-token: write # Required for OIDC trusted publishing
+  contents: write # Required for pushing git tags
+
 jobs:
   publish:
     name: NPM Publish
@@ -12,16 +16,19 @@ jobs:
 
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: boson
           fetch-depth: 0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 20
-          registry-url: 'https://registry.npmjs.org'
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Update npm for trusted publishing
+        run: npm install -g npm@latest
 
       - name: Install Dependencies
         run: npm ci
@@ -78,8 +85,6 @@ jobs:
                   cd -
               done
           fi
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Upload to S3
         run: |

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@photonhealth/elements",
-  "version": "0.17.5",
+  "version": "0.17.6",
   "description": "",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@photonhealth/elements",
-  "version": "0.17.6",
+  "version": "0.17.5",
   "description": "",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
https://github.blog/changelog/2025-07-31-npm-trusted-publishing-with-oidc-is-generally-available/
https://docs.npmjs.com/trusted-publishers