### PR TITLE
Centering the duplicate prescription modal, and all other modals in mobile

### DIFF
--- a/packages/components/src/particles/Dialog/index.tsx
+++ b/packages/components/src/particles/Dialog/index.tsx
@@ -79,10 +79,13 @@ function Dialog(props: DialogProps) {
         {merged.open && (
           <div class="fixed inset-0 z-20 overflow-y-auto">
             <div
-              class={clsx('flex min-h-full justify-center p-4 text-center sm:items-center sm:p-0', {
-                'items-end': merged.position === 'bottom',
-                'items-center': merged.position === 'center'
-              })}
+              class={clsx(
+                'flex flex-col min-h-full justify-center p-4 text-center sm:items-center sm:p-0',
+                {
+                  'items-end': merged.position === 'bottom',
+                  'items-center': merged.position === 'center'
+                }
+              )}
             >
               <div class={panelClasses()}>
                 <Show when={merged?.onClose}>

--- a/packages/components/src/particles/Dialog/index.tsx
+++ b/packages/components/src/particles/Dialog/index.tsx
@@ -15,7 +15,7 @@ export interface DialogProps {
 }
 
 function Dialog(props: DialogProps) {
-  const merged = mergeProps({ size: 'md', open: false, position: 'bottom' }, props);
+  const merged = mergeProps({ size: 'md', open: false, position: 'center' }, props);
 
   const panelClasses = createMemo(() =>
     clsx(
@@ -79,13 +79,10 @@ function Dialog(props: DialogProps) {
         {merged.open && (
           <div class="fixed inset-0 z-20 overflow-y-auto">
             <div
-              class={clsx(
-                'flex flex-col min-h-full justify-center p-4 text-center sm:items-center sm:p-0',
-                {
-                  'items-end': merged.position === 'bottom',
-                  'items-center': merged.position === 'center'
-                }
-              )}
+              class={clsx('flex min-h-full justify-center p-4 text-center sm:p-0', {
+                'items-end': merged.position === 'bottom',
+                'items-center': merged.position === 'center'
+              })}
             >
               <div class={panelClasses()}>
                 <Show when={merged?.onClose}>


### PR DESCRIPTION
From this ticket: https://www.notion.so/Combine-order-modal-should-be-centered-2aa8bfbbf4ec8013acd8fe8a8151f595?source=copy_link

## Before 
<img width="412" height="738" alt="Screenshot 2025-12-11 at 6 24 54 PM" src="https://github.com/user-attachments/assets/ccdf6b30-0fdc-4d29-8c6c-8adcd674b540" />


## After
<img width="417" height="742" alt="Screenshot 2025-12-11 at 6 21 44 PM" src="https://github.com/user-attachments/assets/9e68ef1d-ff73-4db2-a06f-096e274dabb6" />


