### PR TITLE
Collapse Patient Card on Mobile

### DIFF
--- a/packages/components/src/systems/PatientInfo/index.tsx
+++ b/packages/components/src/systems/PatientInfo/index.tsx
@@ -6,6 +6,7 @@ import { usePhotonClient } from '../SDKProvider';
 import Button from '../../particles/Button';
 import Text from '../../particles/Text';
 import Card from '../../particles/Card';
+import Icon from '../../particles/Icon';
 
 const GET_PATIENT = gql`
   query GetPatient($id: ID!) {
@@ -76,6 +77,7 @@ const formatDate = (dateString: string) => {
 export default function PatientInfo(props: PatientInfoProps) {
   const client = usePhotonClient();
   const [patient, setPatient] = createSignal<Patient | undefined>(undefined);
+  const [isExpanded, setIsExpanded] = createSignal(false);
 
   const fetchPatient = async () => {
     const { data } = await client!.apollo.query({
@@ -116,10 +118,25 @@ export default function PatientInfo(props: PatientInfoProps) {
         </Show>
       </div>
       <div class="pt-4" data-dd-privacy="mask">
-        <Text size="lg" bold loading={!patient()} sampleLoadingText="Sally Patient">
-          {patient()?.name.full || 'N/A'}
-        </Text>
-        <div class="pt-4 sm:grid sm:grid-cols-2 sm:gap-2">
+        <div>
+          <Text size="lg" bold loading={!patient()} sampleLoadingText="Sally Patient">
+            {patient()?.name.full || 'N/A'}
+          </Text>
+          <button
+            type="button"
+            class="sm:hidden flex items-center gap-1 text-gray-400 hover:text-gray-500 mt-1"
+            onClick={() => setIsExpanded(!isExpanded())}
+            aria-expanded={isExpanded() ? 'true' : 'false'}
+          >
+            <span class="text-xs">{isExpanded() ? 'Show Less' : 'Show More'}</span>
+            <Icon name={isExpanded() ? 'chevronUp' : 'chevronDown'} size="sm" />
+          </button>
+        </div>
+        <div
+          class={`pt-4 sm:grid sm:grid-cols-2 sm:gap-2 ${
+            isExpanded() ? 'block' : 'hidden sm:grid'
+          }`}
+        >
           <table class="table-auto">
             <tbody>
               <InfoRow label="Email">

--- a/packages/components/src/systems/PatientInfo/index.tsx
+++ b/packages/components/src/systems/PatientInfo/index.tsx
@@ -117,14 +117,14 @@ export default function PatientInfo(props: PatientInfoProps) {
           </Button>
         </Show>
       </div>
-      <div class="pt-4" data-dd-privacy="mask">
+      <div class="pt-2" data-dd-privacy="mask">
         <div>
           <Text size="lg" bold loading={!patient()} sampleLoadingText="Sally Patient">
             {patient()?.name.full || 'N/A'}
           </Text>
           <button
             type="button"
-            class="sm:hidden flex items-center gap-1 text-gray-400 hover:text-gray-500 mt-1"
+            class="sm:hidden flex items-center gap-1 text-gray-400 hover:text-gray-500 mt-3"
             onClick={() => setIsExpanded(!isExpanded())}
             aria-expanded={isExpanded() ? 'true' : 'false'}
           >

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@photonhealth/elements",
-  "version": "0.17.6",
+  "version": "0.17.7",
   "description": "",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
https://www.notion.so/photons/Provider-sees-condensed-patient-info-card-in-New-Prescription-page-2d18bfbbf4ec80c9a8e6c52125f53991?source=copy_link

# DESKTOP
<img width="1116" height="328" alt="Screenshot 2025-12-31 at 12 37 20 PM" src="https://github.com/user-attachments/assets/b8952298-efd7-406a-93b6-d1a79fb4d3a6" />

# MOBILE
<img width="521" height="196" alt="Screenshot 2025-12-31 at 12 37 08 PM" src="https://github.com/user-attachments/assets/fb2d4507-e7bc-4da7-9c26-f8aa5b65943c" />
<img width="522" height="464" alt="Screenshot 2025-12-31 at 12 37 02 PM" src="https://github.com/user-attachments/assets/6fbbfc66-7a43-4033-ac88-354001184ab9" />
