### PR TITLE
Add retail price to analytics

### DIFF
--- a/apps/patient/src/utils/tracking/OfferImpressionTracker.tsx
+++ b/apps/patient/src/utils/tracking/OfferImpressionTracker.tsx
@@ -30,6 +30,7 @@ const OfferImpressionTracker = ({
           ordinal_position: ordinalPosition,
           distance: pharmacy.distance,
           price: pharmacy.price,
+          retailPrice: pharmacy.retailPrice,
           showReadyIn30Min: pharmacy.showReadyIn30Min,
           is24Hr: pharmacy.is24Hr,
           isClosingSoon: pharmacy.isClosingSoon,


### PR DESCRIPTION
I noticed today we aren't storing retailPrice in the offer_impressions table on the analytics database. This should fix that.