### PR TITLE
fix rudderstack error on sso page

### DIFF
--- a/apps/app/src/configs/providerAnalytics.ts
+++ b/apps/app/src/configs/providerAnalytics.ts
@@ -43,5 +43,13 @@ export class ProviderAnalytics {
   }
 }
 
-// Singleton instance
-export const providerAnalytics = new ProviderAnalytics();
+// Lazy singleton instance - only instantiates when first accessed
+// to fix /sso redirect page from throwing many Rudderstack errors on page load
+let _providerAnalytics: ProviderAnalytics | undefined;
+
+export function getProviderAnalytics(): ProviderAnalytics {
+  if (!_providerAnalytics) {
+    _providerAnalytics = new ProviderAnalytics();
+  }
+  return _providerAnalytics;
+}

--- a/apps/app/src/hooks/useProviderAnalytics.tsx
+++ b/apps/app/src/hooks/useProviderAnalytics.tsx
@@ -2,7 +2,7 @@ import { createContext, useContext, useMemo, ReactNode, useCallback, useEffect }
 import { gql, useQuery } from '@apollo/client';
 import { usePhoton } from '@photonhealth/react';
 import { ApiObject } from '@rudderstack/analytics-js';
-import { providerAnalytics } from '../configs/providerAnalytics';
+import { getProviderAnalytics } from '../configs/providerAnalytics';
 import { setInstrumentationUserContext } from '../instrumentation/setInstrumentationUserContext';
 
 const ENVIRONMENT = process.env.REACT_APP_ENV_NAME || 'development';
@@ -116,7 +116,7 @@ export const ProviderAnalyticsProvider = ({ children }: ProviderAnalyticsProvide
   // Wrapped track function that auto-includes context
   const track = useCallback(
     (eventName: string, properties: ApiObject = {}) => {
-      providerAnalytics.track(eventName, {
+      getProviderAnalytics().track(eventName, {
         ...contextData,
         ...properties
       });


### PR DESCRIPTION
Wasn't this annoying? Using lazy load on `track` so SSO page doesn't attempt to load Rudderstack.

<img width="2032" height="1167" alt="image" src="https://github.com/user-attachments/assets/0122f703-383e-4bc9-9db3-74e33bb88b0b" />
