### PR TITLE
Create order with address id 

### DIFF
--- a/apps/app/src/model/fragments.ts
+++ b/apps/app/src/model/fragments.ts
@@ -42,6 +42,7 @@ const PATIENT_FIELDS = gql`
     email
     phone
     address {
+      id
       name {
         full
       }

--- a/apps/app/src/views/routes/NewOrder/components/OrderForm.tsx
+++ b/apps/app/src/views/routes/NewOrder/components/OrderForm.tsx
@@ -254,7 +254,7 @@ export const OrderForm = ({
             const updateResult = await updatePatientMutation({
               variables: {
                 id: patient.id,
-                address: { ...values.address }
+                address
               }
             });
             orderAddressId = updateResult?.data?.updatePatient?.address?.id ?? undefined;
@@ -262,7 +262,7 @@ export const OrderForm = ({
 
           // override with provided address when not saving to patient
           if (!updateAddress && showAddress) {
-            await createOrderMutation({ variables: { ...rest, address }, onCompleted: onClose });
+            await createOrderMutation({ variables: values, onCompleted: onClose });
           } else {
             // fall back to updated or existing address id
             if (!orderAddressId) {

--- a/apps/app/src/views/routes/NewOrder/components/OrderForm.tsx
+++ b/apps/app/src/views/routes/NewOrder/components/OrderForm.tsx
@@ -246,7 +246,10 @@ export const OrderForm = ({
           })
         ) {
           setSubmitting(true);
-          createOrderMutation({ variables: values, onCompleted: onClose });
+          const addressId = !showAddress ? patient?.address?.id : undefined;
+          const { address, ...rest } = values;
+          const variables = addressId ? { ...rest, addressId } : values;
+          createOrderMutation({ variables, onCompleted: onClose });
 
           // if the user has selected to set the customer's address
           if (updateAddress) {

--- a/apps/app/src/views/routes/NewOrder/components/OrderForm.tsx
+++ b/apps/app/src/views/routes/NewOrder/components/OrderForm.tsx
@@ -246,20 +246,25 @@ export const OrderForm = ({
           })
         ) {
           setSubmitting(true);
-          const addressId = !showAddress ? patient?.address?.id : undefined;
+          let orderAddressId: string | undefined;
           const { address, ...rest } = values;
-          const variables = addressId ? { ...rest, addressId } : values;
-          createOrderMutation({ variables, onCompleted: onClose });
 
           // if the user has selected to set the customer's address
           if (updateAddress) {
-            updatePatientMutation({
+            const updateResult = await updatePatientMutation({
               variables: {
                 id: patient.id,
                 address: { ...values.address }
               }
             });
+            orderAddressId = updateResult?.data?.updatePatient?.address?.id ?? undefined;
+          } else if (!showAddress) {
+            orderAddressId = patient?.address?.id ?? undefined;
           }
+
+          const variables = orderAddressId ? { ...rest, addressId: orderAddressId } : rest;
+
+          await createOrderMutation({ variables, onCompleted: onClose });
 
           // if the user has selected to save the pharmacy as their preferred pharmacy
           if (updatePreferredPharmacy) {

--- a/apps/app/src/views/routes/NewOrder/components/OrderForm.tsx
+++ b/apps/app/src/views/routes/NewOrder/components/OrderForm.tsx
@@ -249,7 +249,7 @@ export const OrderForm = ({
           let orderAddressId: string | undefined;
           const { address, ...rest } = values;
 
-          // if the user has selected to set the customer's address
+          // update patient address when requested
           if (updateAddress) {
             const updateResult = await updatePatientMutation({
               variables: {
@@ -258,13 +258,21 @@ export const OrderForm = ({
               }
             });
             orderAddressId = updateResult?.data?.updatePatient?.address?.id ?? undefined;
-          } else if (!showAddress) {
-            orderAddressId = patient?.address?.id ?? undefined;
           }
 
-          const variables = orderAddressId ? { ...rest, addressId: orderAddressId } : rest;
-
-          await createOrderMutation({ variables, onCompleted: onClose });
+          // override with provided address when not saving to patient
+          if (!updateAddress && showAddress) {
+            await createOrderMutation({ variables: { ...rest, address }, onCompleted: onClose });
+          } else {
+            // fall back to updated or existing address id
+            if (!orderAddressId) {
+              orderAddressId = patient?.address?.id ?? undefined;
+            }
+            await createOrderMutation({
+              variables: orderAddressId ? { ...rest, addressId: orderAddressId } : rest,
+              onCompleted: onClose
+            });
+          }
 
           // if the user has selected to save the pharmacy as their preferred pharmacy
           if (updatePreferredPharmacy) {

--- a/packages/components/src/particles/ListBox/index.tsx
+++ b/packages/components/src/particles/ListBox/index.tsx
@@ -39,7 +39,7 @@ export default function ListSelect(props: ListSelectProps): JSX.Element {
         value={selected()}
         onSelectChange={(item?: ListItem) => {
           setSelected(item ?? { name: props.selectMessage });
-          onInput(item?.name ?? '');
+          onInput(item?.value ?? item?.id ?? item?.name ?? '');
         }}
         class="relative shadow-sm rounded-lg"
       >

--- a/packages/components/src/systems/AddressForm/index.tsx
+++ b/packages/components/src/systems/AddressForm/index.tsx
@@ -26,6 +26,15 @@ const UPDATE_PATIENT_ADDRESS = gql`
   mutation UpdateAddress($id: ID!, $address: AddressInput) {
     updatePatient(id: $id, address: $address) {
       id
+      address {
+        id
+        street1
+        street2
+        city
+        state
+        postalCode
+        country
+      }
     }
   }
 `;
@@ -51,29 +60,28 @@ export default function AddressForm(props: AddressFormProps) {
   const showRequiredBanner = () => props.showRequiredBanner ?? true;
 
   const updatePatientAddress = async (address: AddressProps) => {
-    await client!.apollo.mutate({
+    const { data } = await client!.apollo.mutate({
       mutation: UPDATE_PATIENT_ADDRESS,
-      variables: { id: props.patientId, address },
-      update: () => {
-        setSubmitting(false);
-        triggerToast({
-          header: 'Address Updated',
-          body: 'The patient address has been updated.',
-          status: 'success'
-        });
-        if (props?.setAddress) {
-          props.setAddress(address);
-        }
-      }
+      variables: { id: props.patientId, address }
     });
+    setSubmitting(false);
+    triggerToast({
+      header: 'Address Updated',
+      body: 'The patient address has been updated.',
+      status: 'success'
+    });
+    if (props?.setAddress) {
+      props.setAddress(data?.updatePatient?.address ?? address);
+    }
   };
 
   const { form, errors } = createForm({
     onSubmit: async (values) => {
       setSubmitting(true);
       try {
-        updatePatientAddress({ country: 'US', ...values });
+        await updatePatientAddress({ country: 'US', ...values });
       } catch (e) {
+        setSubmitting(false);
         triggerToast({
           header: 'Error Updating Patient',
           body: 'The patient address has not been updated.',

--- a/packages/components/src/systems/PatientInfo/index.tsx
+++ b/packages/components/src/systems/PatientInfo/index.tsx
@@ -22,6 +22,7 @@ const GET_PATIENT = gql`
       gender
       dateOfBirth
       address {
+        id
         street1
         street2
         city
@@ -51,6 +52,7 @@ const InfoRow = (props: InfoRowProps) => {
 };
 
 export type Address = {
+  id?: string;
   city: string;
   postalCode: string;
   state: string;

--- a/packages/components/src/systems/PrescribeProvider/PrescribeProvider.tsx
+++ b/packages/components/src/systems/PrescribeProvider/PrescribeProvider.tsx
@@ -128,6 +128,7 @@ export const PrescribeProvider = (props: PrescribeProviderProps) => {
   const [patientPreferredPharmacyId, setPatientPreferredPharmacyId] = createSignal<string | null>(
     null
   );
+  const [lastPatientId, setLastPatientId] = createSignal<string | null>(null);
   const [patientAddress, setPatientAddress] = createSignal<Address | null>(null);
   const [didSelectOtherCoverageOption, setDidSelectOtherCoverageOption] =
     createSignal<boolean>(false);
@@ -218,12 +219,19 @@ export const PrescribeProvider = (props: PrescribeProviderProps) => {
   });
 
   createEffect(() => {
-    // reset state on patient change
-    if (props.patientId) {
+    // reset state only when the patient id changes or is cleared
+    if (props.patientId && props.patientId !== lastPatientId()) {
       setDraftPrescriptions([]);
       setSelectedCoverageOption(undefined);
       setDidSelectOtherCoverageOption(false);
       setCoverageOptions([]);
+      setLastPatientId(props.patientId);
+    } else if (!props.patientId && lastPatientId() !== null) {
+      setDraftPrescriptions([]);
+      setSelectedCoverageOption(undefined);
+      setDidSelectOtherCoverageOption(false);
+      setCoverageOptions([]);
+      setLastPatientId(null);
     }
   });
 

--- a/packages/components/src/systems/RecentOrders/RecentOrders.tsx
+++ b/packages/components/src/systems/RecentOrders/RecentOrders.tsx
@@ -89,6 +89,7 @@ type RecentOrdersState = {
   patientId?: string;
   patientName?: string;
   // in case the combine order fails, we need address to make a new order
+  addressId?: string;
   address?: Address;
   // if provider chooses not to combine the order, call this to create a new order
   createOrder?: () => void;
@@ -102,7 +103,12 @@ type RecentOrdersState = {
 };
 
 type RecentOrdersActions = {
-  setIsCombineDialogOpen: (isOpen: boolean, createOrder?: () => void, address?: Address) => void;
+  setIsCombineDialogOpen: (
+    isOpen: boolean,
+    createOrder?: () => void,
+    addressId?: string,
+    address?: Address
+  ) => void;
   setIsDuplicateDialogOpen: (
     isOpen: boolean,
     duplicate?: { order: Order; fill: Fill },
@@ -153,10 +159,11 @@ function RecentOrders(props: SDKProviderProps) {
   const value: RecentOrdersContextValue = [
     state,
     {
-      setIsCombineDialogOpen(isOpen, createOrder, address) {
+      setIsCombineDialogOpen(isOpen, createOrder, addressId, address) {
         setState({
           isCombineDialogOpen: isOpen,
           ...(createOrder ? { createOrder } : { createOrderCb: undefined }),
+          ...(addressId ? { addressId } : { addressId: undefined }),
           ...(address ? { address } : { address: undefined })
         });
       },

--- a/packages/components/src/systems/RecentOrders/RecentOrdersCombineDialog.tsx
+++ b/packages/components/src/systems/RecentOrders/RecentOrdersCombineDialog.tsx
@@ -42,9 +42,10 @@ const CREATE_ORDER_MUTATION = gql`
   mutation RecentOrdersCombineDialogCreateOrder(
     $patientId: ID!
     $fills: [FillInput!]!
+    $addressId: ID
     $address: AddressInput
   ) {
-    createOrder(patientId: $patientId, fills: $fills, address: $address) {
+    createOrder(patientId: $patientId, fills: $fills, addressId: $addressId, address: $address) {
       id
     }
   }
@@ -61,6 +62,7 @@ type SuccessCreateOrder = { createOrder: SuccessResponse };
 type VariablesCreateOrder = {
   patientId: string;
   fills: { prescriptionId: string }[];
+  addressId?: string;
   address?: Address;
 };
 
@@ -156,7 +158,7 @@ export default function RecentOrdersCombineDialog() {
       // if there is an error updating an order, most likely because the order state has
       // changed since it was first fetched so we need to create a new order
       try {
-        if (!state?.address || !state?.patientId) {
+        if ((!state?.addressId && !state?.address) || !state?.patientId) {
           throw new Error('No address provided');
         }
 
@@ -164,7 +166,7 @@ export default function RecentOrdersCombineDialog() {
           variables: {
             patientId: state.patientId,
             fills,
-            address: state.address
+            ...(state.addressId ? { addressId: state.addressId } : { address: state.address })
           }
         });
 

--- a/packages/elements/index.html
+++ b/packages/elements/index.html
@@ -38,7 +38,7 @@
     >
       <div style="padding: 15px" id="parent">
         <photon-prescribe-workflow
-          patient-id="pat_01G8Y2AVQGM0TCQ4T5V57WTM80"
+          patient-id="pat_01KF4789CC1QH1ERAQKHK44ZQQ"
           optional-patient-address="true"
           enable-order="true"
           enable-med-history="true"

--- a/packages/elements/index.html
+++ b/packages/elements/index.html
@@ -40,6 +40,7 @@
         <photon-prescribe-workflow
           patient-id="pat_01KF40AHFHKG02P786WXJGRVR0"
           optional-patient-address="true"
+          address='{"street1": "123 Main St", "city": "Calistoga", "state": "CA", "postalCode": "94515"}'
           enable-order="true"
           enable-med-history="true"
           enable-med-history-refill-button="true"

--- a/packages/elements/index.html
+++ b/packages/elements/index.html
@@ -38,7 +38,7 @@
     >
       <div style="padding: 15px" id="parent">
         <photon-prescribe-workflow
-          patient-id="pat_01KF4789CC1QH1ERAQKHK44ZQQ"
+          patient-id="pat_01KF40AHFHKG02P786WXJGRVR0"
           optional-patient-address="true"
           enable-order="true"
           enable-med-history="true"

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@photonhealth/elements",
-  "version": "0.19.1",
+  "version": "0.19.2",
   "description": "",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/elements/src/photon-multirx-form-wrapper/photon-multirx-form-wrapper-component.tsx
+++ b/packages/elements/src/photon-multirx-form-wrapper/photon-multirx-form-wrapper-component.tsx
@@ -1,5 +1,6 @@
 import { Button, triggerToast, usePhoton } from '@photonhealth/components';
 import photonStyles from '@photonhealth/components/dist/style.css?inline';
+import { types } from '@photonhealth/sdk';
 import jwtDecode from 'jwt-decode';
 import { customElement } from 'solid-element';
 import { createSignal, onMount } from 'solid-js';
@@ -17,6 +18,26 @@ const shouldWarn = (form: any) =>
   form()['notes']?.value ||
   form()['refillsInput']?.value ||
   form()['treatment']?.value;
+
+const hasUsableAddress = (address?: { id?: string }) => {
+  return Boolean(address?.id);
+};
+
+const fulfillmentNeedsAddress = (fulfillmentType?: string) => {
+  return (
+    fulfillmentType === types.FulfillmentType.PickUp ||
+    fulfillmentType === types.FulfillmentType.MailOrder
+  );
+};
+
+const shouldBlockOrderWithoutAddress = (
+  fulfillmentType?: string,
+  address?: {
+    id?: string;
+  }
+) => {
+  return fulfillmentNeedsAddress(fulfillmentType) && !hasUsableAddress(address);
+};
 
 const Component = (props: {
   enableMedHistory: boolean;
@@ -89,9 +110,25 @@ const Component = (props: {
     ref?.dispatchEvent(event);
   };
 
+  const attemptCreateOrder = () => {
+    const fulfillmentType = form()?.fulfillmentType?.value;
+    const address = form()?.address?.value ?? form()?.patient?.value?.address;
+    if (shouldBlockOrderWithoutAddress(fulfillmentType, address)) {
+      setTriggerSubmit(false);
+      return triggerToast({
+        status: 'error',
+        header: 'Address required',
+        body: 'Please add a patient address to place a local pickup or mail order.'
+      });
+    }
+
+    setIsCreateOrder(true);
+    setTriggerSubmit(true);
+  };
+
   const handleUnsavedConfirm = () => {
     setContinueSubmitOpen(false);
-    setTriggerSubmit(true);
+    attemptCreateOrder();
   };
   const handleUnsavedCancel = () => setContinueSubmitOpen(false);
 
@@ -118,8 +155,7 @@ const Component = (props: {
     }
 
     // else if all good, create the order
-    setIsCreateOrder(true);
-    setTriggerSubmit(true);
+    attemptCreateOrder();
   };
 
   const handleCreatePrescriptions = () => {
@@ -169,8 +205,7 @@ const Component = (props: {
         cancel-text="Yes, save only"
         on:photon-dialog-confirmed={() => {
           setContinueSaveOnly(false);
-          setIsCreateOrder(true);
-          setTriggerSubmit(true);
+          attemptCreateOrder();
         }}
         on:photon-dialog-canceled={() => {
           setContinueSaveOnly(false);

--- a/packages/elements/src/photon-multirx-form/photon-prescribe-workflow.tsx
+++ b/packages/elements/src/photon-multirx-form/photon-prescribe-workflow.tsx
@@ -256,6 +256,12 @@ export function PrescribeWorkflow(props: PrescribeProps) {
     return patientAddress && patientAddress.street1;
   });
 
+  const addressId = createMemo(() => {
+    const patientAddress =
+      props.formStore?.address?.value ?? props.formStore?.patient?.value?.address;
+    return patientAddress?.id;
+  });
+
   const formattedAddress = createMemo(() => {
     // remove unnecessary fields, and add country and street2 if missing
     const patientAddress =
@@ -402,6 +408,7 @@ export function PrescribeWorkflow(props: PrescribeProps) {
     return recentOrdersActions.setIsCombineDialogOpen(
       true,
       () => submitForm(props.enableOrder),
+      addressId(),
       formattedAddress()
     );
   };
@@ -528,7 +535,11 @@ export function PrescribeWorkflow(props: PrescribeProps) {
           patientId: props.formStore.patient?.value.id,
           pharmacyId,
           fulfillmentType: props.formStore.fulfillmentType?.value || '',
-          ...(hasValidAddress() ? { address: formattedAddress() } : {}),
+          ...(addressId()
+            ? { addressId: addressId() }
+            : hasValidAddress()
+            ? { address: formattedAddress() }
+            : {}),
           fills: prescriptionIds().map((id) => ({
             prescriptionId: id
           }))

--- a/packages/elements/src/photon-patient-form/photon-patient-form-component.tsx
+++ b/packages/elements/src/photon-patient-form/photon-patient-form-component.tsx
@@ -215,6 +215,89 @@ const PatientForm = (props: { patientId: string; optionalPatientAddress: boolean
     return prefOption;
   });
 
+  const AddressFields = () => (
+    <>
+      <p class="font-sans text-lg mt-8">
+        Address
+        <Show when={props.optionalPatientAddress && !hasAnyAddressField()}>
+          <span class="text-gray-500 text-sm font-normal"> (optional)</span>
+        </Show>
+      </p>
+      <photon-text-input
+        debounce-time="0"
+        invalid={store['address_street1']?.error}
+        help-text={store['address_street1']?.error}
+        label="Street 1"
+        required={!props.optionalPatientAddress || hasAnyAddressField()}
+        on:photon-input-changed={async (e: any) => {
+          actions.updateFormValue({
+            key: 'address_street1',
+            value: e.detail.input
+          });
+        }}
+        value={store['address_street1']?.value ?? pStore.selectedPatient.data?.address?.street1}
+      />
+      <photon-text-input
+        debounce-time="0"
+        invalid={store['address_street2']?.error}
+        help-text={store['address_street2']?.error}
+        label="Street 2"
+        on:photon-input-changed={async (e: any) => {
+          actions.updateFormValue({
+            key: 'address_street2',
+            value: e.detail.input
+          });
+        }}
+        value={store['address_street2']?.value ?? pStore.selectedPatient.data?.address?.street2}
+      />
+      <photon-text-input
+        debounce-time="0"
+        invalid={store['address_city']?.error}
+        help-text={store['address_city']?.error}
+        label="City"
+        required={!props.optionalPatientAddress || hasAnyAddressField()}
+        on:photon-input-changed={async (e: any) => {
+          actions.updateFormValue({
+            key: 'address_city',
+            value: e.detail.input
+          });
+        }}
+        value={store['address_city']?.value ?? pStore.selectedPatient.data?.address?.city}
+      />
+      <div class="flex gap-4">
+        <photon-state-input
+          class="flex-grow min-w-[40%]"
+          label="State"
+          required={!props.optionalPatientAddress || hasAnyAddressField()}
+          help-text={store['address_state']?.error}
+          invalid={store['address_state']?.error !== undefined}
+          on:photon-state-selected={(e: any) => {
+            actions.updateFormValue({
+              key: 'address_state',
+              value: e.detail.state
+            });
+          }}
+          selected={store['state']?.value ?? pStore.selectedPatient.data?.address?.state}
+        />
+        <photon-text-input
+          debounce-time="0"
+          class="flex-grow min-w-[40%]"
+          invalid={store['address_zip']?.error}
+          help-text={store['address_zip']?.error}
+          label="Zip code"
+          required={!props.optionalPatientAddress || hasAnyAddressField()}
+          on:photon-input-changed={async (e: any) => {
+            actions.updateFormValue({
+              key: 'address_zip',
+              value: e.detail.input
+            });
+          }}
+          value={store['address_zip']?.value ?? pStore.selectedPatient.data?.address?.postalCode}
+        />
+      </div>
+    </>
+  );
+
   return (
     <div class="w-full h-full relative" ref={ref}>
       <style>{tailwind}</style>
@@ -316,91 +399,9 @@ const PatientForm = (props: { patientId: string; optionalPatientAddress: boolean
                     selected={pStore.selectedPatient.data?.sex}
                   />
                 </div>
-                <p class="font-sans text-lg mt-8">
-                  Address
-                  <Show when={props.optionalPatientAddress && !hasAnyAddressField()}>
-                    <span class="text-gray-500 text-sm font-normal"> (optional)</span>
-                  </Show>
-                </p>
-                <photon-text-input
-                  debounce-time="0"
-                  invalid={store['address_street1']?.error}
-                  help-text={store['address_street1']?.error}
-                  label="Street 1"
-                  required={!props.optionalPatientAddress || hasAnyAddressField()}
-                  on:photon-input-changed={async (e: any) => {
-                    actions.updateFormValue({
-                      key: 'address_street1',
-                      value: e.detail.input
-                    });
-                  }}
-                  value={
-                    store['address_street1']?.value ?? pStore.selectedPatient.data?.address?.street1
-                  }
-                />
-                <photon-text-input
-                  debounce-time="0"
-                  invalid={store['address_street2']?.error}
-                  help-text={store['address_street2']?.error}
-                  label="Street 2"
-                  on:photon-input-changed={async (e: any) => {
-                    actions.updateFormValue({
-                      key: 'address_street2',
-                      value: e.detail.input
-                    });
-                  }}
-                  value={
-                    store['address_street2']?.value ?? pStore.selectedPatient.data?.address?.street2
-                  }
-                />
-                <photon-text-input
-                  debounce-time="0"
-                  invalid={store['address_city']?.error}
-                  help-text={store['address_city']?.error}
-                  label="City"
-                  required={!props.optionalPatientAddress || hasAnyAddressField()}
-                  on:photon-input-changed={async (e: any) => {
-                    actions.updateFormValue({
-                      key: 'address_city',
-                      value: e.detail.input
-                    });
-                  }}
-                  value={store['address_city']?.value ?? pStore.selectedPatient.data?.address?.city}
-                />
-                <div class="flex gap-4">
-                  <photon-state-input
-                    class="flex-grow min-w-[40%]"
-                    label="State"
-                    required={!props.optionalPatientAddress || hasAnyAddressField()}
-                    help-text={store['address_state']?.error}
-                    invalid={store['address_state']?.error !== undefined}
-                    on:photon-state-selected={(e: any) => {
-                      actions.updateFormValue({
-                        key: 'address_state',
-                        value: e.detail.state
-                      });
-                    }}
-                    selected={store['state']?.value ?? pStore.selectedPatient.data?.address?.state}
-                  />
-                  <photon-text-input
-                    debounce-time="0"
-                    class="flex-grow min-w-[40%]"
-                    invalid={store['address_zip']?.error}
-                    help-text={store['address_zip']?.error}
-                    label="Zip code"
-                    required={!props.optionalPatientAddress || hasAnyAddressField()}
-                    on:photon-input-changed={async (e: any) => {
-                      actions.updateFormValue({
-                        key: 'address_zip',
-                        value: e.detail.input
-                      });
-                    }}
-                    value={
-                      store['address_zip']?.value ??
-                      pStore.selectedPatient.data?.address?.postalCode
-                    }
-                  />
-                </div>
+                <Show when={!props.optionalPatientAddress}>
+                  <AddressFields />
+                </Show>
                 <button
                   class="mb-4 flex items-center md:!hidden"
                   onClick={() => setShowOptionalFields((value) => !value)}
@@ -413,6 +414,9 @@ const PatientForm = (props: { patientId: string; optionalPatientAddress: boolean
                   />
                 </button>
                 <div class={`mb-4 ${showOptionalFields() ? 'block' : 'hidden md:!block'}`}>
+                  <Show when={props.optionalPatientAddress}>
+                    <AddressFields />
+                  </Show>
                   <photon-gender-input
                     label="Gender"
                     required="false"

--- a/packages/elements/src/stores/patient.ts
+++ b/packages/elements/src/stores/patient.ts
@@ -21,6 +21,7 @@ const PATIENT_ORDER_FIELDS = gql`
     email
     phone
     address {
+      id
       name {
         full
       }

--- a/packages/sdk/src/clinical/order.ts
+++ b/packages/sdk/src/clinical/order.ts
@@ -139,6 +139,7 @@ export class OrderQueryManager {
         $externalId: ID
         $patientId: ID!
         $fills: [FillInput!]!
+        $addressId: ID
         $address: AddressInput
         $pharmacyId: ID
         $groupId: ID
@@ -147,6 +148,7 @@ export class OrderQueryManager {
           externalId: $externalId
           patientId: $patientId
           fills: $fills
+          addressId: $addressId
           address: $address
           pharmacyId: $pharmacyId
           groupId: $groupId

--- a/packages/sdk/src/fragments.ts
+++ b/packages/sdk/src/fragments.ts
@@ -20,6 +20,7 @@ export const PATIENT_FIELDS = gql`
     email
     phone
     address {
+      id
       name {
         full
       }

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -22,6 +22,7 @@ export type Scalars = {
 
 export type Address = {
   __typename?: 'Address';
+  id?: Maybe<Scalars['ID']>;
   city: Scalars['String'];
   country: Scalars['String'];
   name?: Maybe<Name>;
@@ -255,7 +256,8 @@ export type MutationAddToCatalogArgs = {
 };
 
 export type MutationCreateOrderArgs = {
-  address: AddressInput;
+  address?: InputMaybe<AddressInput>;
+  addressId?: InputMaybe<Scalars['ID']>;
   externalId?: InputMaybe<Scalars['ID']>;
   fills: Array<FillInput>;
   patientId: Scalars['ID'];


### PR DESCRIPTION
Sorry this probably should have been 3 different PRs.

- Frontend passes addressId on createOrder API call instead of full address
- Save button spins endlessly when selecting local pickup w/ empty address form 
- Address fields go in optional fields on mobile 

P H O 135