### PR TITLE
Disable google tag manager

### DIFF
--- a/apps/app/public/index.html
+++ b/apps/app/public/index.html
@@ -28,14 +28,14 @@
     <title>Photon</title>
   </head>
   <!-- Google tag (gtag.js) -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=%REACT_APP_GOOGLE_TAG_ID%"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
+<!--  <script async src="https://www.googletagmanager.com/gtag/js?id=%REACT_APP_GOOGLE_TAG_ID%"></script>-->
+<!--  <script>-->
+<!--    window.dataLayer = window.dataLayer || [];-->
+<!--    function gtag(){dataLayer.push(arguments);}-->
+<!--    gtag('js', new Date());-->
 
-    gtag('config', '%REACT_APP_GOOGLE_TAG_ID%');
-  </script>
+<!--    gtag('config', '%REACT_APP_GOOGLE_TAG_ID%');-->
+<!--  </script>-->
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>


### PR DESCRIPTION
I believe this is causing the `Script error.` spam in RUM. Going to disable to confirm. No one seems to be using this data anyway.

<img width="1218" height="889" alt="image" src="https://github.com/user-attachments/assets/d62b1306-f6fb-478d-97f1-39942afc8c83" />
