### PR TITLE
fixing critical vuln

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4243,6 +4243,24 @@
         "node": ">=14"
       }
     },
+    "node_modules/@datadog/datadog-ci/node_modules/form-data": {
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.4.tgz",
+      "integrity": "sha512-Y/3MmRiR8Nd+0CUtrbvcKtKzLWiUfpQ7DFVggH8PwmGt/0r7RSy32GuP4hpCJlQNEBusisSx1DLtD8uD386HJQ==",
+      "deprecated": "This version has an incorrect dependency; please use v2.5.5",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "has-own": "^1.0.1",
+        "mime-types": "^2.1.35",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.12"
+      }
+    },
     "node_modules/@datadog/datadog-ci/node_modules/rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -22961,12 +22979,15 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
         "mime-types": "^2.1.12"
       },
       "engines": {
@@ -24059,6 +24080,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/has-own": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-own/-/has-own-1.0.1.tgz",
+      "integrity": "sha512-RDKhzgQTQfMaLvIFhjahU+2gGnRBK6dYOd5Gd9BzkmnBneOCRYjRC003RIMrdAbH52+l+CnMS4bBCXGer8tEhg==",
+      "deprecated": "This project is not maintained. Use Object.hasOwn() instead.",
+      "license": "MIT"
     },
     "node_modules/has-property-descriptors": {
       "version": "1.0.2",
@@ -37914,22 +37942,6 @@
       },
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      }
-    },
-    "node_modules/react-scripts/node_modules/form-data": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.4.tgz",
-      "integrity": "sha512-f0cRzm6dkyVYV3nPoooP8XlccPQukegwhAnpoLcXy+X+A8KfpGOoXwDr9FLZd3wzgLaBGQBE3lY93Zm/i1JvIQ==",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.35"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/react-scripts/node_modules/fs-extra": {

--- a/package.json
+++ b/package.json
@@ -183,7 +183,23 @@
     "@chakra-ui/react": {
       "@zag-js/focus-visible": "^1.18.0"
     },
+    "@datadog/datadog-ci": { "form-data": "2.5.4" },
+    "@nx/cypress": { "form-data": "4.0.4" },
+    "@nx/eslint-plugin": { "form-data": "4.0.4" },
+    "@nx/jest": { "form-data": "4.0.4" },
+    "@nx/js": { "form-data": "4.0.4" },
+    "@nx/react": { "form-data": "4.0.4" },
+    "@nx/webpack": { "form-data": "4.0.4" },
+    "@nx/workspace": { "form-data": "4.0.4" },
+    "@storybook/addon-essentials": { "form-data": "4.0.4" },
+    "@storybook/blocks": { "form-data": "4.0.4" },
+    "@storybook/html": { "form-data": "4.0.4" },
+    "@storybook/html-vite": { "form-data": "4.0.4" },
     "graphql-request": { "form-data": "3.0.4" },
-    "react-scripts": { "form-data": "3.0.4" }
+    "jest-environment-jsdom": { "form-data": "4.0.4" },
+    "jsdom": { "form-data": "4.0.4" },
+    "nx": { "form-data": "4.0.4" },
+    "react-scripts": { "form-data": "3.0.4" },
+    "storybook": { "form-data": "4.0.4" }
   }
 }


### PR DESCRIPTION
this is the safest way to get rid of the critical vuln - by manually declaring things as an override for specific package.

longer term (more correct) wayt o do this is to :

-update @datadog to whichever version uses form-data 2.5.4 of form-data, then remove the overrides
- update @nx, @storybook, jsdom, to whichever version uses 4.0.4 of form-data, then remove the overrides
- update graphql-scripts, graph-ql request, react-scripts, to whichever version uses 3.0.4, then remove the overrides

once this goes through i'll make tickets for those