### PR TITLE
move more code into DraftPrescriptionsProvider

### DIFF
--- a/packages/components/dev/App.tsx
+++ b/packages/components/dev/App.tsx
@@ -83,14 +83,14 @@ const App = () => {
           />
         </div>
         <PrescribeEventDispatchProvider>
-          <DraftPrescriptionsProvider
-            patientId={patientId}
-            templateIdsPrefill={[]}
-            templateOverrides={{}}
-            prescriptionIdsPrefill={prescriptionIds()}
-            enableCombineAndDuplicate={true}
-          >
-            <RecentOrders patientId={patientId}>
+          <RecentOrders patientId={patientId}>
+            <DraftPrescriptionsProvider
+              patientId={patientId}
+              templateIdsPrefill={[]}
+              templateOverrides={{}}
+              prescriptionIdsPrefill={prescriptionIds()}
+              enableCombineAndDuplicate={true}
+            >
               <PrescribeProvider patientId={patientId} enableCoverageCheck={true}>
                 <div class="mb-10">
                   <h2>Patient Info</h2>
@@ -112,8 +112,8 @@ const App = () => {
                   routingConstraints={[]}
                 />
               </PrescribeProvider>
-            </RecentOrders>
-          </DraftPrescriptionsProvider>
+            </DraftPrescriptionsProvider>
+          </RecentOrders>
         </PrescribeEventDispatchProvider>
 
         <div class="mb-10">

--- a/packages/components/dev/App.tsx
+++ b/packages/components/dev/App.tsx
@@ -83,16 +83,15 @@ const App = () => {
           />
         </div>
         <PrescribeEventDispatchProvider>
-          <DraftPrescriptionsProvider>
+          <DraftPrescriptionsProvider
+            patientId={patientId}
+            templateIdsPrefill={[]}
+            templateOverrides={{}}
+            prescriptionIdsPrefill={prescriptionIds()}
+            enableCombineAndDuplicate={true}
+          >
             <RecentOrders patientId={patientId}>
-              <PrescribeProvider
-                templateIdsPrefill={[]}
-                templateOverrides={{}}
-                prescriptionIdsPrefill={prescriptionIds()}
-                patientId={patientId}
-                enableCombineAndDuplicate={true}
-                enableCoverageCheck={true}
-              >
+              <PrescribeProvider patientId={patientId} enableCoverageCheck={true}>
                 <div class="mb-10">
                   <h2>Patient Info</h2>
                   <PatientInfo patientId="pat_01JEVF5DWQAQFHTVYK9ABG65JZ" />

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -7,7 +7,10 @@ import ComboBox from './particles/ComboBox';
 import {
   DraftPrescriptionList,
   DraftPrescriptionsProvider,
-  useDraftPrescriptions
+  useDraftPrescriptions,
+  type PrescriptionFormData,
+  type TemplateOverrides,
+  type TryCreatePrescriptionTemplateOptions
 } from './systems/DraftPrescriptions';
 import Icon from './particles/Icon';
 import PatientInfo from './systems/PatientInfo';
@@ -43,13 +46,7 @@ import { PhotonClientStore } from './store';
 
 export { usePhoton, PhotonClientStore, PhotonContext };
 
-import {
-  CoverageOption,
-  PrescribeProvider,
-  usePrescribe,
-  type PrescriptionFormData,
-  type TemplateOverrides
-} from './systems/PrescribeProvider';
+import { CoverageOption, PrescribeProvider, usePrescribe } from './systems/PrescribeProvider';
 
 import { GoogleServiceProvider, useGoogleService } from './systems/GoogleServiceProvider';
 
@@ -107,5 +104,6 @@ export type {
   RoutingConstraint,
   TemplateOverrides,
   PrescriptionFormData,
-  CoverageOption
+  CoverageOption,
+  TryCreatePrescriptionTemplateOptions
 };

--- a/packages/components/src/systems/DraftPrescriptions/DraftPrescriptionList.tsx
+++ b/packages/components/src/systems/DraftPrescriptions/DraftPrescriptionList.tsx
@@ -19,8 +19,8 @@ interface DraftPrescriptionsProps {
 }
 
 export function DraftPrescriptionList(props: DraftPrescriptionsProps) {
-  const { draftPrescriptions } = useDraftPrescriptions();
-  const { isLoadingPrefills, prescriptionIds, coverageOptions } = usePrescribe();
+  const { draftPrescriptions, prescriptionIds } = useDraftPrescriptions();
+  const { isLoadingPrefills, coverageOptions } = usePrescribe();
   const prescriptionRoutingConstraints = createMemo((): Map<string, RoutingConstraint> => {
     return getPrescriptionRoutingConstraints(props.routingConstraints);
   });

--- a/packages/components/src/systems/DraftPrescriptions/DraftPrescriptionList.tsx
+++ b/packages/components/src/systems/DraftPrescriptions/DraftPrescriptionList.tsx
@@ -3,8 +3,8 @@ import Banner from '../../particles/Banner';
 import Text from '../../particles/Text';
 import { ScreeningAlertType } from '../ScreeningAlerts';
 import { RoutingConstraint, getPrescriptionRoutingConstraints } from '../RoutingConstraints';
-import { useDraftPrescriptions } from './DraftPrescriptionsProvider';
-import { CoverageOption, PrescriptionFormData, usePrescribe } from '../PrescribeProvider';
+import { PrescriptionFormData, useDraftPrescriptions } from './DraftPrescriptionsProvider';
+import { CoverageOption, usePrescribe } from '../PrescribeProvider';
 import { DraftPrescriptionLayout, DraftPrescriptionListItem } from './DraftPrescriptionListItem';
 import Divider from '../../particles/Divider';
 
@@ -19,8 +19,8 @@ interface DraftPrescriptionsProps {
 }
 
 export function DraftPrescriptionList(props: DraftPrescriptionsProps) {
-  const { draftPrescriptions, prescriptionIds } = useDraftPrescriptions();
-  const { isLoadingPrefills, coverageOptions } = usePrescribe();
+  const { isLoadingPrefills, draftPrescriptions, prescriptionIds } = useDraftPrescriptions();
+  const { coverageOptions } = usePrescribe();
   const prescriptionRoutingConstraints = createMemo((): Map<string, RoutingConstraint> => {
     return getPrescriptionRoutingConstraints(props.routingConstraints);
   });

--- a/packages/components/src/systems/DraftPrescriptions/DraftPrescriptionListItem.tsx
+++ b/packages/components/src/systems/DraftPrescriptions/DraftPrescriptionListItem.tsx
@@ -5,10 +5,11 @@ import Text from '../../particles/Text';
 import formatRxString from '../../utils/formatRxString';
 import { ScreeningAlerts, ScreeningAlertType } from '../ScreeningAlerts';
 import { RoutingConstraint, PrescriptionRoutingAlert } from '../RoutingConstraints';
-import { CoverageOption, PrescriptionFormData } from '../PrescribeProvider';
+import { CoverageOption } from '../PrescribeProvider';
 import { CoverageOptionSummary } from './CoverageOptions/CoverageOptionSummary';
 import { OtherCoverageOptionsList } from './CoverageOptions/OtherCoverageOptionsList';
 import { toPrescriptionFormData } from './utils/mappers';
+import { PrescriptionFormData } from './DraftPrescriptionsProvider';
 
 interface DraftPrescriptionListItemProps {
   draft: Prescription;

--- a/packages/components/src/systems/DraftPrescriptions/DraftPrescriptionsProvider.tsx
+++ b/packages/components/src/systems/DraftPrescriptions/DraftPrescriptionsProvider.tsx
@@ -1,9 +1,19 @@
-import { Accessor, createContext, createSignal, JSXElement, Setter, useContext } from 'solid-js';
+import {
+  Accessor,
+  createContext,
+  createMemo,
+  createSignal,
+  JSXElement,
+  Setter,
+  useContext
+} from 'solid-js';
 import { Prescription } from '@photonhealth/sdk/dist/types';
 
 const DraftPrescriptionsContext = createContext<{
   // values
   draftPrescriptions: Accessor<Prescription[]>;
+  prescriptionIds: Accessor<string[]>;
+
   // actions
   setDraftPrescriptions: Setter<Prescription[]>;
 }>();
@@ -15,9 +25,14 @@ interface DraftPrescriptionProviderProps {
 export const DraftPrescriptionsProvider = (props: DraftPrescriptionProviderProps) => {
   const [draftPrescriptions, setDraftPrescriptions] = createSignal<Prescription[]>([]);
 
+  const prescriptionIds = createMemo(() =>
+    draftPrescriptions().map((prescription) => prescription.id)
+  );
+
   const value = {
     // values
     draftPrescriptions,
+    prescriptionIds,
     // actions
     setDraftPrescriptions
   };

--- a/packages/components/src/systems/DraftPrescriptions/DraftPrescriptionsProvider.tsx
+++ b/packages/components/src/systems/DraftPrescriptions/DraftPrescriptionsProvider.tsx
@@ -173,6 +173,10 @@ export const DraftPrescriptionsProvider = (props: DraftPrescriptionProviderProps
       }
     } catch (error) {
       console.error('Error while trying to create prescriptions from prefill IDs', { error });
+      triggerToast({
+        status: 'error',
+        body: 'There was an issue creating prescriptions from prefill IDs. Please check your configuration.'
+      });
     } finally {
       setIsLoadingPrefills(false);
     }

--- a/packages/components/src/systems/DraftPrescriptions/DraftPrescriptionsProvider.tsx
+++ b/packages/components/src/systems/DraftPrescriptions/DraftPrescriptionsProvider.tsx
@@ -25,7 +25,7 @@ import {
 } from '../../fetch';
 import triggerToast from '../../utils/toastTriggers';
 
-const DraftPrescriptionsContext = createContext<{
+export type DraftPrescriptionsContextType = {
   // values
   draftPrescriptions: Accessor<Prescription[]>;
   prescriptionIds: Accessor<string[]>;
@@ -39,7 +39,9 @@ const DraftPrescriptionsContext = createContext<{
   ) => Promise<Prescription>;
   deletePrescription: (id: string) => void;
   tryUpdatePrescriptionStates: (ids: string[], state: PrescriptionState) => Promise<boolean>;
-}>();
+};
+
+const DraftPrescriptionsContext = createContext<DraftPrescriptionsContextType>();
 
 interface DraftPrescriptionProviderProps {
   children: JSXElement;

--- a/packages/components/src/systems/DraftPrescriptions/DraftPrescriptionsProvider.tsx
+++ b/packages/components/src/systems/DraftPrescriptions/DraftPrescriptionsProvider.tsx
@@ -1,40 +1,338 @@
 import {
   Accessor,
   createContext,
+  createEffect,
   createMemo,
   createSignal,
   JSXElement,
   Setter,
   useContext
 } from 'solid-js';
-import { Prescription } from '@photonhealth/sdk/dist/types';
+import {
+  MutationCreatePrescriptionsArgs,
+  Prescription,
+  PrescriptionState
+} from '@photonhealth/sdk/dist/types';
+import { usePrescribeEventDispatch } from '../PrescribeEventDispatchProvider';
+import { useRecentOrders } from '../RecentOrders';
+import { usePhotonClient } from '../SDKProvider';
+import {
+  CreatePrescription,
+  CreatePrescriptions,
+  CreatePrescriptionTemplate,
+  GetPrescription,
+  UpdatePrescriptionStates
+} from '../../fetch';
+import triggerToast from '../../utils/toastTriggers';
 
 const DraftPrescriptionsContext = createContext<{
   // values
   draftPrescriptions: Accessor<Prescription[]>;
   prescriptionIds: Accessor<string[]>;
+  isLoadingPrefills: Accessor<boolean>;
 
   // actions
   setDraftPrescriptions: Setter<Prescription[]>;
+  tryCreatePrescription: (
+    prescriptionFormData: PrescriptionFormData,
+    options?: TryCreatePrescriptionTemplateOptions
+  ) => Promise<Prescription>;
+  deletePrescription: (id: string) => void;
+  tryUpdatePrescriptionStates: (ids: string[], state: PrescriptionState) => Promise<boolean>;
 }>();
 
 interface DraftPrescriptionProviderProps {
   children: JSXElement;
+  patientId: string;
+  templateIdsPrefill: string[];
+  templateOverrides: TemplateOverrides;
+  prescriptionIdsPrefill: string[];
+  enableCombineAndDuplicate: boolean;
+}
+
+export type TemplateOverrides = {
+  [key: string]: {
+    daysSupply?: number;
+    dispenseAsWritten?: boolean;
+    dispenseQuantity?: number;
+    dispenseUnit?: string;
+    fillsAllowed?: number;
+    instructions?: string;
+    notes?: string;
+    externalId?: string;
+  };
+};
+
+export type PrescriptionFormData = {
+  id?: string;
+  doNotFillBeforeDate?: string;
+  treatment: {
+    id: string;
+    name: string;
+  };
+  dispenseAsWritten: boolean;
+  dispenseQuantity?: number;
+  dispenseUnit?: string;
+  daysSupply?: number;
+  instructions: string;
+  notes: string;
+  fillsAllowed?: number;
+  catalogId?: string;
+  externalId?: string;
+  diagnoseCodes: string[];
+};
+
+const transformPrescriptionFormData = (prescription: PrescriptionFormData, patientId: string) => ({
+  externalId: prescription.externalId,
+  patientId: patientId,
+  treatmentId: prescription.treatment?.id,
+  dispenseAsWritten: prescription.dispenseAsWritten,
+  dispenseQuantity: prescription.dispenseQuantity,
+  dispenseUnit: prescription.dispenseUnit,
+  fillsAllowed: prescription.fillsAllowed,
+  daysSupply: prescription.daysSupply,
+  instructions: prescription.instructions,
+  notes: prescription.notes,
+  doNotFillBeforeDate: prescription.doNotFillBeforeDate,
+  diagnoses: prescription.diagnoseCodes
+});
+
+export type TryCreatePrescriptionTemplateOptions = {
+  addToTemplates?: boolean;
+  templateName?: string;
+  catalogId?: string;
+  showSuccessToast?: boolean;
+};
+
+function isTreatmentInDraftPrescriptions(
+  treatmentId: string,
+  draftedPrescriptions: { treatment: { id: string } }[]
+) {
+  return draftedPrescriptions.some((draft) => draft.treatment.id === treatmentId);
 }
 
 export const DraftPrescriptionsProvider = (props: DraftPrescriptionProviderProps) => {
+  const { dispatchDraftPrescriptionCreated } = usePrescribeEventDispatch();
+  const [, recentOrdersActions] = useRecentOrders();
+  const client = usePhotonClient();
+  const [hasCreatedPrescriptions, setHasCreatedPrescriptions] = createSignal<boolean>(false);
+  const [isLoadingPrefills, setIsLoadingPrefills] = createSignal<boolean>(false);
+
   const [draftPrescriptions, setDraftPrescriptions] = createSignal<Prescription[]>([]);
 
   const prescriptionIds = createMemo(() =>
     draftPrescriptions().map((prescription) => prescription.id)
   );
 
+  // Prefill new prescriptions based on templateIds or prescriptionIds when we get a patientId
+  createEffect(() => {
+    if (
+      // must have templateIds or prescriptionIds to create prescriptions
+      (props.templateIdsPrefill.length > 0 || props.prescriptionIdsPrefill.length > 0) &&
+      // must have a patientId
+      !!props.patientId &&
+      // must not have created prescriptions yet
+      !hasCreatedPrescriptions()
+    ) {
+      createPrescriptionsFromIds();
+    }
+  });
+
+  async function createPrescriptionsFromIds() {
+    setHasCreatedPrescriptions(true);
+    setIsLoadingPrefills(true);
+
+    try {
+      // Create prescriptions from template ids with a few optional override values
+      if (props.templateIdsPrefill.length > 0) {
+        const dedupedTemplateIds = Array.from(new Set(props.templateIdsPrefill));
+        const templatedCreateRxList = dedupedTemplateIds.map((templateId) => ({
+          ...props.templateOverrides?.[templateId],
+          patientId: props.patientId,
+          templateId
+        }));
+
+        await createPrescriptionsOnApi(templatedCreateRxList);
+      }
+
+      // Fetch prescriptions if needed
+      if (props.prescriptionIdsPrefill.length > 0) {
+        const fetchedPrescriptions = await Promise.all(
+          props.prescriptionIdsPrefill.map(async (prescriptionId: string) => {
+            const { data } = await client.apollo.query({
+              query: GetPrescription,
+              variables: { id: prescriptionId }
+            });
+            return transformPrescriptionFormData(data?.prescription, props.patientId);
+          })
+        );
+
+        await createPrescriptionsOnApi(fetchedPrescriptions);
+      }
+    } catch (error) {
+      console.error('Error while trying to create prescriptions from prefill IDs', { error });
+    } finally {
+      setIsLoadingPrefills(false);
+    }
+  }
+
+  const tryCreatePrescription = async (
+    prescriptionFormData: PrescriptionFormData,
+    options: TryCreatePrescriptionTemplateOptions = { showSuccessToast: true }
+  ): Promise<Prescription> => {
+    const isPrescriptionAlreadyAdded = isTreatmentInDraftPrescriptions(
+      prescriptionFormData.treatment.id,
+      draftPrescriptions()
+    );
+
+    if (isPrescriptionAlreadyAdded) {
+      triggerToast({
+        status: 'error',
+        body: 'You already have this prescription in your order. You can modify the prescription or delete it in Pending Order.'
+      });
+
+      throw new Error('Prescription already added');
+    }
+
+    const duplicateFill = recentOrdersActions.checkDuplicateFill(
+      prescriptionFormData.treatment.name
+    );
+
+    if (props.enableCombineAndDuplicate && duplicateFill) {
+      // if there's a duplicate order, check first if they want to report an issue
+      await new Promise<void>((resolve, reject) => {
+        recentOrdersActions.setIsDuplicateDialogOpen(true, duplicateFill, resolve, reject);
+      });
+    }
+
+    return await createPrescriptionOnApi(prescriptionFormData, options);
+  };
+
+  const createPrescriptionOnApi = async (
+    prescriptionFormData: PrescriptionFormData,
+    options: TryCreatePrescriptionTemplateOptions = {
+      addToTemplates: false,
+      showSuccessToast: true
+    }
+  ): Promise<Prescription> => {
+    let createdPrescription: Prescription | null = null;
+
+    try {
+      const res = await client.apollo.mutate({
+        mutation: CreatePrescription,
+        variables: transformPrescriptionFormData(prescriptionFormData, props.patientId)
+      });
+      const created = res.data.createPrescription as Prescription;
+      createdPrescription = created;
+      setDraftPrescriptions((prev) => [...prev, created]);
+      dispatchDraftPrescriptionCreated(created);
+    } catch (error) {
+      console.error('Mutation error:', error);
+      triggerToast({
+        status: 'error',
+        header: 'Error Adding Prescription',
+        body: 'There was an issue adding the prescription. Please try again.'
+      });
+      throw error;
+    }
+
+    if (options?.addToTemplates && options?.catalogId != null) {
+      await createPrescriptionTemplateOnApi(
+        prescriptionFormData,
+        options.catalogId,
+        options.templateName
+      );
+
+      if (options.showSuccessToast) {
+        triggerToast({
+          status: 'success',
+          header: 'Personal Template Saved'
+        });
+      }
+    }
+
+    if (options.showSuccessToast) {
+      triggerToast({
+        status: 'success',
+        header: 'Prescription Added',
+        body: 'You can send this order or add another prescription before sending it'
+      });
+    }
+
+    return createdPrescription;
+  };
+
+  const createPrescriptionsOnApi = async (
+    prescriptions: MutationCreatePrescriptionsArgs['prescriptions']
+  ) => {
+    const res = await client.apollo.mutate({
+      mutation: CreatePrescriptions,
+      variables: { prescriptions }
+    });
+    const newRxs = res.data.createPrescriptions as Prescription[];
+    setDraftPrescriptions((prev) => [...prev, ...newRxs]);
+    newRxs.map((rx) => dispatchDraftPrescriptionCreated(rx));
+  };
+
+  const createPrescriptionTemplateOnApi = async (
+    prescription: PrescriptionFormData,
+    catalogId: string,
+    templateName = ''
+  ) => {
+    const res = await client.apollo.mutate({
+      mutation: CreatePrescriptionTemplate,
+      variables: {
+        ...transformPrescriptionFormData(prescription, props.patientId),
+        catalogId,
+        isPrivate: true,
+        ...(templateName ? { name: templateName } : {})
+      }
+    });
+    return res;
+  };
+
+  const deletePrescription = (toDeleteId: string) => {
+    setDraftPrescriptions((prev) => prev.filter((rx) => rx.id !== toDeleteId));
+  };
+
+  const tryUpdatePrescriptionStates = async (
+    ids: string[],
+    state: PrescriptionState
+  ): Promise<boolean> => {
+    try {
+      const res = await client.apolloClinical.mutate({
+        mutation: UpdatePrescriptionStates,
+        variables: {
+          input: {
+            ids,
+            state
+          }
+        }
+      });
+
+      return res.data.updatePrescriptionStates as boolean;
+    } catch (error) {
+      console.error('Mutation error:', error);
+      triggerToast({
+        status: 'error',
+        header: 'Error Saving Prescription(s)',
+        body: (error as Error).message
+      });
+      throw error;
+    }
+  };
+
   const value = {
     // values
     draftPrescriptions,
     prescriptionIds,
+    isLoadingPrefills,
+
     // actions
-    setDraftPrescriptions
+    setDraftPrescriptions,
+    tryCreatePrescription,
+    tryUpdatePrescriptionStates,
+    deletePrescription
   };
 
   return (
@@ -50,4 +348,8 @@ export const useDraftPrescriptions = () => {
     throw new Error("can't find DraftPrescriptionsContext");
   }
   return context;
+};
+
+export const useDraftPrescriptionsOptional = () => {
+  return useContext(DraftPrescriptionsContext);
 };

--- a/packages/components/src/systems/DraftPrescriptions/utils/mappers.ts
+++ b/packages/components/src/systems/DraftPrescriptions/utils/mappers.ts
@@ -1,5 +1,5 @@
 import { Prescription } from '@photonhealth/sdk/dist/types';
-import { PrescriptionFormData } from '../../PrescribeProvider';
+import { PrescriptionFormData } from '../DraftPrescriptionsProvider';
 
 export function toPrescriptionFormData(
   prescription: Prescription,

--- a/packages/components/src/systems/PatientMedHistory/PatientMedHistory.test.tsx
+++ b/packages/components/src/systems/PatientMedHistory/PatientMedHistory.test.tsx
@@ -3,14 +3,14 @@ import PatientMedHistory, { GetPatientResponse } from './index';
 import { vi } from 'vitest';
 import { MockPhotonClient, MockSDKProvider } from '../TestMocks/MockSDKProvider';
 import { PhotonClient } from '@photonhealth/sdk';
-import {
-  MockPrescribeContext,
-  mockPrescribeContextValues,
-  MockPrescribeProvider
-} from '../TestMocks/MockPrescribeProvider';
 import userEvent from '@testing-library/user-event';
 import { Prescription } from '@photonhealth/sdk/dist/types';
 import { useContext } from 'solid-js';
+import {
+  MockDraftPrescriptionsContext,
+  mockDraftPrescriptionsContextValues,
+  MockDraftPrescriptionsProvider
+} from '../TestMocks/MockDraftPrescriptionsProvider';
 
 vi.mock('../SDKProvider', () => ({
   usePhotonClient: () => new MockPhotonClient()
@@ -18,7 +18,7 @@ vi.mock('../SDKProvider', () => ({
 
 vi.mock('../PrescribeProvider', () => {
   return {
-    usePrescribeOptional: () => useContext(MockPrescribeContext)
+    useDraftPrescriptionsOptional: () => useContext(MockDraftPrescriptionsContext)
   };
 });
 
@@ -60,7 +60,7 @@ test('PatientMedHistory renders without PrescribeContext', async () => {
 test('PatientMedHistory allows refills', async () => {
   const user = userEvent.setup();
   const mockClient = new MockPhotonClient();
-  const mockPrescribeFunctions = mockPrescribeContextValues();
+  const mockContextValues = mockDraftPrescriptionsContextValues();
 
   createQueryMock.mockReturnValueOnce(() =>
     generatePatientMedHistoryResponse([
@@ -73,13 +73,13 @@ test('PatientMedHistory allows refills', async () => {
 
   render(() => (
     <MockSDKProvider client={mockClient as unknown as PhotonClient}>
-      <MockPrescribeProvider mockFunctions={mockPrescribeFunctions}>
+      <MockDraftPrescriptionsProvider mockValues={mockContextValues}>
         <PatientMedHistory
           patientId="test-patient-id"
           enableLinks={false}
           enableRefillButton={true}
         />
-      </MockPrescribeProvider>
+      </MockDraftPrescriptionsProvider>
     </MockSDKProvider>
   ));
 
@@ -87,13 +87,13 @@ test('PatientMedHistory allows refills', async () => {
   expect(refillButton).not.toBeDisabled();
   await user.click(refillButton);
 
-  expect(mockPrescribeFunctions.tryCreatePrescription).toHaveBeenCalledTimes(1);
+  expect(mockContextValues.tryCreatePrescription).toHaveBeenCalledTimes(1);
 });
 
 test('PatientMedHistory disables External Medication refill button', async () => {
   const user = userEvent.setup();
   const mockClient = new MockPhotonClient();
-  const mockPrescribeFunctions = mockPrescribeContextValues();
+  const mockContextValues = mockDraftPrescriptionsContextValues();
 
   createQueryMock.mockReturnValueOnce(() =>
     generatePatientMedHistoryResponse([
@@ -110,13 +110,13 @@ test('PatientMedHistory disables External Medication refill button', async () =>
 
   render(() => (
     <MockSDKProvider client={mockClient as unknown as PhotonClient}>
-      <MockPrescribeProvider mockFunctions={mockPrescribeFunctions}>
+      <MockDraftPrescriptionsProvider mockValues={mockContextValues}>
         <PatientMedHistory
           patientId="test-patient-id"
           enableLinks={false}
           enableRefillButton={true}
         />
-      </MockPrescribeProvider>
+      </MockDraftPrescriptionsProvider>
     </MockSDKProvider>
   ));
 
@@ -124,7 +124,7 @@ test('PatientMedHistory disables External Medication refill button', async () =>
   expect(refillButton).toBeDisabled();
   expect(refillButton).not.toHaveTextContent('Loading...');
   await user.click(refillButton);
-  expect(mockPrescribeFunctions.tryCreatePrescription).not.toHaveBeenCalled();
+  expect(mockContextValues.tryCreatePrescription).not.toHaveBeenCalled();
 });
 
 function createPrescription(): Prescription {

--- a/packages/components/src/systems/PatientMedHistory/PatientMedHistoryTable.tsx
+++ b/packages/components/src/systems/PatientMedHistory/PatientMedHistoryTable.tsx
@@ -4,7 +4,7 @@ import { Treatment } from '@photonhealth/sdk/dist/types';
 import { IconButton } from '../../particles/IconButton';
 import clsx from 'clsx';
 import { MedHistoryPrescription } from './index';
-import { usePrescribeOptional } from '../PrescribeProvider';
+import { useDraftPrescriptionsOptional } from '../DraftPrescriptions';
 
 export type MedHistoryRowItem = {
   treatment: Treatment;
@@ -24,7 +24,7 @@ export type PatientMedHistoryTableProps = {
 export default function PatientMedHistoryTable(props: PatientMedHistoryTableProps) {
   // Component can be used as a standalone element
   // so PrescribeProvider is not guaranteed to be rendered
-  const prescribeContext = usePrescribeOptional();
+  const draftPrescriptionsContext = useDraftPrescriptionsOptional();
 
   const [isCreatingPrescriptionId, setIsCreatingPrescriptionId] = createSignal<string | undefined>(
     undefined
@@ -48,12 +48,12 @@ export default function PatientMedHistoryTable(props: PatientMedHistoryTableProp
     if (isCreatingPrescriptionId() === undefined) {
       setIsCreatingPrescriptionId(prescription.id);
 
-      if (!prescribeContext) {
-        throw new Error('Refill requires <PrescribeProvider>');
+      if (!draftPrescriptionsContext) {
+        throw new Error('Refill requires <DraftPrescriptionsProvider>');
       }
 
       try {
-        await prescribeContext.tryCreatePrescription({
+        await draftPrescriptionsContext.tryCreatePrescription({
           ...prescription,
           treatment,
           diagnoseCodes: prescription.diagnoses?.map((diagnosis) => diagnosis.code) || []

--- a/packages/components/src/systems/PrescribeProvider/PrescribeProvider.tsx
+++ b/packages/components/src/systems/PrescribeProvider/PrescribeProvider.tsx
@@ -43,7 +43,6 @@ interface PrescribeOrderFormData {
 
 export type PrescribeContextType = {
   // values
-  prescriptionIds: Accessor<string[]>;
   isLoadingPrefills: Accessor<boolean>;
   coverageOptions: Accessor<CoverageOption[]>;
   routingConstraints: Accessor<RoutingConstraint[]>;
@@ -147,10 +146,6 @@ export const PrescribeProvider = (props: PrescribeProviderProps) => {
   const client = usePhotonClient();
   const { draftPrescriptions, setDraftPrescriptions } = useDraftPrescriptions();
   const [, recentOrdersActions] = useRecentOrders();
-
-  const prescriptionIds = createMemo(() =>
-    draftPrescriptions().map((prescription) => prescription.id)
-  );
 
   const routingConstraints = createMemo((): RoutingConstraint[] => {
     return draftPrescriptions().map((prescription: Prescription) =>
@@ -519,7 +514,6 @@ export const PrescribeProvider = (props: PrescribeProviderProps) => {
 
   const value = {
     // values
-    prescriptionIds,
     isLoadingPrefills,
     coverageOptions,
     routingConstraints,
@@ -529,7 +523,7 @@ export const PrescribeProvider = (props: PrescribeProviderProps) => {
     selectedCoverageOption,
 
     // actions
-    tryCreatePrescription,
+    tryCreatePrescription, // used
     tryUpdatePrescriptionStates,
     deletePrescription,
     selectOtherCoverageOption,

--- a/packages/components/src/systems/PrescribeProvider/PrescribeProvider.tsx
+++ b/packages/components/src/systems/PrescribeProvider/PrescribeProvider.tsx
@@ -8,22 +8,13 @@ import {
   useContext
 } from 'solid-js';
 import { usePhotonClient } from '../SDKProvider';
+import { Prescription } from '@photonhealth/sdk/dist/types';
 import {
-  MutationCreatePrescriptionsArgs,
-  Prescription,
-  PrescriptionState
-} from '@photonhealth/sdk/dist/types';
-import {
-  CreatePrescription,
-  CreatePrescriptions,
-  CreatePrescriptionTemplate,
   GenerateCoverageOptions,
   GetPatientPreferredPharmaciesAndAddress,
-  GetPharmaciesQuery,
-  GetPrescription,
-  UpdatePrescriptionStates
+  GetPharmaciesQuery
 } from '../../fetch';
-import { triggerToast, useRecentOrders } from '../../index';
+import { triggerToast } from '../../index';
 import { useDraftPrescriptions } from '../DraftPrescriptions';
 import {
   combineAllRoutingConstraints,
@@ -33,7 +24,7 @@ import {
 import { createStore } from 'solid-js/store';
 import getLocation from '../../utils/getLocations';
 import { useGoogleService } from '../GoogleServiceProvider';
-import { usePrescribeEventDispatch } from '../PrescribeEventDispatchProvider';
+
 // The order form data will consist of, at least, the list of selected prescription IDs and pharmacy ID.
 // The prescription form data (todo) will consist of a single prescription's data during user input
 // Note: Multiple prescription "sub" forms can be opened/completed within a single order form
@@ -43,7 +34,6 @@ interface PrescribeOrderFormData {
 
 export type PrescribeContextType = {
   // values
-  isLoadingPrefills: Accessor<boolean>;
   coverageOptions: Accessor<CoverageOption[]>;
   routingConstraints: Accessor<RoutingConstraint[]>;
   combinedRoutingConstraint: Accessor<RoutingConstraint>;
@@ -52,12 +42,6 @@ export type PrescribeContextType = {
   selectedCoverageOption: Accessor<CoverageOption | undefined>;
 
   // actions
-  deletePrescription: (id: string) => void;
-  tryCreatePrescription: (
-    prescriptionFormData: PrescriptionFormData,
-    options?: TryCreatePrescriptionTemplateOptions
-  ) => Promise<Prescription>;
-  tryUpdatePrescriptionStates: (ids: string[], state: PrescriptionState) => Promise<boolean>;
   selectOtherCoverageOption: (value: CoverageOption) => void;
   setOrderFormData: <K extends keyof PrescribeOrderFormData>(
     key: K,
@@ -67,68 +51,46 @@ export type PrescribeContextType = {
 
 const PrescribeContext = createContext<PrescribeContextType>();
 
-export type TemplateOverrides = {
-  [key: string]: {
-    daysSupply?: number;
-    dispenseAsWritten?: boolean;
-    dispenseQuantity?: number;
-    dispenseUnit?: string;
-    fillsAllowed?: number;
-    instructions?: string;
-    notes?: string;
-    externalId?: string;
-  };
-};
-
-export type PrescriptionFormData = {
-  id?: string;
-  doNotFillBeforeDate?: string;
-  treatment: {
-    id: string;
-    name: string;
-  };
-  dispenseAsWritten: boolean;
-  dispenseQuantity?: number;
-  dispenseUnit?: string;
-  daysSupply?: number;
-  instructions: string;
-  notes: string;
-  fillsAllowed?: number;
-  catalogId?: string;
-  externalId?: string;
-  diagnoseCodes: string[];
-};
-
 interface PrescribeProviderProps {
   children: JSXElement;
-  templateIdsPrefill: string[];
-  templateOverrides: TemplateOverrides;
-  prescriptionIdsPrefill: string[];
   patientId: string;
   enableCombineAndDuplicate: boolean;
   enableCoverageCheck: boolean;
 }
 
-const transformPrescriptionFormData = (prescription: PrescriptionFormData, patientId: string) => ({
-  externalId: prescription.externalId,
-  patientId: patientId,
-  treatmentId: prescription.treatment?.id,
-  dispenseAsWritten: prescription.dispenseAsWritten,
-  dispenseQuantity: prescription.dispenseQuantity,
-  dispenseUnit: prescription.dispenseUnit,
-  fillsAllowed: prescription.fillsAllowed,
-  daysSupply: prescription.daysSupply,
-  instructions: prescription.instructions,
-  notes: prescription.notes,
-  doNotFillBeforeDate: prescription.doNotFillBeforeDate,
-  diagnoses: prescription.diagnoseCodes
-});
+export type PatientPreferredPharmacy = {
+  id: string;
+  name: string;
+};
+
+export type CoverageOption = {
+  daysSupply: number;
+  dispenseQuantity: number;
+  dispenseUnit: string;
+  id: string;
+  isAlternative: boolean;
+  paRequired: boolean;
+  prescriptionId: string;
+  price: number | null;
+  status: 'COVERED' | 'COVERED_WITH_RESTRICTIONS' | 'NOT_COVERED';
+  statusMessage: string;
+  treatment: { id: string; name: string };
+  alerts: Array<{ label: string; text: string }>;
+  pharmacy: { id: string; name: string };
+};
+
+export type Address = {
+  street1: string;
+  street2: string;
+  city: string;
+  state: string;
+  postalCode: string;
+};
 
 export const PrescribeProvider = (props: PrescribeProviderProps) => {
   const { googleMapsServices } = useGoogleService();
-  const { dispatchDraftPrescriptionCreated } = usePrescribeEventDispatch();
-  const [isLoadingPrefills, setIsLoadingPrefills] = createSignal<boolean>(false);
-  const [hasCreatedPrescriptions, setHasCreatedPrescriptions] = createSignal<boolean>(false);
+  const { draftPrescriptions, setDraftPrescriptions } = useDraftPrescriptions();
+  const client = usePhotonClient();
   const [coverageOptions, setCoverageOptions] = createSignal<CoverageOption[]>([]);
   const [patientPreferredPharmacyId, setPatientPreferredPharmacyId] = createSignal<string | null>(
     null
@@ -142,10 +104,6 @@ export const PrescribeProvider = (props: PrescribeProviderProps) => {
   >();
 
   const [orderFormData, setOrderFormData] = createStore<PrescribeOrderFormData>();
-
-  const client = usePhotonClient();
-  const { draftPrescriptions, setDraftPrescriptions } = useDraftPrescriptions();
-  const [, recentOrdersActions] = useRecentOrders();
 
   const routingConstraints = createMemo((): RoutingConstraint[] => {
     return draftPrescriptions().map((prescription: Prescription) =>
@@ -191,20 +149,6 @@ export const PrescribeProvider = (props: PrescribeProviderProps) => {
     const pharmacies = await fetchPharmacies(locations[0]);
     return pharmacies;
   }
-
-  // Prefill new prescriptions based on templateIds or prescriptionIds when we get a patientId
-  createEffect(() => {
-    if (
-      // must have templateIds or prescriptionIds to create prescriptions
-      (props.templateIdsPrefill.length > 0 || props.prescriptionIdsPrefill.length > 0) &&
-      // must have a patientId
-      !!props.patientId &&
-      // must not have created prescriptions yet
-      !hasCreatedPrescriptions()
-    ) {
-      createPrescriptionsFromIds();
-    }
-  });
 
   createEffect(() => {
     if (props.patientId) {
@@ -284,44 +228,6 @@ export const PrescribeProvider = (props: PrescribeProviderProps) => {
     }
   });
 
-  async function createPrescriptionsFromIds() {
-    setHasCreatedPrescriptions(true);
-    setIsLoadingPrefills(true);
-
-    try {
-      // Create prescriptions from template ids with a few optional override values
-      if (props.templateIdsPrefill.length > 0) {
-        const dedupedTemplateIds = Array.from(new Set(props.templateIdsPrefill));
-        const templatedCreateRxList = dedupedTemplateIds.map((templateId) => ({
-          ...props.templateOverrides?.[templateId],
-          patientId: props.patientId,
-          templateId
-        }));
-
-        await createPrescriptionsOnApi(templatedCreateRxList);
-      }
-
-      // Fetch prescriptions if needed
-      if (props.prescriptionIdsPrefill.length > 0) {
-        const fetchedPrescriptions = await Promise.all(
-          props.prescriptionIdsPrefill.map(async (prescriptionId: string) => {
-            const { data } = await client.apollo.query({
-              query: GetPrescription,
-              variables: { id: prescriptionId }
-            });
-            return transformPrescriptionFormData(data?.prescription, props.patientId);
-          })
-        );
-
-        await createPrescriptionsOnApi(fetchedPrescriptions);
-      }
-    } catch (error) {
-      console.error('Error while trying to create prescriptions from prefill IDs', { error });
-    } finally {
-      setIsLoadingPrefills(false);
-    }
-  }
-
   const getPatientPreferredPharmaciesAndAddress = async (patientId: string) => {
     try {
       const response = await client.apollo.query({
@@ -360,152 +266,6 @@ export const PrescribeProvider = (props: PrescribeProviderProps) => {
     return response.data.generateCoverageOptions as CoverageOption[];
   };
 
-  const tryCreatePrescription = async (
-    prescriptionFormData: PrescriptionFormData,
-    options: TryCreatePrescriptionTemplateOptions = { showSuccessToast: true }
-  ): Promise<Prescription> => {
-    const isPrescriptionAlreadyAdded = isTreatmentInDraftPrescriptions(
-      prescriptionFormData.treatment.id,
-      draftPrescriptions()
-    );
-
-    if (isPrescriptionAlreadyAdded) {
-      triggerToast({
-        status: 'error',
-        body: 'You already have this prescription in your order. You can modify the prescription or delete it in Pending Order.'
-      });
-
-      throw new Error('Prescription already added');
-    }
-
-    const duplicateFill = recentOrdersActions.checkDuplicateFill(
-      prescriptionFormData.treatment.name
-    );
-
-    if (props.enableCombineAndDuplicate && duplicateFill) {
-      // if there's a duplicate order, check first if they want to report an issue
-      await new Promise<void>((resolve, reject) => {
-        recentOrdersActions.setIsDuplicateDialogOpen(true, duplicateFill, resolve, reject);
-      });
-    }
-
-    return await createPrescriptionOnApi(prescriptionFormData, options);
-  };
-
-  const tryUpdatePrescriptionStates = async (
-    ids: string[],
-    state: PrescriptionState
-  ): Promise<boolean> => {
-    try {
-      const res = await client.apolloClinical.mutate({
-        mutation: UpdatePrescriptionStates,
-        variables: {
-          input: {
-            ids,
-            state
-          }
-        }
-      });
-
-      return res.data.updatePrescriptionStates as boolean;
-    } catch (error) {
-      console.error('Mutation error:', error);
-      triggerToast({
-        status: 'error',
-        header: 'Error Saving Prescription(s)',
-        body: (error as Error).message
-      });
-      throw error;
-    }
-  };
-
-  const createPrescriptionOnApi = async (
-    prescriptionFormData: PrescriptionFormData,
-    options: TryCreatePrescriptionTemplateOptions = {
-      addToTemplates: false,
-      showSuccessToast: true
-    }
-  ): Promise<Prescription> => {
-    let createdPrescription: Prescription | null = null;
-
-    try {
-      const res = await client.apollo.mutate({
-        mutation: CreatePrescription,
-        variables: transformPrescriptionFormData(prescriptionFormData, props.patientId)
-      });
-      const created = res.data.createPrescription as Prescription;
-      createdPrescription = created;
-      setDraftPrescriptions((prev) => [...prev, created]);
-      dispatchDraftPrescriptionCreated(created);
-    } catch (error) {
-      console.error('Mutation error:', error);
-      triggerToast({
-        status: 'error',
-        header: 'Error Adding Prescription',
-        body: 'There was an issue adding the prescription. Please try again.'
-      });
-      throw error;
-    }
-
-    if (options?.addToTemplates && options?.catalogId != null) {
-      await createPrescriptionTemplateOnApi(
-        prescriptionFormData,
-        options.catalogId,
-        options.templateName
-      );
-
-      if (options.showSuccessToast) {
-        triggerToast({
-          status: 'success',
-          header: 'Personal Template Saved'
-        });
-      }
-    }
-
-    if (options.showSuccessToast) {
-      triggerToast({
-        status: 'success',
-        header: 'Prescription Added',
-        body: 'You can send this order or add another prescription before sending it'
-      });
-    }
-
-    return createdPrescription;
-  };
-
-  const createPrescriptionsOnApi = async (
-    prescriptions: MutationCreatePrescriptionsArgs['prescriptions']
-  ) => {
-    const res = await client.apollo.mutate({
-      mutation: CreatePrescriptions,
-      variables: { prescriptions }
-    });
-    const newRxs = res.data.createPrescriptions as Prescription[];
-    setDraftPrescriptions((prev) => [...prev, ...newRxs]);
-    newRxs.map((rx) => dispatchDraftPrescriptionCreated(rx));
-  };
-
-  const deletePrescription = (toDeleteId: string) => {
-    setDraftPrescriptions((prev) => prev.filter((rx) => rx.id !== toDeleteId));
-  };
-
-  const createPrescriptionTemplateOnApi = async (
-    prescription: PrescriptionFormData,
-    catalogId: string,
-    templateName = ''
-  ) => {
-    const res = await client.apollo.mutate({
-      mutation: CreatePrescriptionTemplate,
-      variables: {
-        ...transformPrescriptionFormData(prescription, props.patientId),
-        catalogId,
-        isPrivate: true,
-        ...(templateName ? { name: templateName } : {})
-      }
-    });
-    return res;
-  };
-
   const selectOtherCoverageOption = (value: CoverageOption) => {
     setOrderFormData('pharmacyId', value.pharmacy.id);
     setSelectedCoverageOption(value);
@@ -514,7 +274,7 @@ export const PrescribeProvider = (props: PrescribeProviderProps) => {
 
   const value = {
     // values
-    isLoadingPrefills,
+
     coverageOptions,
     routingConstraints,
     combinedRoutingConstraint,
@@ -523,9 +283,7 @@ export const PrescribeProvider = (props: PrescribeProviderProps) => {
     selectedCoverageOption,
 
     // actions
-    tryCreatePrescription, // used
-    tryUpdatePrescriptionStates,
-    deletePrescription,
+
     selectOtherCoverageOption,
     setOrderFormData
   };
@@ -539,51 +297,4 @@ export const usePrescribe = () => {
     throw new Error('usePrescribe must be used within the PrescribeProvider');
   }
   return context;
-};
-
-export const usePrescribeOptional = () => {
-  return useContext(PrescribeContext);
-};
-
-export function isTreatmentInDraftPrescriptions(
-  treatmentId: string,
-  draftedPrescriptions: { treatment: { id: string } }[]
-) {
-  return draftedPrescriptions.some((draft) => draft.treatment.id === treatmentId);
-}
-
-export type TryCreatePrescriptionTemplateOptions = {
-  addToTemplates?: boolean;
-  templateName?: string;
-  catalogId?: string;
-  showSuccessToast?: boolean;
-};
-
-export type PatientPreferredPharmacy = {
-  id: string;
-  name: string;
-};
-
-export type CoverageOption = {
-  daysSupply: number;
-  dispenseQuantity: number;
-  dispenseUnit: string;
-  id: string;
-  isAlternative: boolean;
-  paRequired: boolean;
-  prescriptionId: string;
-  price: number | null;
-  status: 'COVERED' | 'COVERED_WITH_RESTRICTIONS' | 'NOT_COVERED';
-  statusMessage: string;
-  treatment: { id: string; name: string };
-  alerts: Array<{ label: string; text: string }>;
-  pharmacy: { id: string; name: string };
-};
-
-export type Address = {
-  street1: string;
-  street2: string;
-  city: string;
-  state: string;
-  postalCode: string;
 };

--- a/packages/components/src/systems/PrescribeProvider/PrescribeProvider.tsx
+++ b/packages/components/src/systems/PrescribeProvider/PrescribeProvider.tsx
@@ -273,7 +273,6 @@ export const PrescribeProvider = (props: PrescribeProviderProps) => {
 
   const value = {
     // values
-
     coverageOptions,
     routingConstraints,
     combinedRoutingConstraint,
@@ -282,7 +281,6 @@ export const PrescribeProvider = (props: PrescribeProviderProps) => {
     selectedCoverageOption,
 
     // actions
-
     selectOtherCoverageOption,
     setOrderFormData
   };

--- a/packages/components/src/systems/PrescribeProvider/PrescribeProvider.tsx
+++ b/packages/components/src/systems/PrescribeProvider/PrescribeProvider.tsx
@@ -54,7 +54,6 @@ const PrescribeContext = createContext<PrescribeContextType>();
 interface PrescribeProviderProps {
   children: JSXElement;
   patientId: string;
-  enableCombineAndDuplicate: boolean;
   enableCoverageCheck: boolean;
 }
 

--- a/packages/components/src/systems/TestMocks/MockDraftPrescriptionsProvider.tsx
+++ b/packages/components/src/systems/TestMocks/MockDraftPrescriptionsProvider.tsx
@@ -1,0 +1,32 @@
+import { createContext, JSXElement, untrack } from 'solid-js';
+import { vi } from 'vitest';
+import { DraftPrescriptionsContextType } from '../DraftPrescriptions';
+
+export const MockDraftPrescriptionsContext = createContext<DraftPrescriptionsContextType>();
+
+export const mockDraftPrescriptionsContextValues = () => {
+  return {
+    draftPrescriptions: () => [],
+    prescriptionIds: () => [],
+    isLoadingPrefills: () => false,
+    deletePrescription: vi.fn(),
+    tryCreatePrescription: vi.fn(),
+    tryUpdatePrescriptionStates: vi.fn(),
+    setDraftPrescriptions: vi.fn()
+  };
+};
+
+interface MockDraftPrescriptionsProviderProps {
+  children: JSXElement;
+  mockValues?: ReturnType<typeof mockDraftPrescriptionsContextValues>;
+}
+
+export function MockDraftPrescriptionsProvider(props: MockDraftPrescriptionsProviderProps) {
+  const mocks = untrack(() => ({ ...mockDraftPrescriptionsContextValues(), ...props.mockValues }));
+
+  return (
+    <MockDraftPrescriptionsContext.Provider value={mocks}>
+      {props.children}
+    </MockDraftPrescriptionsContext.Provider>
+  );
+}

--- a/packages/components/src/systems/TestMocks/MockPrescribeProvider.tsx
+++ b/packages/components/src/systems/TestMocks/MockPrescribeProvider.tsx
@@ -1,31 +1,18 @@
 import { PhotonClient } from '@photonhealth/sdk';
-import { createContext, JSXElement, untrack } from 'solid-js';
+import { createContext, JSXElement } from 'solid-js';
 import { vi } from 'vitest';
 import { PrescribeContextType } from '../PrescribeProvider';
 
 export const MockPrescribeContext = createContext<PrescribeContextType>();
 
-export const mockPrescribeContextValues = () => {
-  return {
-    deletePrescription: vi.fn(),
-    tryCreatePrescription: vi.fn(),
-    tryUpdatePrescriptionStates: vi.fn(),
-    setDidSelectOtherCoverageOption: vi.fn()
-  };
-};
-
 interface MockPrescribeProviderProps {
   client?: PhotonClient;
   children: JSXElement;
-  mockFunctions?: ReturnType<typeof mockPrescribeContextValues>;
 }
 
 export function MockPrescribeProvider(props: MockPrescribeProviderProps) {
-  const mocks = untrack(() => props.mockFunctions || mockPrescribeContextValues());
-
   const mockValues: PrescribeContextType = {
     // mock values
-    isLoadingPrefills: () => false,
     coverageOptions: () => [],
     routingConstraints: () => [],
     combinedRoutingConstraint: () => {
@@ -38,10 +25,7 @@ export function MockPrescribeProvider(props: MockPrescribeProviderProps) {
     unroutablePharmacyIds: () => new Set(),
     selectedCoverageOption: () => undefined,
     // mock actions
-    deletePrescription: mocks.deletePrescription,
-    tryCreatePrescription: mocks.tryCreatePrescription,
-    tryUpdatePrescriptionStates: mocks.tryUpdatePrescriptionStates,
-    selectOtherCoverageOption: mocks.setDidSelectOtherCoverageOption,
+    selectOtherCoverageOption: vi.fn(),
     orderFormData: { pharmacyId: 'test-pharmacy-id' },
     setOrderFormData: () => undefined
   };

--- a/packages/components/src/systems/TestMocks/MockPrescribeProvider.tsx
+++ b/packages/components/src/systems/TestMocks/MockPrescribeProvider.tsx
@@ -25,7 +25,6 @@ export function MockPrescribeProvider(props: MockPrescribeProviderProps) {
 
   const mockValues: PrescribeContextType = {
     // mock values
-    prescriptionIds: () => [],
     isLoadingPrefills: () => false,
     coverageOptions: () => [],
     routingConstraints: () => [],

--- a/packages/elements/src/photon-multirx-form/components/AddPrescriptionCard.tsx
+++ b/packages/elements/src/photon-multirx-form/components/AddPrescriptionCard.tsx
@@ -8,8 +8,9 @@ import {
   ScreeningAlertType,
   Text,
   triggerToast,
-  usePrescribe,
-  usePrescribeEventDispatch
+  usePrescribeEventDispatch,
+  TryCreatePrescriptionTemplateOptions,
+  useDraftPrescriptions
 } from '@photonhealth/components';
 import { DispenseUnit, Medication, Prescription } from '@photonhealth/sdk/dist/types';
 import { any, min, number, optional, record, refine, size, string } from 'superstruct';
@@ -23,7 +24,6 @@ import { GraphQLFormattedError } from 'graphql';
 import { createEffect, createSignal, onMount, Show } from 'solid-js';
 import clearForm from '../util/clearForm';
 import repopulateForm from '../util/repopulateForm';
-import { TryCreatePrescriptionTemplateOptions } from '@photonhealth/components/src/systems/PrescribeProvider';
 import { DisableList } from './PrescribeWorkflow';
 
 setBasePath('https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.4.0/dist/');
@@ -61,7 +61,7 @@ export const AddPrescriptionCard = (props: {
   enableOrder: boolean;
   disableList?: DisableList;
 }) => {
-  const { tryCreatePrescription } = usePrescribe();
+  const { tryCreatePrescription } = useDraftPrescriptions();
   const { dispatchOrderError } = usePrescribeEventDispatch();
   const [offCatalog, setOffCatalog] = createSignal<Medication | undefined>(undefined);
   const [dispenseUnit] = createSignal<DispenseUnit | undefined>(undefined);

--- a/packages/elements/src/photon-multirx-form/components/DraftPrescriptionCard.tsx
+++ b/packages/elements/src/photon-multirx-form/components/DraftPrescriptionCard.tsx
@@ -30,8 +30,8 @@ export const DraftPrescriptionCard = (props: {
   const [editDialogConfirm, setEditDialogConfirm] = createSignal<(() => void) | undefined>();
   const [editDraft, setEditDraft] = createSignal<PrescriptionFormData | undefined>(undefined);
   const [deleteDraftId, setDeleteDraftId] = createSignal<string | undefined>();
-  const { prescriptionIds, deletePrescription, selectOtherCoverageOption } = usePrescribe();
-  const { draftPrescriptions } = useDraftPrescriptions();
+  const { deletePrescription, selectOtherCoverageOption } = usePrescribe();
+  const { draftPrescriptions, prescriptionIds } = useDraftPrescriptions();
 
   const editPrescription = () => {
     const formData = editDraft();

--- a/packages/elements/src/photon-multirx-form/components/DraftPrescriptionCard.tsx
+++ b/packages/elements/src/photon-multirx-form/components/DraftPrescriptionCard.tsx
@@ -30,8 +30,8 @@ export const DraftPrescriptionCard = (props: {
   const [editDialogConfirm, setEditDialogConfirm] = createSignal<(() => void) | undefined>();
   const [editDraft, setEditDraft] = createSignal<PrescriptionFormData | undefined>(undefined);
   const [deleteDraftId, setDeleteDraftId] = createSignal<string | undefined>();
-  const { deletePrescription, selectOtherCoverageOption } = usePrescribe();
-  const { draftPrescriptions, prescriptionIds } = useDraftPrescriptions();
+  const { selectOtherCoverageOption } = usePrescribe();
+  const { draftPrescriptions, prescriptionIds, deletePrescription } = useDraftPrescriptions();
 
   const editPrescription = () => {
     const formData = editDraft();

--- a/packages/elements/src/photon-multirx-form/components/PrescribeWorkflow.tsx
+++ b/packages/elements/src/photon-multirx-form/components/PrescribeWorkflow.tsx
@@ -136,7 +136,7 @@ export function PrescribeWorkflow(props: PrescribeProps) {
   let ref: Ref<any> | undefined;
   let prescriptionRef: HTMLDivElement | undefined;
 
-  const { draftPrescriptions } = useDraftPrescriptions();
+  const { draftPrescriptions, prescriptionIds } = useDraftPrescriptions();
   const {
     routingConstraints,
     combinedRoutingConstraint,
@@ -153,10 +153,6 @@ export function PrescribeWorkflow(props: PrescribeProps) {
     dispatchClinicalAlertAcknowledge,
     dispatchClinicalAlertCancel
   } = usePrescribeEventDispatch();
-
-  const prescriptionIds = createMemo(() =>
-    draftPrescriptions().map((prescription) => prescription.id)
-  );
 
   const autoRoutedPharmacyId = createMemo(() => {
     if (props.pharmacyId) {

--- a/packages/elements/src/photon-multirx-form/components/PrescribeWorkflow.tsx
+++ b/packages/elements/src/photon-multirx-form/components/PrescribeWorkflow.tsx
@@ -136,14 +136,9 @@ export function PrescribeWorkflow(props: PrescribeProps) {
   let ref: Ref<any> | undefined;
   let prescriptionRef: HTMLDivElement | undefined;
 
-  const { draftPrescriptions, prescriptionIds } = useDraftPrescriptions();
-  const {
-    routingConstraints,
-    combinedRoutingConstraint,
-    tryUpdatePrescriptionStates,
-    isLoadingPrefills,
-    orderFormData
-  } = usePrescribe();
+  const { draftPrescriptions, prescriptionIds, tryUpdatePrescriptionStates, isLoadingPrefills } =
+    useDraftPrescriptions();
+  const { routingConstraints, combinedRoutingConstraint, orderFormData } = usePrescribe();
   const {
     dispatchFormValidate,
     dispatchPrescriptionsCreated,

--- a/packages/elements/src/photon-multirx-form/photon-prescribe-workflow-component.tsx
+++ b/packages/elements/src/photon-multirx-form/photon-prescribe-workflow-component.tsx
@@ -45,14 +45,14 @@ const Component = (props: PrescribeWorkflowComponentProps) => {
 
   return (
     <PrescribeEventDispatchProvider>
-      <DraftPrescriptionsProvider
-        patientId={store.patient?.value?.id}
-        templateIdsPrefill={props.templateIds?.split(',').map((id) => id.trim()) || []}
-        templateOverrides={props.templateOverrides || {}}
-        prescriptionIdsPrefill={props.prescriptionIds?.split(',').map((id) => id.trim()) || []}
-        enableCombineAndDuplicate={props.enableCombineAndDuplicate}
-      >
-        <RecentOrders patientId={store.patient?.value?.id}>
+      <RecentOrders patientId={store.patient?.value?.id}>
+        <DraftPrescriptionsProvider
+          patientId={store.patient?.value?.id}
+          templateIdsPrefill={props.templateIds?.split(',').map((id) => id.trim()) || []}
+          templateOverrides={props.templateOverrides || {}}
+          prescriptionIdsPrefill={props.prescriptionIds?.split(',').map((id) => id.trim()) || []}
+          enableCombineAndDuplicate={props.enableCombineAndDuplicate}
+        >
           <PrescribeProvider
             patientId={store.patient?.value?.id}
             enableCoverageCheck={props.enableCoverageCheck}
@@ -98,8 +98,8 @@ const Component = (props: PrescribeWorkflowComponentProps) => {
               initialShowForm={!props.templateIds && !props.prescriptionIds}
             />
           </PrescribeProvider>
-        </RecentOrders>
-      </DraftPrescriptionsProvider>
+        </DraftPrescriptionsProvider>
+      </RecentOrders>
     </PrescribeEventDispatchProvider>
   );
 };

--- a/packages/elements/src/photon-multirx-form/photon-prescribe-workflow-component.tsx
+++ b/packages/elements/src/photon-multirx-form/photon-prescribe-workflow-component.tsx
@@ -45,14 +45,16 @@ const Component = (props: PrescribeWorkflowComponentProps) => {
 
   return (
     <PrescribeEventDispatchProvider>
-      <DraftPrescriptionsProvider>
+      <DraftPrescriptionsProvider
+        patientId={store.patient?.value?.id}
+        templateIdsPrefill={props.templateIds?.split(',').map((id) => id.trim()) || []}
+        templateOverrides={props.templateOverrides || {}}
+        prescriptionIdsPrefill={props.prescriptionIds?.split(',').map((id) => id.trim()) || []}
+        enableCombineAndDuplicate={props.enableCombineAndDuplicate}
+      >
         <RecentOrders patientId={store.patient?.value?.id}>
           <PrescribeProvider
-            templateIdsPrefill={props.templateIds?.split(',').map((id) => id.trim()) || []}
-            templateOverrides={props.templateOverrides || {}}
-            prescriptionIdsPrefill={props.prescriptionIds?.split(',').map((id) => id.trim()) || []}
             patientId={store.patient?.value?.id}
-            enableCombineAndDuplicate={props.enableCombineAndDuplicate}
             enableCoverageCheck={props.enableCoverageCheck}
           >
             <style>{tailwind}</style>


### PR DESCRIPTION
Since I'm already working in this area from PR https://github.com/Photon-Health/client/pull/2266, figured I'd also work on moving code related to managing draft prescriptions out of PrescribeProvider into DraftPrescriptionsProvider. PrescribeProvider now mainly deals with checks around pharmacy coverage.

Part of PHO-156