### PR TITLE
Add datadog rum session data for self signup

### DIFF
--- a/apps/app/src/instrumentation/setInstrumentationUserContext.tsx
+++ b/apps/app/src/instrumentation/setInstrumentationUserContext.tsx
@@ -15,3 +15,13 @@ export function setInstrumentationUserContext(user: {
     name: user.name
   });
 }
+
+export function setInstrumentationSelfSignupUserContext(user: { email: string; name: string }) {
+  datadogRum.setGlobalContextProperty('org', {
+    isSelfSignup: true
+  });
+  datadogRum.setUser({
+    email: user.email,
+    name: user.name
+  });
+}

--- a/apps/app/src/views/routes/SelfSignup/views/SelfSignupPage.tsx
+++ b/apps/app/src/views/routes/SelfSignup/views/SelfSignupPage.tsx
@@ -33,6 +33,8 @@ import { FormikStateSelect } from '../../Settings/components/utils/States';
 import { SignupFormData, signupFormSchema } from './form';
 import { FaInfoCircle } from 'react-icons/fa';
 import { useEffect, useMemo } from 'react';
+import { datadogRum } from '@datadog/browser-rum';
+import { setInstrumentationSelfSignupUserContext } from '../../../../instrumentation/setInstrumentationUserContext';
 
 const VALID_LICENSES = new Set(['MD', 'DO', 'PA', 'NP']);
 
@@ -88,6 +90,8 @@ export const SelfSignupPage = () => {
   // Track page view on mount
   useEffect(() => {
     const hasPrefilledName = !!(firstName && lastName);
+    const fullName = hasPrefilledName ? `${firstName} ${lastName}` : undefined;
+    setInstrumentationSelfSignupUserContext({ email: email ?? '', name: fullName ?? '' });
     trackSelfSignupEvent(
       'Self Signup Page Viewed',
       {
@@ -96,7 +100,7 @@ export const SelfSignupPage = () => {
         hasPrefilledNpi: canPrefillNpi,
         hasPrefilledEmail: !!email,
         hasPrefilledName,
-        fullName: hasPrefilledName ? `${firstName} ${lastName}` : undefined
+        fullName
       },
       sessionToken
     );
@@ -376,6 +380,9 @@ function extractTokenData(tosSessionToken?: string): SelfSignupFormPrefillData {
   }
   const [, payload] = tosSessionToken.split('.');
   const decodedPayload = JSON.parse(atob(payload));
+
+  datadogRum.setGlobalContextProperty('SelfSignupData', { decodedPayload });
+
   const firstName: string = decodedPayload.first_name;
   const lastName: string = decodedPayload.last_name;
   const email: string = decodedPayload.email;


### PR DESCRIPTION
* add isSelfSignup flag to DDRum context data, so we can retain these RUM sessions and understand signup usage better
* add token payload data to the RUM session for self signup
* added retention filter in datadog rum app settings for self signup sessions ([link](https://app.datadoghq.com/rum/application/9ed45146-41c8-4bfa-a74d-e6fbda8412e0/retention-filters?query=%40context.org.isSelfSignup%3Atrue&fromUser=false&from_ts=1769804264724&to_ts=1770409064724&live=true))
 
## Example Datadog Rum session data:
<img width="1150" height="680" alt="signup ddrum" src="https://github.com/user-attachments/assets/6c0e89d4-9788-4958-b851-08e527e724f1" />
