### PR TITLE
Don't override org in ddrum context

### DIFF
--- a/apps/app/src/instrumentation/setInstrumentationUserContext.tsx
+++ b/apps/app/src/instrumentation/setInstrumentationUserContext.tsx
@@ -17,7 +17,7 @@ export function setInstrumentationUserContext(user: {
 }
 
 export function setInstrumentationSelfSignupUserContext(user: { email: string; name: string }) {
-  datadogRum.setGlobalContextProperty('org', {
+  datadogRum.setGlobalContextProperty('session', {
     isSelfSignup: true
   });
   datadogRum.setUser({


### PR DESCRIPTION
I noticed it's possible for a multi-org/power user (e.g. mainly us devs) to overwrite the `org` param in DDRum context when switching from non-selfsignup user to a selfsignup user session. I don't want to ever accidentally overwrite this.