### PR TITLE
For Mail Orders, Use the same status page copy as SENT for RECEIVED

### DIFF
--- a/apps/patient/src/components/status/Header.tsx
+++ b/apps/patient/src/components/status/Header.tsx
@@ -126,7 +126,7 @@ function subheaderText(props: OrderStatusHeaderProps) {
   // Then just check the status
   if (
     (props.fulfillmentType === 'MAIL_ORDER' || props.integrated) &&
-    (props.status === 'CREATED' || props.status === 'SENT')
+    ['CREATED', 'SENT', 'RECEIVED'].includes(props.status)
   ) {
     return "We've sent your order to the pharmacy. They will reach out shortly.";
   }


### PR DESCRIPTION
In lambdas, we've been keeping mail order fulfillments in SENT, rather than RECEIVED, when we autocomplete them because of this copy. We should treat them as Received if our faxes got through, rather than just sent. The same copy should be used, pending redesigns. 
