### PR TITLE
Persist self signup rum flag during redirect

### DIFF
--- a/apps/app/src/instrumentation/setInstrumentationUserContext.tsx
+++ b/apps/app/src/instrumentation/setInstrumentationUserContext.tsx
@@ -1,5 +1,7 @@
 import { datadogRum } from '@datadog/browser-rum';
 
+const SELF_SIGNUP_STORAGE_KEY = 'dd_rum_is_self_signup';
+
 export function setInstrumentationUserContext(user: {
   org_id: string;
   email: string;
@@ -14,9 +16,19 @@ export function setInstrumentationUserContext(user: {
     email: user.email,
     name: user.name
   });
+
+  // Restore isSelfSignup flag that was persisted before the Auth0 redirect
+  if (sessionStorage.getItem(SELF_SIGNUP_STORAGE_KEY)) {
+    datadogRum.setGlobalContextProperty('session', {
+      isSelfSignup: true
+    });
+  }
 }
 
 export function setInstrumentationSelfSignupUserContext(user: { email: string; name: string }) {
+  // Persist flag so it survives the full-page, post-signup submission redirect through Auth0
+  sessionStorage.setItem(SELF_SIGNUP_STORAGE_KEY, 'true');
+
   datadogRum.setGlobalContextProperty('session', {
     isSelfSignup: true
   });


### PR DESCRIPTION
I noticed my datadog rum filter was only showing signups that did not complete. This is because our redirect is wiping the in-memory rum context during post-submit redirect. This change will restore the session flag for the signup session so we can accurately view signup sessions in rum.