### PR TITLE
Accessible state picker

### DIFF
--- a/apps/app/src/views/routes/SelfSignup/components/StateSelect.tsx
+++ b/apps/app/src/views/routes/SelfSignup/components/StateSelect.tsx
@@ -1,0 +1,66 @@
+import { Select, SelectProps } from '@chakra-ui/react';
+
+export const StateSelect = (props: SelectProps) => (
+  <Select autoComplete="address-level1" placeholder="Select state" {...props}>
+    {US_STATES.map((s) => (
+      <option key={s.value} value={s.value}>
+        {s.label}
+      </option>
+    ))}
+  </Select>
+);
+
+const US_STATES = [
+  { value: 'AL', label: 'Alabama' },
+  { value: 'AK', label: 'Alaska' },
+  { value: 'AZ', label: 'Arizona' },
+  { value: 'AR', label: 'Arkansas' },
+  { value: 'CA', label: 'California' },
+  { value: 'CO', label: 'Colorado' },
+  { value: 'CT', label: 'Connecticut' },
+  { value: 'DE', label: 'Delaware' },
+  { value: 'DC', label: 'District of Columbia' },
+  { value: 'FL', label: 'Florida' },
+  { value: 'GA', label: 'Georgia' },
+  { value: 'HI', label: 'Hawaii' },
+  { value: 'ID', label: 'Idaho' },
+  { value: 'IL', label: 'Illinois' },
+  { value: 'IN', label: 'Indiana' },
+  { value: 'IA', label: 'Iowa' },
+  { value: 'KS', label: 'Kansas' },
+  { value: 'KY', label: 'Kentucky' },
+  { value: 'LA', label: 'Louisiana' },
+  { value: 'ME', label: 'Maine' },
+  { value: 'MD', label: 'Maryland' },
+  { value: 'MA', label: 'Massachusetts' },
+  { value: 'MI', label: 'Michigan' },
+  { value: 'MN', label: 'Minnesota' },
+  { value: 'MS', label: 'Mississippi' },
+  { value: 'MO', label: 'Missouri' },
+  { value: 'MT', label: 'Montana' },
+  { value: 'NE', label: 'Nebraska' },
+  { value: 'NV', label: 'Nevada' },
+  { value: 'NH', label: 'New Hampshire' },
+  { value: 'NJ', label: 'New Jersey' },
+  { value: 'NM', label: 'New Mexico' },
+  { value: 'NY', label: 'New York' },
+  { value: 'NC', label: 'North Carolina' },
+  { value: 'ND', label: 'North Dakota' },
+  { value: 'OH', label: 'Ohio' },
+  { value: 'OK', label: 'Oklahoma' },
+  { value: 'OR', label: 'Oregon' },
+  { value: 'PA', label: 'Pennsylvania' },
+  { value: 'PR', label: 'Puerto Rico' },
+  { value: 'RI', label: 'Rhode Island' },
+  { value: 'SC', label: 'South Carolina' },
+  { value: 'SD', label: 'South Dakota' },
+  { value: 'TN', label: 'Tennessee' },
+  { value: 'TX', label: 'Texas' },
+  { value: 'UT', label: 'Utah' },
+  { value: 'VT', label: 'Vermont' },
+  { value: 'VA', label: 'Virginia' },
+  { value: 'WA', label: 'Washington' },
+  { value: 'WV', label: 'West Virginia' },
+  { value: 'WI', label: 'Wisconsin' },
+  { value: 'WY', label: 'Wyoming' }
+];

--- a/apps/app/src/views/routes/SelfSignup/views/SelfSignupPage.tsx
+++ b/apps/app/src/views/routes/SelfSignup/views/SelfSignupPage.tsx
@@ -38,7 +38,7 @@ export const SelfSignupPage = () => {
     street1: '',
     street2: '',
     city: '',
-    state: { value: '' },
+    state: '',
     postalCode: '',
     didAgreeToTerms: false
   };
@@ -169,7 +169,7 @@ const buildSignupContinueParams = (state: string, formData: SignupFormData): str
     phone: formData.phone,
     street1: formData.street1,
     city: formData.city,
-    state_address: formData.state.value,
+    state_address: formData.state,
     postal_code: formData.postalCode,
     did_accept_tos: formData.didAgreeToTerms.toString(),
     // these version numbers must match an entry in the attestations table

--- a/apps/app/src/views/routes/SelfSignup/views/SignupForm.tsx
+++ b/apps/app/src/views/routes/SelfSignup/views/SignupForm.tsx
@@ -22,7 +22,7 @@ import {
 } from '@chakra-ui/react';
 import { ErrorMessage, Field, Formik } from 'formik';
 import { FaInfoCircle } from 'react-icons/fa';
-import { FormikStateSelect } from '../../Settings/components/utils/States';
+import { StateSelect } from '../components/StateSelect';
 import { SignupFormData, signupFormSchema } from './form';
 
 interface SignupFormProps {
@@ -45,15 +45,7 @@ export const SignupForm = ({
         validationSchema={signupFormSchema}
         onSubmit={onSubmit}
       >
-        {({
-          errors,
-          touched,
-          isSubmitting,
-          handleSubmit,
-          values,
-          setFieldValue,
-          setFieldTouched
-        }) => (
+        {({ errors, touched, isSubmitting, handleSubmit, values, setFieldValue }) => (
           <form onSubmit={handleSubmit}>
             <Stack spacing="8">
               <Stack spacing="4" textAlign="left">
@@ -179,15 +171,10 @@ export const SignupForm = ({
                   <ErrorMessage name="city" component={FormErrorMessage} />
                 </FormControl>
 
-                <FormControl isRequired isInvalid={!!errors.state?.value && touched.state?.value}>
+                <FormControl isRequired isInvalid={!!errors.state && touched.state}>
                   <FormLabel htmlFor="state">State</FormLabel>
-                  <FormikStateSelect
-                    value={values.state}
-                    setFieldValue={setFieldValue}
-                    setFieldTouched={setFieldTouched}
-                    fieldName="state"
-                  />
-                  <ErrorMessage name="state.value" component={FormErrorMessage} />
+                  <Field as={StateSelect} id="state" name="state" />
+                  <ErrorMessage name="state" component={FormErrorMessage} />
                 </FormControl>
 
                 <FormControl isRequired isInvalid={!!errors.postalCode && touched.postalCode}>

--- a/apps/app/src/views/routes/SelfSignup/views/form.ts
+++ b/apps/app/src/views/routes/SelfSignup/views/form.ts
@@ -16,7 +16,7 @@ export const signupFormSchema = yup.object({
   street1: yup.string().required('Street address is required'),
   street2: yup.string(),
   city: yup.string().required('City is required'),
-  state: yup.object({ value: yupStateSchema.required('State is required') }),
+  state: yupStateSchema.required('State is required'),
   postalCode: yup
     .string()
     .required('ZIP code is required')


### PR DESCRIPTION
* use Chakra's `<Select>` (uses native html `<select>`) instead of chakra-react-select (which is entirely custom and doesn't meet accessibility standard)
  * fixes on-device address prefill not working for State field (it was working for all other fields)

Part of PHO-205 ([ticket has video](https://linear.app/photon-health/issue/PHO-205/spike-reduce-provider-signup-time-via-address-autofill-address-loading#comment-3911eb86))