### PR TITLE
Toggle show and hide text; fix spacing around the content

### DIFF
--- a/packages/elements/src/photon-patient-form/photon-patient-form-component.tsx
+++ b/packages/elements/src/photon-patient-form/photon-patient-form-component.tsx
@@ -215,9 +215,13 @@ const PatientForm = (props: { patientId: string; optionalPatientAddress: boolean
     return prefOption;
   });
 
+  const optionalFieldsButtonText = () =>
+    showOptionalFields() ? 'Hide optional fields' : 'Show optional fields';
+  const optionalFieldsChevron = () => (showOptionalFields() ? 'chevronUp' : 'chevronDown');
+
   const AddressFields = () => (
     <>
-      <p class="font-sans text-lg mt-8">
+      <p class="font-sans text-lg mt-4 md:!mt-8">
         Address
         <Show when={props.optionalPatientAddress && !hasAnyAddressField()}>
           <span class="text-gray-500 text-sm font-normal"> (optional)</span>
@@ -403,15 +407,11 @@ const PatientForm = (props: { patientId: string; optionalPatientAddress: boolean
                   <AddressFields />
                 </Show>
                 <button
-                  class="mb-4 flex items-center md:!hidden"
+                  class="mb-4 mt-8 flex items-center md:!hidden"
                   onClick={() => setShowOptionalFields((value) => !value)}
                 >
-                  <span class="font-sans text-lg">Show optional fields</span>
-                  <Icon
-                    name={showOptionalFields() ? 'chevronUp' : 'chevronDown'}
-                    size="md"
-                    class="inline-block ml-1 mt-1"
-                  />
+                  <span class="font-sans text-lg">{optionalFieldsButtonText()}</span>
+                  <Icon name={optionalFieldsChevron()} size="md" class="inline-block ml-1 mt-1" />
                 </button>
                 <div class={`mb-4 ${showOptionalFields() ? 'block' : 'hidden md:!block'}`}>
                   <Show when={props.optionalPatientAddress}>

--- a/packages/elements/src/photon-patient-form/photon-patient-form-component.tsx
+++ b/packages/elements/src/photon-patient-form/photon-patient-form-component.tsx
@@ -215,10 +215,6 @@ const PatientForm = (props: { patientId: string; optionalPatientAddress: boolean
     return prefOption;
   });
 
-  const optionalFieldsButtonText = () =>
-    showOptionalFields() ? 'Hide optional fields' : 'Show optional fields';
-  const optionalFieldsChevron = () => (showOptionalFields() ? 'chevronUp' : 'chevronDown');
-
   const AddressFields = () => (
     <>
       <p class="font-sans text-lg mt-4 md:!mt-8">
@@ -410,8 +406,14 @@ const PatientForm = (props: { patientId: string; optionalPatientAddress: boolean
                   class="mb-4 mt-8 flex items-center md:!hidden"
                   onClick={() => setShowOptionalFields((value) => !value)}
                 >
-                  <span class="font-sans text-lg">{optionalFieldsButtonText()}</span>
-                  <Icon name={optionalFieldsChevron()} size="md" class="inline-block ml-1 mt-1" />
+                  <span class="font-sans text-lg">
+                    {showOptionalFields() ? 'Hide optional fields' : 'Show optional fields'}
+                  </span>
+                  <Icon
+                    name={showOptionalFields() ? 'chevronUp' : 'chevronDown'}
+                    size="md"
+                    class="inline-block ml-1 mt-1"
+                  />
                 </button>
                 <div class={`mb-4 ${showOptionalFields() ? 'block' : 'hidden md:!block'}`}>
                   <Show when={props.optionalPatientAddress}>

--- a/packages/elements/src/photon-patient-form/photon-patient-form-component.tsx
+++ b/packages/elements/src/photon-patient-form/photon-patient-form-component.tsx
@@ -217,6 +217,8 @@ const PatientForm = (props: { patientId: string; optionalPatientAddress: boolean
 
   const AddressFields = () => (
     <>
+      {/*Using !mt-8 because of tailwind issue in shadowDom elements */}
+      {/*when not using the !important modifier*/}
       <p class="font-sans text-lg mt-4 md:!mt-8">
         Address
         <Show when={props.optionalPatientAddress && !hasAnyAddressField()}>


### PR DESCRIPTION
* Toggle text between "Show" and "Hide" depending on whether toggle is showing or hiding
* Improve awkward spacing around the Show optional fields and Address headers

# New text/margin when showing
<img width="452" height="996" alt="Screenshot 2026-02-13 at 5 30 16 PM" src="https://github.com/user-attachments/assets/43b67cf1-5406-4dfa-80a0-ad98d2bca7ed" />

# New text/margin when hiding
<img width="456" height="998" alt="Screenshot 2026-02-13 at 5 30 10 PM" src="https://github.com/user-attachments/assets/15237799-d12d-4cc1-aba0-a22e7d5b8d47" />
