### PR TITLE
Remove redundant context setter that could override better data

### DIFF
--- a/apps/app/src/views/routes/Main.tsx
+++ b/apps/app/src/views/routes/Main.tsx
@@ -7,7 +7,6 @@ import { SelectOrg } from './SelectOrg';
 import { auth0Config } from '../../configs/auth';
 import useQueryParams from '../../hooks/useQueryParams';
 import { Env } from '@photonhealth/sdk';
-import { setInstrumentationUserContext } from '../../instrumentation/setInstrumentationUserContext';
 
 declare global {
   namespace JSX {
@@ -25,12 +24,6 @@ export const Main = () => {
   const { user, isAuthenticated, isLoading, error } = usePhoton();
   const location = useLocation();
   const navigate = useNavigate();
-
-  useEffect(() => {
-    if (isAuthenticated && !isLoading) {
-      setInstrumentationUserContext(user);
-    }
-  }, [isAuthenticated, isLoading]);
 
   useEffect(() => {
     if (!isLoading && error) {


### PR DESCRIPTION
There's a race condition between this invocation of `setInstrumentationUserContext` and the one in `apps/app/src/hooks/useProviderAnalytics.tsx`