### PR TITLE
Prettier runs on commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -167,10 +167,10 @@
   "lint-staged": {
     "**/*.{js,ts,jsx,tsx}": [
       "eslint",
-      "prettier --check"
+      "prettier --write"
     ],
     "**/*.{json,css,scss,md}": [
-      "prettier --check"
+      "prettier --write"
     ]
   },
   "optionalDependencies": {


### PR DESCRIPTION
Git commit check hooks often fail if prettier wasn't run. This automatically runs prettier on commit, in case developer hasn't configured their editor to run prettier on save.