### PR TITLE
add edit and delete test for adding a draft

### DIFF
--- a/apps/app/e2e/create_prescription.spec.ts
+++ b/apps/app/e2e/create_prescription.spec.ts
@@ -1,6 +1,8 @@
 import { expect, test } from '@playwright/test';
 
-test('user can create patient and add draft prescription', async ({ page }) => {
+test('user can create patient then add, edit, and delete a draft prescription', async ({
+  page
+}) => {
   await page.goto('/');
 
   await page.getByRole('link', { name: /Patients/ }).click();
@@ -25,6 +27,7 @@ test('user can create patient and add draft prescription', async ({ page }) => {
   const medSearchInput = page.getByPlaceholder('Type medication');
   await expect(medSearchInput).toBeVisible({ timeout: 30_000 });
 
+  // add draft
   await medSearchInput.fill('Amoxicillin');
   const amoxicillinOption = page
     .locator('sl-menu-item')
@@ -32,17 +35,30 @@ test('user can create patient and add draft prescription', async ({ page }) => {
     .first();
   await expect(amoxicillinOption).toBeVisible({ timeout: 10_000 });
   await amoxicillinOption.click();
-
   await page.getByLabel('Quantity').fill('30');
   await page.getByLabel('Dispense Unit').selectOption('Capsule');
   await page.getByLabel('Days Supply').fill('10');
   await page.getByLabel('Refills').fill('0');
   await page.getByLabel('Patient Instructions (SIG)').fill('test-instructions-text');
-
   await page.getByRole('button', { name: 'Add to drafts' }).click();
-
   await expect(page.getByText('Draft Prescriptions')).toBeVisible({ timeout: 10_000 });
   await expect(page.getByText(/Amoxicillin/i)).toBeVisible();
+  await expect(page.getByText(/30 Capsule, 0 Refills - test-instructions-text/i)).toBeVisible();
+
+  // edit draft
+  await page.getByTitle('Edit').click();
+  await expect(medSearchInput).toHaveValue(/Amoxicillin/i);
+  await page.getByLabel('Quantity').fill('60');
+  await page.getByRole('button', { name: 'Add to drafts' }).click();
+  await expect(page.getByText(/60 Capsule, 0 Refills - test-instructions-text/i)).toBeVisible();
+  await expect(page.getByText('Draft Prescriptions')).toBeVisible({ timeout: 10_000 });
+  await expect(page.getByText(/Amoxicillin/i)).toBeVisible();
+
+  // delete draft
+  await page.getByTitle('Delete').click();
+  await page.getByRole('button', { name: 'Yes, Delete' }).click();
+  await expect(page.getByText(/Delete pending prescription/i)).not.toBeVisible({ timeout: 5_000 });
+  await expect(page.getByText(/Add prescription\(s\) before sending/i)).toBeVisible();
 
   // before uncommenting this and sending the order,
   // we need to decide what test patient phone number to use since currently text messages are sent

--- a/packages/elements/src/photon-multirx-form/components/AddPrescriptionCard.tsx
+++ b/packages/elements/src/photon-multirx-form/components/AddPrescriptionCard.tsx
@@ -252,6 +252,7 @@ export const AddPrescriptionCard = (props: {
               <InputGroup label="Quantity" required error={props.store.dispenseQuantity?.error}>
                 <Input
                   type="number"
+                  inputMode="decimal"
                   value={props.store.dispenseQuantity?.value ?? undefined}
                   min={0}
                   onInput={(e: InputEvent & { currentTarget: HTMLInputElement }) => {
@@ -317,6 +318,7 @@ export const AddPrescriptionCard = (props: {
           <InputGroup label="Days Supply" required error={props.store.daysSupply?.error}>
             <Input
               type="number"
+              inputMode="numeric"
               value={props.store.daysSupply?.value ?? undefined}
               min={0}
               onInput={(e: InputEvent & { currentTarget: HTMLInputElement }) => {
@@ -330,6 +332,7 @@ export const AddPrescriptionCard = (props: {
           <InputGroup label="Refills" required error={props.store.refillsInput?.error}>
             <Input
               type="number"
+              inputMode="numeric"
               value={props.store.refillsInput?.value ?? undefined}
               min={0}
               max={11}


### PR DESCRIPTION
* update e2e test
* set the `inputMode` for number fields (quantity, days supply, refills) so that iOS/android show number keyboards on input focus.