### PR TITLE
feat(settings): add LillyDirect to Form Health mail order pharmacies

### DIFF
--- a/packages/settings/src/lib/photon.ts
+++ b/packages/settings/src/lib/photon.ts
@@ -245,5 +245,9 @@ const organizationSettings: {
   // openloop
   org_Oxc0CSPfdiyWW3VM: {
     provider: [NOVOCARE_PHARMACY_ID]
+  },
+  // Form Health
+  org_vhFRkpsq7JXLxjXr: {
+    provider: [GIFTHEALTH_PHARMACY_ID]
   }
 };


### PR DESCRIPTION
## Summary

- Adds GiftHealth / LillyDirect Self Pay (`phr_01J6APWHGNFJCE74SB031VYPHW`) to Form Health's (`org_vhFRkpsq7JXLxjXr`) `provider` mail order list in `photon.ts`
- Form Health providers were unable to see LillyDirect in the Mail Order tab of the Elements prescribing widget, blocking their KwikPen rollout
- This is a **bridge config** while Form Health implements the preferred long-term solution: passing `pharmacy-id` as a client-side attribute on the Elements widget

## Context

- Partner request from Emily Wang (Form Health) — live rollout blocker as of today
- Routing constraint audit confirmed: constraint system is advisory-only, no backend validation is bypassed by this change
- Long-term: Form Health will pass `pharmacy-id="phr_01J6APWHGNFJCE74SB031VYPHW"` directly in their Elements widget integration, at which point this config entry can be removed or expanded

## Test plan

- [ ] Verify Form Health provider org can see LillyDirect Self Pay in the Mail Order tab in the Elements widget (production)
- [ ] Confirm no other org's pharmacy list is affected
- [ ] Confirm existing auto-routing logic for other orgs using GiftHealth (Found, Ognomy, Measured) is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)