### PR TITLE
Setup boson-targeting e2e test

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -1,31 +1,28 @@
 name: Playwright Smoke Tests
 on:
   repository_dispatch:
-    types:
-#      - codebuild-complete
-# todo: discuss with team when to run this workflow. (e.g. after client/backend deployments? before?)
+    types: [ smoke-test ]
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Environment to test against'
+        type: choice
+        options:
+          - boson
+          - neutron
+        default: boson
 
 jobs:
   test:
     timeout-minutes: 10
     runs-on: ubuntu-latest
+    environment: ${{ github.event.client_payload.environment || inputs.environment || 'boson' }}
+    env:
+      TARGET_ENV: ${{ github.event.client_payload.environment || inputs.environment || 'boson' }}
 
     steps:
-      - name: Print CodeBuild completion event payload
-        run: |
-          echo "CodeBuild deployment completed"
-          echo "Branch Name: ${{ github.event.client_payload.branchName }}"
-
-      - name: Set playwright base url
-        uses: actions/github-script@v5
-        with:
-          script: |
-            const branchName = "${{github.event.client_payload.branchName}}"
-            const ref = branchName.replace(/\//g, "_")
-            const baseUrl = `https://app-${ref}.boson.health`
-            core.exportVariable('PLAYWRIGHT_BASE_URL', baseUrl);
-
       - uses: actions/checkout@v4
+
       - name: Use Node.js 20.x
         uses: actions/setup-node@v4
         with:
@@ -40,8 +37,12 @@ jobs:
 
       - name: Run Playwright tests
         run: |
-          echo "Running tests against $PLAYWRIGHT_BASE_URL"
+          echo "Running smoke tests against https://app.${TARGET_ENV}.health"
           npx nx run app:e2e:ci
+        env:
+          PLAYWRIGHT_BASE_URL: https://app.${{ env.TARGET_ENV }}.health
+          PLAYWRIGHT_E2E_ACCOUNT_USERNAME: ${{ secrets.PLAYWRIGHT_E2E_ACCOUNT_USERNAME }}
+          PLAYWRIGHT_E2E_ACCOUNT_PASSWORD: ${{ secrets.PLAYWRIGHT_E2E_ACCOUNT_PASSWORD }}
 
       - uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,6 +178,8 @@ const mailOrderProviders = getOrgMailOrderPharms(user?.org_id)?.provider;
 
 Environment is selected via `env-cmd -f .env.<name>` in Nx targets.
 
+**Nx automatic `.env` loading:** Nx automatically loads `.env.local` (and other `.env` files) from the project root before running any target. Variables loaded first take precedence — Nx won't overwrite a variable already set in the process. This means `.env.local` values are available to all Nx targets without explicit `env-cmd` references. For example, Playwright credentials (`PLAYWRIGHT_E2E_ACCOUNT_USERNAME`, `PLAYWRIGHT_E2E_ACCOUNT_PASSWORD`) and `PLAYWRIGHT_BASE_URL` stored in `apps/app/.env.local` are automatically available when running `nx run app:e2e`, even though that target only explicitly loads `.env.boson` via `env-cmd`.
+
 ### Backend APIs
 
 The platform has two backend API layers. The SDK (`packages/sdk`) maintains separate Apollo clients for each:

--- a/apps/app/.env.local.sample
+++ b/apps/app/.env.local.sample
@@ -1,3 +1,9 @@
+# For local dev server:
 PLAYWRIGHT_BASE_URL=http://localhost:3000
+
+# For deployed environments:
+# PLAYWRIGHT_BASE_URL=https://app.boson.health
+# PLAYWRIGHT_BASE_URL=https://app.neutron.health
+
 PLAYWRIGHT_E2E_ACCOUNT_USERNAME="test_user_1"
 PLAYWRIGHT_E2E_ACCOUNT_PASSWORD="PASTE_FROM_PASSWORD_MANAGER"

--- a/apps/app/playwright.config.ts
+++ b/apps/app/playwright.config.ts
@@ -1,5 +1,7 @@
 import { defineConfig, devices } from '@playwright/test';
 
+const baseUrl = process.env.PLAYWRIGHT_BASE_URL ?? 'http://localhost:3000';
+
 /**
  * See https://playwright.dev/docs/test-configuration.
  */
@@ -14,7 +16,7 @@ export default defineConfig({
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: 'html',
   use: {
-    baseURL: process.env.PLAYWRIGHT_BASE_URL,
+    baseURL: baseUrl,
     trace: 'on-first-retry'
   },
   projects: [
@@ -28,10 +30,18 @@ export default defineConfig({
       dependencies: ['setup']
     }
   ],
-  webServer: {
-    command: 'nx start',
-    url: process.env.PLAYWRIGHT_BASE_URL ?? 'http://localhost:3000',
-    reuseExistingServer: !process.env.CI,
-    timeout: 180_000
-  }
+  ...localDevServer()
 });
+
+function localDevServer(): { webServer: ReturnType<typeof defineConfig>['webServer'] } | {} {
+  if (!baseUrl.includes('localhost')) return {};
+  // for local dev, start (or re-use if running) the already running app
+  return {
+    webServer: {
+      command: 'nx start',
+      url: baseUrl,
+      reuseExistingServer: !process.env.CI,
+      timeout: 180_000
+    }
+  };
+}


### PR DESCRIPTION
* e2e tests can be run against `boson` and `neutron` by setting `PLAYWRIGHT_BASE_URL` env var in the `.env.local` file
* I setup two environments on the `client` repo [github settings](https://github.com/Photon-Health/client/settings/environments): boson and neutron.
  * these enable each environment to have different values for env vars when running `smoke_tests` repository_dispatch job :
    * `PLAYWRIGHT_BASE_URL`
    * `PLAYWRIGHT_E2E_ACCOUNT_USERNAME`
    * `PLAYWRIGHT_E2E_ACCOUNT_PASSWORD` 
* Going to add Post-merge `repository_dispatch` calls to run Boson e2e tests after lambdas merge, services-infra boson merge, and potentially dependabot auto-merges some day



This sort of job step in a Github Action will invoke the `smoke-tests`:
```
  - name: Trigger e2e smoke tests
    run: |
      gh api repos/Photon-Health/client/dispatches \
        --field event_type=smoke-test \
        --field 'client_payload[environment]=boson'
    env:
      GH_TOKEN: ${{ secrets.CROSS_REPO_PAT }}
```

Part of PHO-290