### PR TITLE
allow e2e test to specify login connection

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -41,7 +41,7 @@ jobs:
           npx nx run app:e2e:ci
         env:
           PLAYWRIGHT_BASE_URL: https://app.${{ env.TARGET_ENV }}.health
-          PLAYWRIGHT_E2E_ACCOUNT_USERNAME: ${{ secrets.PLAYWRIGHT_E2E_ACCOUNT_USERNAME }}
+          PLAYWRIGHT_E2E_ACCOUNT_USERNAME: ${{ vars.PLAYWRIGHT_E2E_ACCOUNT_USERNAME }}
           PLAYWRIGHT_E2E_ACCOUNT_PASSWORD: ${{ secrets.PLAYWRIGHT_E2E_ACCOUNT_PASSWORD }}
 
       - uses: actions/upload-artifact@v4

--- a/apps/app/e2e/auth.setup.ts
+++ b/apps/app/e2e/auth.setup.ts
@@ -5,7 +5,8 @@ import * as path from 'path';
 const authFile = path.join(__dirname, './.auth/user.json');
 
 setup('authenticate', async ({ page }) => {
-  await page.goto(`/`);
+  // both boson and neutron have Auth0 connections named "e2e-test-users"
+  await page.goto(`/login?connection=e2e-test-users`);
   await expect(page).toHaveTitle(/Photon/);
   await page.getByRole('button', { name: 'Log in' }).click();
   await expect(page.getByText('Log in to continue to Photon Clinical App')).toBeVisible();

--- a/apps/app/src/views/routes/Login.tsx
+++ b/apps/app/src/views/routes/Login.tsx
@@ -14,6 +14,7 @@ import {
 import { Navigate, useLocation, useSearchParams } from 'react-router-dom';
 
 import { usePhoton } from '@photonhealth/react';
+import type { LoginOptions } from '@photonhealth/sdk';
 import { Logo } from '../components/Logo';
 import useQueryParams from '../../hooks/useQueryParams';
 
@@ -27,6 +28,7 @@ export const Login = () => {
   const [searchParams] = useSearchParams();
   const invite = searchParams.get('invitation');
   const org = searchParams.get('organization');
+  const connection = searchParams.get('connection');
 
   if (invite && org) {
     login({
@@ -40,7 +42,20 @@ export const Login = () => {
   }
 
   const onLoginClick = () => {
-    login({ appState: { returnTo: location.state?.returnToAfterLogin } });
+    const loginOptions: LoginOptions = {
+      appState: { returnTo: location.state?.returnToAfterLogin }
+    };
+
+    // only including the e2e connection because we want it to be easy for the automated
+    // e2e tests to get to an auth0 login page with only the username/password fields.
+    // When not specifying a connection in Neutron, for example, auth0 shows email/password by default
+    // since we have an email/password db connection for some customer testing.
+    const allowedConnections = ['e2e-test-users'];
+    if (connection && allowedConnections.includes(connection)) {
+      loginOptions.connection = connection;
+    }
+
+    login(loginOptions);
   };
 
   const presentedError = presentError(error);

--- a/apps/app/src/views/routes/Login.tsx
+++ b/apps/app/src/views/routes/Login.tsx
@@ -50,6 +50,7 @@ export const Login = () => {
     // e2e tests to get to an auth0 login page with only the username/password fields.
     // When not specifying a connection in Neutron, for example, auth0 shows email/password by default
     // since we have an email/password db connection for some customer testing.
+    // Doing an allowList because we aren't necessarily ready to open up connection-based login for the whole world.
     const allowedConnections = ['e2e-test-users'];
     if (connection && allowedConnections.includes(connection)) {
       loginOptions.connection = connection;

--- a/packages/sdk/src/lib.ts
+++ b/packages/sdk/src/lib.ts
@@ -18,6 +18,8 @@ import {
   lambdasApiUrl
 } from './utils';
 import pkg from '../package.json';
+
+export type { LoginOptions } from './auth';
 export * as types from './types';
 export * as fragments from './fragments';
 export * from './graphql/clinical-api/query';


### PR DESCRIPTION
This change allows e2e tests to navigate to `https://app.neutron.health/login?connection=e2e-test-users` so that the Login button navigates to an auth0 page that shows the **username**/password fields (which are required for the `e2e-test-users` connection). 

Before this PR, login page didn't provide a way to specify connection, and auth0 was defaulting to the **email**/password fields used by some customers testing the app.

* also, update smoke-tests job to use config var for username param

Part of PHO-290