### PR TITLE
better dependabot PR groups; fix playwright report path

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,16 +7,61 @@ updates:
       day: "monday"
       time: "08:00"
       timezone: "America/New_York"
-    open-pull-requests-limit: 2
-    allow:
-      - dependency-type: "all"
+    open-pull-requests-limit: 3
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-patch"]
     groups:
+      # Security updates stay grouped for fast remediation
       security:
         applies-to: security-updates
         patterns: ["*"]
-      general:
+      # Minor updates grouped by ecosystem
+      react-and-ui:
         applies-to: version-updates
-        patterns: ["*"]
+        update-types: ["minor"]
+        patterns:
+          - "react*"
+          - "@types/react*"
+          - "@chakra-ui/*"
+          - "@emotion/*"
+      testing:
+        applies-to: version-updates
+        update-types: ["minor"]
+        patterns:
+          - "@testing-library/*"
+          - "@solidjs/testing-library"
+          - "jest*"
+          - "@types/jest"
+          - "vitest*"
+          - "@playwright/*"
+          - "playwright*"
+      linting:
+        applies-to: version-updates
+        update-types: ["minor"]
+        patterns:
+          - "eslint*"
+          - "prettier*"
+          - "@typescript-eslint/*"
+      build-and-tooling:
+        applies-to: version-updates
+        update-types: ["minor"]
+        patterns:
+          - "typescript"
+          - "vite*"
+          - "webpack*"
+          - "nx"
+          - "@nx/*"
+          - "env-cmd"
+          - "husky"
+          - "lint-staged"
+      # Major updates get individual PRs (not grouped)
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "08:00"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 2

--- a/.github/workflows/pr-e2e-tests.yml
+++ b/.github/workflows/pr-e2e-tests.yml
@@ -36,5 +36,5 @@ jobs:
         if: ${{ !cancelled() }}
         with:
           name: playwright-report
-          path: playwright-report/
+          path: apps/app/playwright-report/
           retention-days: 30

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -48,5 +48,5 @@ jobs:
         if: ${{ !cancelled() }}
         with:
           name: playwright-report
-          path: playwright-report/
+          path: apps/app/playwright-report/
           retention-days: 30


### PR DESCRIPTION
* add smarter groups to dependabot PR creation
* Trying to fix error/warning on smoke tests job:  `No files were found with the provided path: playwright-report/. No artifacts will be uploaded.`