### PR TITLE
Add permissions to workflows to fix codescan vulns

### DIFF
--- a/.github/workflows/auto-bump-neutron.yml
+++ b/.github/workflows/auto-bump-neutron.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [boson]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   bumpAndOpen:
     name: Bump neutron

--- a/.github/workflows/auto-bump-photon.yml
+++ b/.github/workflows/auto-bump-photon.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [neutron]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   bumpAndOpen:
     name: Bump Photon

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [boson, neutron, photon]
 
+permissions:
+  contents: read
+
 jobs:
   run-linters:
     name: Run linters

--- a/.github/workflows/merge-bot.yml
+++ b/.github/workflows/merge-bot.yml
@@ -8,6 +8,10 @@ on:
       - unlabeled
     branches: [neutron, photon]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   merge:
     name: Merge

--- a/.github/workflows/pr-e2e-tests.yml
+++ b/.github/workflows/pr-e2e-tests.yml
@@ -3,6 +3,9 @@ on:
   pull_request:
     branches: [boson]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     timeout-minutes: 10

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [boson, neutron, photon]
 
+permissions:
+  contents: read
+
 jobs:
   prettier:
     name: Prettier

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -12,6 +12,9 @@ on:
           - neutron
         default: boson
 
+permissions:
+  contents: read
+
 jobs:
   test:
     timeout-minutes: 10

--- a/.github/workflows/type-check.yml
+++ b/.github/workflows/type-check.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [boson, neutron, photon]
 
+permissions:
+  contents: read
+
 jobs:
   run-linters:
     name: Run type check

--- a/.github/workflows/vitest.yml
+++ b/.github/workflows/vitest.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: ['boson']
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Vitest


### PR DESCRIPTION
Fixing medium vulns seen here: https://github.com/Photon-Health/client/security/code-scanning

Most of our workflows dont need the default read/write and are explicitly set to read now.