### PR TITLE
remove unused s3 deployment and dependencies

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -62,9 +62,9 @@ jobs:
               for PACKAGE in $PACKAGES
               do
                   echo "Publishing $PACKAGE..."
-                  
+
                   cd $PACKAGE
-                  
+
                   PACKAGE_VERSION=$(node -p "require('./package.json').version")
                   PACKAGE_NAME=$(basename $PACKAGE)
                   PACKAGE_TAG="${PACKAGE_NAME}_v${PACKAGE_VERSION}"
@@ -81,37 +81,7 @@ jobs:
 
                   git tag -a $PACKAGE_TAG -m "$PACKAGE_BODY"
                   git push origin $PACKAGE_TAG
-                  
+
                   cd -
-              done
-          fi
-
-      - name: Upload to S3
-        run: |
-          PACKAGES="${{ steps.check.outputs.packages }}"
-          if [ -z "$PACKAGES" ]
-          then
-              echo "No package updates found. Skipping S3 upload."
-          else
-              for PACKAGE in $PACKAGES
-              do
-                  PACKAGE_NAME=$(basename $PACKAGE)
-
-                  if [[ "$PACKAGE_NAME" == "elements" ]]
-                  then
-                      echo "Package updates found for Elements"
-                      cd $PACKAGE && npm run build:prod
-                      
-                      PACKAGE_VERSION=$(node -p "require('./package.json').version")
-                      PREFIX="elements/v${PACKAGE_VERSION}"
-                      PREFIX_LATEST="elements/@latest"
-                      AWS_ACCESS_KEY_ID="${{ secrets.AWS_ACCESS_KEY_ID }}"
-                      AWS_SECRET_ACCESS_KEY="${{ secrets.AWS_SECRET_ACCESS_KEY }}"
-
-                      echo "Uploading Elements to S3..."
-                      npm run upload-s3
-
-                      cd -
-                  fi
               done
           fi

--- a/package-lock.json
+++ b/package-lock.json
@@ -124,7 +124,6 @@
         "prettier": "^2.8.1",
         "react-test-renderer": "^18.2.0",
         "rimraf": "^5.0.1",
-        "s3-deploy": "^1.4.0",
         "storybook": "^10.2.13",
         "tw-colors": "^1.2.6",
         "typescript-eslint": "^8.33.0",
@@ -13561,59 +13560,6 @@
         "node": ">=14"
       }
     },
-    "node_modules/aws-sdk": {
-      "version": "2.1693.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1693.0.tgz",
-      "integrity": "sha512-cJmb8xEnVLT+R6fBS5sn/EFJiX7tUnDaPtOPZ1vFbOJtd0fnZn/Ky2XGgsvvoeliWeH7mL3TWSX5zXXGSQV6gQ==",
-      "deprecated": "The AWS SDK for JavaScript (v2) has reached end-of-support, and no longer receives updates. Please migrate your code to use AWS SDK for JavaScript (v3). More info https://a.co/cUPnyil",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "buffer": "4.9.2",
-        "events": "1.1.1",
-        "ieee754": "1.1.13",
-        "jmespath": "0.16.0",
-        "querystring": "0.2.0",
-        "sax": "1.2.1",
-        "url": "0.10.3",
-        "util": "^0.12.4",
-        "uuid": "8.0.0",
-        "xml2js": "0.6.2"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/aws-sdk/node_modules/buffer": {
-      "version": "4.9.2",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
-      "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.0.2",
-        "ieee754": "^1.1.4",
-        "isarray": "^1.0.0"
-      }
-    },
-    "node_modules/aws-sdk/node_modules/ieee754": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/aws-sdk/node_modules/uuid": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.0.0.tgz",
-      "integrity": "sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/axios": {
       "version": "1.13.6",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
@@ -13984,18 +13930,6 @@
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
-    "node_modules/babel-polyfill": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
-      "integrity": "sha512-F2rZGQnAdaHWQ8YAoeRbukc7HS9QgdgeyJ0rQDd485v9opwuPvjpPFcOOT/WmkKTdgy9ESgSPXDcTNpzrGr6iQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "babel-runtime": "^6.26.0",
-        "core-js": "^2.5.0",
-        "regenerator-runtime": "^0.10.5"
-      }
-    },
     "node_modules/babel-preset-current-node-syntax": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.2.0.tgz",
@@ -14097,24 +14031,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/babel-runtime": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-      "integrity": "sha512-ITKNuq2wKlW1fJg9sSW52eepoYgZBggvOAHC0u/CYu/qxQ9EVzThCgR69BnSXLHjy2f7SY5zaQ4yt7H9ZVxY2g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "core-js": "^2.4.0",
-        "regenerator-runtime": "^0.11.0"
-      }
-    },
-    "node_modules/babel-runtime/node_modules/regenerator-runtime": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/balanced-match": {
       "version": "4.0.4",
@@ -14946,73 +14862,6 @@
         "node": ">= 0.12.0"
       }
     },
-    "node_modules/co-from-stream": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/co-from-stream/-/co-from-stream-0.0.0.tgz",
-      "integrity": "sha512-w1GOkQmvYMWr5B3VsjyS/gxXd5YLhy4wcC1YxwajoGgMFJQLSsuzTxb6o9SiK+TMKN+DRJpsj4MN0CeOKSDAQA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "co-read": "0.0.1"
-      }
-    },
-    "node_modules/co-fs-extra": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/co-fs-extra/-/co-fs-extra-1.2.1.tgz",
-      "integrity": "sha512-zvN7PK5lcqgoxetadOTaYxQyyl0qBn6szmb6o8Xf6CjHnqv8zI9YdjbQhjE3OmKyJgN4WzUec1pGf7i9LLL8+g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "co-from-stream": "~0.0.0",
-        "fs-extra": "~0.26.5",
-        "thunkify-wrap": "~1.0.4"
-      }
-    },
-    "node_modules/co-fs-extra/node_modules/fs-extra": {
-      "version": "0.26.7",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.26.7.tgz",
-      "integrity": "sha512-waKu+1KumRhYv8D8gMRCKJGAMI9pRnPuEb1mvgYD0f7wBscg+h6bW4FDTmEZhB9VKxvoTtxW+Y7bnIlB7zja6Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^2.1.0",
-        "klaw": "^1.0.0",
-        "path-is-absolute": "^1.0.0",
-        "rimraf": "^2.2.8"
-      }
-    },
-    "node_modules/co-fs-extra/node_modules/jsonfile": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
-      "integrity": "sha512-PKllAqbgLgxHaj8TElYymKCAgrASebJrWpTnEkOaTowt23VKXXN0sUeriJ+eh7y6ufb/CC5ap11pz71/cM0hUw==",
-      "dev": true,
-      "license": "MIT",
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/co-fs-extra/node_modules/rimraf": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      }
-    },
-    "node_modules/co-read": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/co-read/-/co-read-0.0.1.tgz",
-      "integrity": "sha512-OLceyyztHxwNtjuS2NjQ3QlczQIwOIW+n18DXAk89ej0wDso3exNvNrB7A3AiTVvFNEFe8LdqETIvRhtpkvLeA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/codemirror": {
       "version": "5.65.21",
       "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.65.21.tgz",
@@ -15363,15 +15212,6 @@
       "dependencies": {
         "toggle-selection": "^1.0.6"
       }
-    },
-    "node_modules/core-js": {
-      "version": "2.6.12",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
-      "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
-      "deprecated": "core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT"
     },
     "node_modules/core-js-compat": {
       "version": "3.48.0",
@@ -16379,16 +16219,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/enable": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/enable/-/enable-1.3.2.tgz",
-      "integrity": "sha512-X836S0L169pR8DOBMw6pWruSSUuosq7yTjzD74neq6k9I4XJD50R648Hl7G0j3On0a3uAfqWd6oE5WtyIRb3Lg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.10.0"
-      }
-    },
     "node_modules/encodeurl": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
@@ -17211,16 +17041,6 @@
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/events": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
-      "integrity": "sha512-kEcvvCBByWXGnZy6JUlgAp2gBIUjfCAV6P6TgT1/aaQKcmuAEC4OZTV1I4EWQLz2gxZw76atuVyvHhTxvi0Flw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.x"
-      }
     },
     "node_modules/execa": {
       "version": "5.1.1",
@@ -19478,23 +19298,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-arguments": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
-      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "has-tostringtag": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-array-buffer": {
@@ -24066,16 +23869,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/jmespath": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
-      "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">= 0.6.0"
-      }
-    },
     "node_modules/jose": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.0.tgz",
@@ -24380,16 +24173,6 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
-      }
-    },
-    "node_modules/klaw": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
-      "integrity": "sha512-TED5xi9gGQjGpNnvRWknrwAB1eL5GciPfVFOt3Vk1OJCVDQbzuSfrF3hkUQKlsgKrG1F+0t5W0m+Fje1jIt8rw==",
-      "dev": true,
-      "license": "MIT",
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.9"
       }
     },
     "node_modules/known-css-properties": {
@@ -26840,16 +26623,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -27551,13 +27324,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/punycode": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-      "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/pure-rand": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-7.0.1.tgz",
@@ -27629,16 +27395,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/querystring": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==",
-      "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
-      "dev": true,
-      "engines": {
-        "node": ">=0.4.x"
       }
     },
     "node_modules/queue-microtask": {
@@ -28246,13 +28002,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/regenerator-runtime": {
-      "version": "0.10.5",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-      "integrity": "sha512-02YopEIhAgiBHWeoTiA8aitHDt8z6w+rQqNuIftlM+ZtvSl/brTouaU7DW6GO/cHtvxJvS4Hwv2ibKdxIRi24w==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
@@ -28696,27 +28445,6 @@
         "tslib": "^2.1.0"
       }
     },
-    "node_modules/s3-deploy": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/s3-deploy/-/s3-deploy-1.4.0.tgz",
-      "integrity": "sha512-ukUqA0YbXrTMjQfdX/lbszAcaRCB/jRADz5b7m0eTW/Vdb8c744zdyl3u0Y48euT9TvNdR+QU6qb1NHjMfl/kg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "aws-sdk": "^2.334.0",
-        "babel-polyfill": "^6.26.0",
-        "co": "^4.5.4",
-        "co-fs-extra": "^1.0.1",
-        "glob": "^7.1.3",
-        "globrex": "^0.1.1",
-        "lodash": "^4.17.11",
-        "mime": "^1.4.1",
-        "minimist": "^1.1.1"
-      },
-      "bin": {
-        "s3-deploy": "bin/s3-deploy"
-      }
-    },
     "node_modules/safe-array-concat": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
@@ -28864,13 +28592,6 @@
         "type": "individual",
         "url": "https://paulmillr.com/funding/"
       }
-    },
-    "node_modules/sax": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
-      "integrity": "sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/saxes": {
       "version": "6.0.0",
@@ -30657,16 +30378,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/thunkify-wrap": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/thunkify-wrap/-/thunkify-wrap-1.0.4.tgz",
-      "integrity": "sha512-FNuuz3q6uxhAAI1K8BBTMZE061e7pGMdXOfQdCyiJDSq+YpCVzfLncdGjRMezf+WDFH5JCafupv7c824QnuNag==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "enable": "1"
-      }
-    },
     "node_modules/timeout-signal": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/timeout-signal/-/timeout-signal-2.0.0.tgz",
@@ -31618,17 +31329,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/url": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
-      "integrity": "sha512-hzSUW2q06EqL1gKM/a+obYHLIO6ct2hwPuviqTTOcfFVc61UbfJ2Q32+uGL/HCPxKqrdGB5QUwIe7UqlDgwsOQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "punycode": "1.3.2",
-        "querystring": "0.2.0"
-      }
-    },
     "node_modules/url-join": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
@@ -31719,20 +31419,6 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/util": {
-      "version": "0.12.5",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
-      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "is-arguments": "^1.0.4",
-        "is-generator-function": "^1.0.7",
-        "is-typed-array": "^1.1.3",
-        "which-typed-array": "^1.1.2"
       }
     },
     "node_modules/util-deprecate": {
@@ -32620,30 +32306,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/xml2js": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
-      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "sax": ">=0.6.0",
-        "xmlbuilder": "~11.0.0"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/xmlbuilder": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
-      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
       }
     },
     "node_modules/xmlchars": {

--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
     "prettier": "^2.8.1",
     "react-test-renderer": "^18.2.0",
     "rimraf": "^5.0.1",
-    "s3-deploy": "^1.4.0",
     "storybook": "^10.2.13",
     "tw-colors": "^1.2.6",
     "typescript-eslint": "^8.33.0",

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -10,11 +10,6 @@
     "build:prod": "npx nx run elements:build",
     "build:watch": "rimraf dist && vite build --watch",
     "prepublishOnly": "npm run build:prod",
-    "upload-s3": "npm run upload-s3:package-json && npm run upload-s3:dist && npm run upload-s3:package-json-latest && npm run upload-s3:dist-latest",
-    "upload-s3:package-json": "s3-deploy './package.json' --cwd './' --region 'us-east-1' --bucket 'cdn.rx.dev' --filePrefix $PREFIX",
-    "upload-s3:dist": "s3-deploy './dist/**' --cwd './dist/' --region 'us-east-1' --bucket 'cdn.rx.dev' --filePrefix $PREFIX/dist",
-    "upload-s3:package-json-latest": "s3-deploy './package.json' --cwd './' --region 'us-east-1' --bucket 'cdn.rx.dev' --filePrefix $PREFIX_LATEST",
-    "upload-s3:dist-latest": "s3-deploy './dist/**' --cwd './dist/' --region 'us-east-1' --bucket 'cdn.rx.dev' --filePrefix $PREFIX_LATEST/dist",
     "lint": "eslint src",
     "lint:only-errors": "eslint src --quiet",
     "lint:fix": "eslint src --fix"


### PR DESCRIPTION
* Remove `s3-deploy` scripts because they caused a small vuln, package not maintained any more, created package noise in our repo. This was part of a deprecated experiment years ago to host our elements/sdk  libraries in s3. We use npm now, and it's fine.