### PR TITLE
fix SupervisorCard npi input bug

### DIFF
--- a/packages/elements/src/photon-multirx-form/components/SupervisorCard.tsx
+++ b/packages/elements/src/photon-multirx-form/components/SupervisorCard.tsx
@@ -152,7 +152,7 @@ const NewSupervisorForm = (props: NewSupervisorFormProps) => {
       setSubmitting(true);
       try {
         validate();
-        if (!isValid) {
+        if (!isValid()) {
           throw new Error();
         }
         const { data } = await client.sdk.apolloClinical.mutate({
@@ -160,7 +160,7 @@ const NewSupervisorForm = (props: NewSupervisorFormProps) => {
           variables: {
             firstName: values.firstName,
             lastName: values.lastName,
-            npi: values.npi
+            npi: String(values.npi)
           }
         });
         if (data?.createSupervisor) {


### PR DESCRIPTION
Switched the NPI input to a number type for better mobile experience > switched the input value type from string to number > number not accepted by GraphQL schema