### PR TITLE
Dependabot auto approves and merges security PRs

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,37 @@
+name: Dependabot Auto Merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+
+      - uses: tibdex/github-app-token@v1
+        if: steps.metadata.outputs.dependency-group == 'security'
+        id: generate-token
+        with:
+          app_id: ${{ secrets.CPR_APP_ID }}
+          private_key: ${{ secrets.CPR_APP_SECRET }}
+
+      - name: Approve PR
+        if: steps.metadata.outputs.dependency-group == 'security'
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+
+      - name: Enable auto-merge
+        if: steps.metadata.outputs.dependency-group == 'security'
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,6 +1,8 @@
 name: Dependabot Auto Merge
 
-on: pull_request
+on:
+  pull_request:
+    branches: [ boson ]
 
 permissions:
   contents: write


### PR DESCRIPTION
* New workflow will auto approve and auto merge Dependabot Security updates.
* These PRs will still require all status checks as a normal PR (e.g. unit tests, e2e tests).