### PR TITLE
Multi meds pricing ap

### DIFF
--- a/apps/patient/src/api/internal.ts
+++ b/apps/patient/src/api/internal.ts
@@ -28,11 +28,7 @@ export const getOffers = async (orderId: string) => {
 
 export const getOfferBundles = async (orderId: string) => {
   const response = await graphQLClient.GetOfferBundlesForOrder({ orderId: orderId });
-  if (response.offerBundles) {
-    return response.offerBundles;
-  } else {
-    throw new Error('No offer bundles found');
-  }
+  return response.offerBundles;
 };
 
 export const getPharmaciesByLocation = async ({

--- a/apps/patient/src/api/internal.ts
+++ b/apps/patient/src/api/internal.ts
@@ -25,6 +25,16 @@ export const getOffers = async (orderId: string) => {
     throw new Error('No offers found');
   }
 };
+
+export const getOfferBundles = async (orderId: string) => {
+  const response = await graphQLClient.GetOfferBundlesForOrder({ orderId: orderId });
+  if (response.offerBundles) {
+    return response.offerBundles;
+  } else {
+    throw new Error('No offer bundles found');
+  }
+};
+
 export const getPharmaciesByLocation = async ({
   searchParams,
   limit,

--- a/apps/patient/src/components/offers/OfferInfo.tsx
+++ b/apps/patient/src/components/offers/OfferInfo.tsx
@@ -1,8 +1,8 @@
 import { Box, HStack, Image, Tag, TagLabel, TagLeftIcon, Text, VStack } from '@chakra-ui/react';
-import { FiInfo, FiStar } from 'react-icons/fi';
+import { FiInfo, FiStar, FiTag } from 'react-icons/fi';
 import { Tooltip } from './Tooltip';
 import { text as t } from '../../utils/text';
-import { OfferDetails } from '../../utils/models';
+import { OfferBundleDetails, OfferDetails, Promotion } from '../../utils/models';
 import { formatPrice } from '../../utils/formatters';
 
 const PreferredTag = () => {
@@ -31,9 +31,32 @@ const CurrentPharmacyTag = () => {
   );
 };
 
+const getLargestPromotionAmount = (promotions: Array<Promotion> | undefined): number =>
+  Math.max(...(promotions ?? []).map((p) => p.amountSaved ?? 0));
+
+const CouponTag = ({ promotions }: { promotions?: Array<Promotion> }) => {
+  const largestPromotion = getLargestPromotionAmount(promotions);
+  return (
+    promotions?.length && (
+      <HStack bg="orange.50" color="orange.500" borderRadius="md" px={1.5} py={0.5}>
+        <FiTag size={10} />
+        {largestPromotion > 0 ? (
+          <Text fontSize="xs">
+            <strong>Up to ${formatPrice(largestPromotion)}</strong> off with coupon if eligible
+          </Text>
+        ) : (
+          <Text fontSize="xs" fontWeight="bold">
+            with coupon if eligible
+          </Text>
+        )}
+      </HStack>
+    )
+  );
+};
+
 interface OfferInfoProps {
   pharmacy?: Pick<OfferDetails['pharmacy'], 'id' | 'name' | 'logo'>;
-  offer: OfferDetails;
+  offer: OfferDetails | OfferBundleDetails;
   isCurrentPharmacy?: boolean;
   isPreferred?: boolean;
 }
@@ -76,6 +99,8 @@ export const OfferInfo = ({ pharmacy, offer, isCurrentPharmacy, isPreferred }: O
 
   const isAmazonPharmacy = pharmacy.id === import.meta.env.VITE_AMAZON_PHARMACY_ID;
 
+  const isOfferBundle = 'medications' in offer; // we can remove this variable once we contract to only using OfferBundleDetails in this component
+
   return (
     <VStack data-testid="pharmacy-info" align="start" w="full">
       {offerTags.length > 0 ? (
@@ -106,7 +131,7 @@ export const OfferInfo = ({ pharmacy, offer, isCurrentPharmacy, isPreferred }: O
           <VStack spacing={0} align="flex-end" minW="fit-content">
             <Text fontSize="sm">{costAmountTitle}</Text>
             <Text fontWeight="bold">${formatPrice(costAmount)}</Text>
-            {retailAmount ? (
+            {retailAmount && retailAmount > costAmount ? (
               <Text fontSize="sm" color="gray.500">
                 {retailAmountTitle}{' '}
                 <Text as="span" textDecoration="line-through">
@@ -117,6 +142,44 @@ export const OfferInfo = ({ pharmacy, offer, isCurrentPharmacy, isPreferred }: O
           </VStack>
         ) : null}
       </HStack>
+
+      {/* currently only OfferBundles have medications */}
+      {isOfferBundle && (
+        <VStack w="full" bg="gray.50" borderRadius="md" p={3}>
+          {offer.medications.map((med) => (
+            <HStack key={med.name} w="full" justify="space-between" align="start">
+              <VStack align="flex-start">
+                <Tooltip
+                  label={med.name}
+                  placement="top-start"
+                  wrapperProps={{
+                    onClick: (e) => {
+                      e.stopPropagation();
+                    }
+                  }}
+                >
+                  <Text fontSize="sm" color="gray.700" noOfLines={1}>
+                    {med.name}
+                  </Text>
+                </Tooltip>
+                <CouponTag promotions={med.promotions} />
+              </VStack>
+
+              <VStack align="flex-end" spacing={1}>
+                <Text fontSize="sm" fontWeight="bold">
+                  ${formatPrice(med.amount)}
+                </Text>
+                {/* only show retail amount if it's higher than the current amount */}
+                {med.retailAmount && med.retailAmount > med.amount && (
+                  <Text fontSize="xs" color="gray.400" textDecoration="line-through">
+                    ${formatPrice(med.retailAmount)}
+                  </Text>
+                )}
+              </VStack>
+            </HStack>
+          ))}
+        </VStack>
+      )}
 
       <VStack w="full" alignItems="start">
         <Text fontSize="sm" fontWeight="semibold">

--- a/apps/patient/src/components/pharmacy-card-list/PickupPharmacyCardList.tsx
+++ b/apps/patient/src/components/pharmacy-card-list/PickupPharmacyCardList.tsx
@@ -18,6 +18,7 @@ interface PickupPharmacyCardListProps {
   loadingMore: boolean;
   showingAllPharmacies: boolean;
   showHeading: boolean;
+  showPrice?: boolean;
   enableOpenNow: boolean;
   enable24Hr: boolean;
   enablePrice: boolean;
@@ -41,6 +42,7 @@ export const PickupPharmacyCardList = ({
   loadingMore,
   showingAllPharmacies,
   showHeading,
+  showPrice = true,
   enableOpenNow,
   enable24Hr,
   setEnableOpenNow,
@@ -90,7 +92,7 @@ export const PickupPharmacyCardList = ({
                 onSelect={() => handleSelect(pharmacy.id)}
                 onSetPreferred={() => handleSetPreferred(pharmacy.id)}
                 selectable={true}
-                showPrice
+                showPrice={showPrice}
                 isCurrentPharmacy={pharmacy.id === currentPharmacyId}
               />
             </OfferImpressionTracker>

--- a/apps/patient/src/graphql/queries.ts
+++ b/apps/patient/src/graphql/queries.ts
@@ -456,3 +456,38 @@ export const GET_OFFERS = gql`
     }
   }
 `;
+
+export const GET_OFFER_BUNDLES = gql`
+  query GetOfferBundlesForOrder($orderId: ID!) {
+    offerBundles(orderId: $orderId) {
+      aggregateCost {
+        totalAmount
+        totalRetailAmount
+      }
+      medications {
+        medicationPrice {
+          amount
+          amountTitle
+          promotions {
+            type
+            amount
+            amountSaved
+          }
+          retailAmount
+          retailAmountTitle
+        }
+        deliveryEstimate {
+          deliveryPromise
+        }
+        prescription {
+          treatment {
+            id
+            name
+          }
+        }
+      }
+      pricingType
+      supplier
+    }
+  }
+`;

--- a/apps/patient/src/utils/deliveryPromise.test.tsx
+++ b/apps/patient/src/utils/deliveryPromise.test.tsx
@@ -1,5 +1,5 @@
 import { expect } from 'vitest';
-import { getLatestDelivery } from '../utils/deliveryPromise';
+import { getLatestDelivery } from './deliveryPromise';
 
 const SAME_DAY = 'Same day';
 const ONE_TO_TWO_DAY = 'Delivery in 1–2 days, after you place your order';

--- a/apps/patient/src/utils/deliveryPromise.ts
+++ b/apps/patient/src/utils/deliveryPromise.ts
@@ -1,0 +1,11 @@
+// Parses day ranges via regex (e.g. "Same day" → 0, "...2-3 days" → 3, "...1-4 days" → 4)
+export function getLatestDelivery(deliveryPromises: string[]): string | undefined {
+  if (deliveryPromises.length === 0) return undefined;
+
+  const parseDays = (promise: string) => {
+    const match = promise.match(/(\d+)(?:\s*[–]\s*(\d+))?\s*day/i); // regex match looks like [original string, lower bound, upper bound]
+    if (!match) return 0;
+    return parseInt(match[2]); // upper bound of the day range
+  };
+  return [...deliveryPromises].sort((a, b) => parseDays(b) - parseDays(a))[0];
+}

--- a/apps/patient/src/utils/models.ts
+++ b/apps/patient/src/utils/models.ts
@@ -3,7 +3,8 @@ import {
   GetOrderQuery,
   Address as GQLAddress,
   FulfillmentType,
-  Maybe
+  Maybe,
+  OfferPromotion
 } from '../__generated__/graphql';
 
 type NotMaybe<T> = Exclude<T, null | undefined>;
@@ -36,6 +37,17 @@ export interface OfferDetails {
   tags: string[];
 }
 
+export interface OfferBundleDetails extends OfferDetails {
+  medications: Array<{
+    name?: string;
+    amount: number;
+    amountTitle?: string;
+    retailAmount?: number;
+    retailAmountTitle?: string;
+    promotions?: Array<OfferPromotion>;
+  }>;
+}
+
 export const OfferTypes = {
   RxSense: 'RxSense',
   GoodRx: 'GoodRx',
@@ -58,3 +70,4 @@ export type EnrichedPharmacy = Pharmacy & {
 export type ExtendedFulfillmentType = FulfillmentType | 'COURIER';
 
 export type Address = GQLAddress;
+export type Promotion = OfferPromotion;

--- a/apps/patient/src/utils/shouldShowPriceToggle.test.tsx
+++ b/apps/patient/src/utils/shouldShowPriceToggle.test.tsx
@@ -12,7 +12,17 @@ test('shows the price toggle switch when order has single medication', async () 
   expect(shouldShowPriceToggle([singleNonGLPFill], order)).toEqual(true);
 });
 
-test('shows the price toggle when order has multiple prescriptions', () => {
+test('shows the price toggle switch when order contains GLP-1 medication', () => {
+  const glp1MedicationName = 'Semaglutide';
+  const glpFill = generateFlattenedFill({
+    treatment: generateTreatment({ name: glp1MedicationName })
+  });
+  const order = generateOrder();
+
+  expect(shouldShowPriceToggle([glpFill], order)).toEqual(true);
+});
+
+test('hides the price toggle when order has multiple prescriptions', () => {
   const multipleFills = [
     generateFlattenedFill({
       treatment: generateTreatment({ name: 'Metformin' })
@@ -23,17 +33,7 @@ test('shows the price toggle when order has multiple prescriptions', () => {
   ];
   const order = generateOrder();
 
-  expect(shouldShowPriceToggle(multipleFills, order)).toEqual(true);
-});
-
-test('shows the price toggle switch when order contains GLP-1 medication', () => {
-  const glp1MedicationName = 'Semaglutide';
-  const glpFill = generateFlattenedFill({
-    treatment: generateTreatment({ name: glp1MedicationName })
-  });
-  const order = generateOrder();
-
-  expect(shouldShowPriceToggle([glpFill], order)).toEqual(true);
+  expect(shouldShowPriceToggle(multipleFills, order)).toEqual(false);
 });
 
 test('hides the price toggle switch when order contains GLP-1 medication for org that hides glp prices', () => {

--- a/apps/patient/src/utils/shouldShowPriceToggle.test.tsx
+++ b/apps/patient/src/utils/shouldShowPriceToggle.test.tsx
@@ -12,6 +12,20 @@ test('shows the price toggle switch when order has single medication', async () 
   expect(shouldShowPriceToggle([singleNonGLPFill], order)).toEqual(true);
 });
 
+test('shows the price toggle when order has multiple prescriptions', () => {
+  const multipleFills = [
+    generateFlattenedFill({
+      treatment: generateTreatment({ name: 'Metformin' })
+    }),
+    generateFlattenedFill({
+      treatment: generateTreatment({ name: 'Lisinopril' })
+    })
+  ];
+  const order = generateOrder();
+
+  expect(shouldShowPriceToggle(multipleFills, order)).toEqual(true);
+});
+
 test('shows the price toggle switch when order contains GLP-1 medication', () => {
   const glp1MedicationName = 'Semaglutide';
   const glpFill = generateFlattenedFill({
@@ -30,20 +44,6 @@ test('hides the price toggle switch when order contains GLP-1 medication for org
   const order = generateOrder({ organization: { id: 'org_hidesGlp1Prices', name: 'test-name' } });
 
   expect(shouldShowPriceToggle([glpFill], order)).toEqual(false);
-});
-
-test('hides the price toggle when order has multiple prescriptions', () => {
-  const multipleFills = [
-    generateFlattenedFill({
-      treatment: generateTreatment({ name: 'Metformin' })
-    }),
-    generateFlattenedFill({
-      treatment: generateTreatment({ name: 'Lisinopril' })
-    })
-  ];
-  const order = generateOrder();
-
-  expect(shouldShowPriceToggle(multipleFills, order)).toEqual(false);
 });
 
 test('hides the price toggle when order has multiple prescriptions including GLP-1', () => {

--- a/apps/patient/src/utils/shouldShowPriceToggle.tsx
+++ b/apps/patient/src/utils/shouldShowPriceToggle.tsx
@@ -2,11 +2,9 @@ import { FillWithCount } from './general';
 import { Order } from './models';
 import { isGLP } from './isGLP';
 
-// note: prices are only for single-rx right now
 export function shouldShowPriceToggle(flattenedFills: FillWithCount[], order: Order): boolean {
   const hideGlp1Prices = shouldHideGlp1Prices(flattenedFills, order.organization.id);
-  const orderIsMultiRx = flattenedFills.length > 1;
-  return (!hideGlp1Prices && !orderIsMultiRx) ?? false;
+  return !hideGlp1Prices;
 }
 
 function shouldHideGlp1Prices(flattenedFills: FillWithCount[], organizationId: string) {

--- a/apps/patient/src/utils/shouldShowPriceToggle.tsx
+++ b/apps/patient/src/utils/shouldShowPriceToggle.tsx
@@ -4,7 +4,8 @@ import { isGLP } from './isGLP';
 
 export function shouldShowPriceToggle(flattenedFills: FillWithCount[], order: Order): boolean {
   const hideGlp1Prices = shouldHideGlp1Prices(flattenedFills, order.organization.id);
-  return !hideGlp1Prices;
+  const orderIsMultiRx = flattenedFills.length > 1;
+  return (!hideGlp1Prices && !orderIsMultiRx) ?? false;
 }
 
 function shouldHideGlp1Prices(flattenedFills: FillWithCount[], organizationId: string) {

--- a/apps/patient/src/views/Pharmacy.test.tsx
+++ b/apps/patient/src/views/Pharmacy.test.tsx
@@ -13,7 +13,7 @@ import {
 import userEvent from '@testing-library/user-event';
 import { routeElements } from '../Routes';
 import { getOffers, getOrder, getPharmaciesByLocation, setOrderPharmacy } from '../api';
-import { fetchOffers, getPharmacy } from './pharmacy.utils';
+import { fetchOfferBundles, fetchOffers, getPharmacy } from './pharmacy.utils';
 import { FulfillmentType } from '../__generated__/graphql';
 
 // Mock the settings and pharmacy utils before any imports
@@ -60,6 +60,7 @@ vi.mock('../configs/graphqlClient', () => ({
 
 vi.mock('./pharmacy.utils', () => ({
   fetchOffers: vi.fn(),
+  fetchOfferBundles: vi.fn(),
   getPharmacy: vi.fn()
 }));
 

--- a/apps/patient/src/views/Pharmacy.tsx
+++ b/apps/patient/src/views/Pharmacy.tsx
@@ -23,7 +23,7 @@ import { FixedFooter, LocationModal, PoweredBy } from '../components';
 import { CouponModal } from '../components/coupons';
 import * as TOAST_CONFIG from '../configs/toast';
 import { preparePharmacy, wait } from '../utils/general';
-import { Pharmacy as EnrichedPharmacy, OfferDetails } from '../utils/models';
+import { Pharmacy as EnrichedPharmacy, OfferBundleDetails, OfferDetails } from '../utils/models';
 import { text as t } from '../utils/text';
 import { useOrderContext } from './Main';
 
@@ -49,7 +49,7 @@ import {
   Prescription
 } from '../__generated__/graphql';
 import { getOrgMailOrderPharms } from '@client/settings';
-import { fetchOffers, getPharmacy } from './pharmacy.utils';
+import { fetchOfferBundles, fetchOffers, getPharmacy } from './pharmacy.utils';
 import _ from 'lodash';
 import {
   BrandedOptionOverrides,
@@ -143,6 +143,7 @@ export const Pharmacy = () => {
   const [loadingPharmacies, setLoadingPharmacies] = useState<boolean>(true);
   const [showingAllPharmacies, setShowingAllPharmacies] = useState<boolean>(false);
   const isLoading = loadingLocation || loadingPharmacies;
+  const orderIsMultiRx = flattenedFills.length > 1;
 
   // pricing
   const shouldTrackOfferImpressionsAndSelections = showPriceToggle && !isDemo;
@@ -157,7 +158,9 @@ export const Pharmacy = () => {
     BrandedOptionOverrides | undefined
   >(undefined);
 
-  const [offers, setOffers] = useState<OfferDetails[] | undefined>(undefined);
+  const [offers, setOffers] = useState<OfferDetails[] | OfferBundleDetails[] | undefined>(
+    undefined
+  );
   const [filteredOffers, setFilteredOffers] = useState<OfferDetails[] | undefined>(undefined);
 
   // pagination
@@ -240,11 +243,19 @@ export const Pharmacy = () => {
 
   useEffect(() => {
     const getOffers = async () => {
-      let fetchedOffers: OfferDetails[] | undefined;
+      let fetchedOffers: OfferDetails[] | OfferBundleDetails | undefined = [];
 
       // only fetch offers if we don't have any
       if (!offers) {
-        fetchedOffers = await fetchOffers(order);
+        if (orderIsMultiRx) {
+          // for multi-rx orders, we are only tracking the response right now
+          const offerBundles = await fetchOfferBundles(order);
+          patientAnalytics.track('Fetched Offer Bundles', order, {
+            offerBundles: offerBundles?.map((bundle) => ({ ...bundle }))
+          });
+        } else {
+          fetchedOffers = await fetchOffers(order);
+        }
 
         if (JSON.stringify(fetchedOffers) !== JSON.stringify(offers)) {
           setOffers(fetchedOffers);
@@ -1136,6 +1147,7 @@ export const Pharmacy = () => {
       loadingMore={isLoading}
       showingAllPharmacies={showingAllPharmacies}
       showHeading={showPickupHeading}
+      showPrice={!orderIsMultiRx}
       enableOpenNow={enableOpenNow}
       enable24Hr={enable24Hr}
       enablePrice={enablePrice}
@@ -1207,7 +1219,7 @@ export const Pharmacy = () => {
                     }}
                   />
                 </HStack>
-                {enablePrice ? (
+                {enablePrice && !orderIsMultiRx ? (
                   <Box p={3} bgColor="blue.100" borderRadius="lg">
                     <Text fontSize="sm">
                       Coupon will be generated after you select a pharmacy.{' '}

--- a/apps/patient/src/views/pharmacy.utils.test.ts
+++ b/apps/patient/src/views/pharmacy.utils.test.ts
@@ -1,0 +1,27 @@
+import { expect } from 'vitest';
+import { getLatestDelivery } from '../utils/deliveryPromise';
+
+const SAME_DAY = 'Same day';
+const ONE_TO_TWO_DAY = 'Delivery in 1–2 days, after you place your order';
+const TWO_TO_THREE_DAY = 'Delivery in 2–3 days, after you place your order';
+const ONE_TO_FOUR_DAY = 'Delivery in 1–4 days, after you place your order';
+
+test('returns undefined when there are no delivery promises', () => {
+  expect(getLatestDelivery([])).toBeUndefined();
+});
+
+test('returns same day when that is the only option', () => {
+  expect(getLatestDelivery([SAME_DAY])).toBe(SAME_DAY);
+});
+
+test('picks the slower delivery when promises differ', () => {
+  expect(getLatestDelivery([ONE_TO_TWO_DAY, TWO_TO_THREE_DAY])).toBe(TWO_TO_THREE_DAY);
+});
+
+test('picks 1-4 days over 1-2 days', () => {
+  expect(getLatestDelivery([ONE_TO_TWO_DAY, ONE_TO_FOUR_DAY])).toBe(ONE_TO_FOUR_DAY);
+});
+
+test('picks a day-range over a same-day promise', () => {
+  expect(getLatestDelivery([SAME_DAY, ONE_TO_TWO_DAY])).toBe(ONE_TO_TWO_DAY);
+});

--- a/apps/patient/src/views/pharmacy.utils.tsx
+++ b/apps/patient/src/views/pharmacy.utils.tsx
@@ -1,4 +1,5 @@
 import { getOfferBundles, getOffers } from '../api';
+import { getLatestDelivery } from '../utils/deliveryPromise';
 import { PHARMACY_BRANDING } from '../components/pharmacy-card-list';
 import {
   EnrichedPharmacy,
@@ -82,15 +83,9 @@ export async function fetchOfferBundles(
       const deliveryPromises = bundle.medications
         .map((m) => m.deliveryEstimate?.deliveryPromise)
         .filter((promise) => promise !== undefined);
-      // pick the latest delivery promise across all medications by looking at the first character
-      // Priority: '2...' (2-3 day) > '1...' (1-2 day) > 'S...' (same day)
-      const latestDelivery =
-        deliveryPromises.find((promise) => promise[0] === '2') ??
-        deliveryPromises.find((promise) => promise[0] === '1') ??
-        deliveryPromises[0];
 
       return {
-        deliveryEstimate: latestDelivery,
+        deliveryEstimate: getLatestDelivery(deliveryPromises),
         costType: bundle.pricingType,
         costAmount: bundle.aggregateCost?.totalAmount,
         costAmountTitle: bundle.medications[0]?.medicationPrice?.amountTitle, // should move amount titles to the top level instead of per medication in the API but for now we'll just use the first one since we expect them to be the same across medications

--- a/apps/patient/src/views/pharmacy.utils.tsx
+++ b/apps/patient/src/views/pharmacy.utils.tsx
@@ -1,6 +1,12 @@
-import { getOffers } from '../api';
+import { getOfferBundles, getOffers } from '../api';
 import { PHARMACY_BRANDING } from '../components/pharmacy-card-list';
-import { EnrichedPharmacy, ExtendedFulfillmentType, OfferDetails, Order } from '../utils/models';
+import {
+  EnrichedPharmacy,
+  ExtendedFulfillmentType,
+  OfferBundleDetails,
+  OfferDetails,
+  Order
+} from '../utils/models';
 import { FulfillmentType, Pharmacy as PharmacyType } from '../__generated__/graphql';
 
 import capsulePharmacyIdLookup from '../data/capsulePharmacyIds.json';
@@ -26,7 +32,7 @@ function getNovocareOffers(order: Order): OfferDetails[] {
   }
 }
 
-// this function will return the offers available for the given order
+// this function will return the offers available for the given order (single rx)
 export async function fetchOffers(order: Order): Promise<OfferDetails[] | undefined> {
   const offers = await getOffers(order.id);
 
@@ -48,6 +54,63 @@ export async function fetchOffers(order: Order): Promise<OfferDetails[] | undefi
       },
       tags: ['In Stock']
     }));
+
+  const novocareOffers = getNovocareOffers(order);
+
+  // measured will only want to show amazon offers if we do not have a novocare offer
+  if (order.organization.id === 'org_pcPnPx5PVamzjS2p') {
+    if (novocareOffers.length === 0) {
+      return amazonOffers;
+    } else {
+      return novocareOffers;
+    }
+  }
+
+  return [...amazonOffers, ...novocareOffers];
+}
+
+// this function will return the offers available for the given order
+// (currently just for multi rx but will expand to single rx in PHO-322)
+export async function fetchOfferBundles(
+  order: Order
+): Promise<OfferBundleDetails[] | OfferDetails[] | undefined> {
+  const bundles = await getOfferBundles(order.id);
+
+  const amazonOffers = bundles
+    .filter((bundle) => bundle.supplier === 'AMAZON_PHARMACY')
+    .map((bundle) => {
+      const deliveryPromises = bundle.medications
+        .map((m) => m.deliveryEstimate?.deliveryPromise)
+        .filter((promise) => promise !== undefined);
+      // pick the latest delivery promise across all medications by looking at the first character
+      // Priority: '2...' (2-3 day) > '1...' (1-2 day) > 'S...' (same day)
+      const latestDelivery =
+        deliveryPromises.find((promise) => promise[0] === '2') ??
+        deliveryPromises.find((promise) => promise[0] === '1') ??
+        deliveryPromises[0];
+
+      return {
+        deliveryEstimate: latestDelivery,
+        costType: bundle.pricingType,
+        costAmount: bundle.aggregateCost?.totalAmount,
+        costAmountTitle: bundle.medications[0]?.medicationPrice?.amountTitle, // should move amount titles to the top level instead of per medication in the API but for now we'll just use the first one since we expect them to be the same across medications
+        retailAmount: bundle.aggregateCost?.totalRetailAmount,
+        retailAmountTitle: bundle.medications[0]?.medicationPrice?.retailAmountTitle, // same as costAmountTitle, should be moved to top level eventually
+        medications: bundle.medications.map((m) => ({
+          name: m.prescription?.treatment?.name,
+          amount: m.medicationPrice?.amount,
+          retailAmount: m.medicationPrice?.retailAmount,
+          promotions: m.medicationPrice?.promotions
+        })),
+        pharmacy: {
+          id: import.meta.env.VITE_AMAZON_PHARMACY_ID as string,
+          name: 'Amazon Pharmacy',
+          fulfillmentTypes: ['MAIL_ORDER'] as FulfillmentType[],
+          logo: PHARMACY_BRANDING['phr_demoAmazon'].logo
+        },
+        tags: ['In Stock']
+      };
+    });
 
   const novocareOffers = getNovocareOffers(order);
 


### PR DESCRIPTION
- setting up a parallel path to pull offer bundles for multi med orders. Not currently displaying the response because we would like to watch the data coming through in prod for a bit to build up some confidence before displaying. Set up a new tracking event, "Fetched Offer Bundles" for this purpose. 
- showing cash toggle for multi med orders now but hiding price on pharmacy cards via new prop, `showPrice` in PickupPharmacyCardList component
- new coupon tag to show promotions from amazon offers