### PR TITLE
Update "Don't see Pharmacy" div to match pharmacies below

### DIFF
--- a/apps/patient/src/views/Pharmacy.tsx
+++ b/apps/patient/src/views/Pharmacy.tsx
@@ -1,6 +1,7 @@
 import {
   Box,
   Button,
+  Card,
   Center,
   CircularProgress,
   Container,
@@ -1263,19 +1264,22 @@ export const Pharmacy = () => {
                 </VStack>
               )}
               {patientMailOrderOptions?.length && (
-                <HStack
-                  w="full"
-                  justifyContent="space-between"
-                  background="Background"
-                  padding="2"
-                  borderRadius="md"
-                >
-                  <> ZAC Changes needed here</>
-                  <Text fontSize="sm">Don't see your pharmacy?</Text>
-                  <Link as="button" onClick={() => setMailOrderModalOpen(true)} fontSize="sm">
-                    See all mail orders
-                  </Link>
-                </HStack>
+                <Card shadow={'none'} mx={{ base: -2, md: undefined }}>
+                  <VStack>
+                    <HStack
+                      w="full"
+                      justifyContent="space-between"
+                      background="Background"
+                      padding="2"
+                      borderRadius="md"
+                    >
+                      <Text fontSize="sm">Don't see your pharmacy?</Text>
+                      <Link as="button" onClick={() => setMailOrderModalOpen(true)} fontSize="sm">
+                        See all mail orders
+                      </Link>
+                    </HStack>
+                  </VStack>
+                </Card>
               )}
               {pickupPharmacyOptions(patientLocation)}
             </VStack>

--- a/apps/patient/src/views/Pharmacy.tsx
+++ b/apps/patient/src/views/Pharmacy.tsx
@@ -1270,6 +1270,7 @@ export const Pharmacy = () => {
                   padding="2"
                   borderRadius="md"
                 >
+                  <> ZAC Changes needed here</>
                   <Text fontSize="sm">Don't see your pharmacy?</Text>
                   <Link as="button" onClick={() => setMailOrderModalOpen(true)} fontSize="sm">
                     See all mail orders


### PR DESCRIPTION
Currently on the Pharmacy Selection Page there's a mismatch in the alignment of the "mail order options" card and the actual selectable Pharmacy Cards, see image below for an example:
<img width="718" height="1172" alt="image" src="https://github.com/user-attachments/assets/58006d05-6cd3-43f1-83a7-c2e63730bd80" />


The fix for this was to bring the mail orders callout into alignment with the PharmacyCard elements (which were set to be at -2 relational to the margin -- that is to say stretched just outside the parent div).

In order to do so I had to replicate the component structure of those cards, wrapping what was originally an HStack of text elements in a VStack and wrapping the whole thing in a Card with the margin set at -2. Eventually we should align to either remove this "outside the margin" behavior or move it into a reusable element between the components since this now brings these cards out of alignment with the blue Coupon Box above:

<img width="679" height="714" alt="Screenshot 2026-03-20 at 11 10 42 AM" src="https://github.com/user-attachments/assets/f943f75b-68e4-4b17-b052-07934f30cf56" />
