### PR TITLE
Add Partner Value Dashboard to Settings

### DIFF
--- a/apps/app/src/App.tsx
+++ b/apps/app/src/App.tsx
@@ -88,6 +88,7 @@ export const App = () => {
                 <Route path="developers" />
                 <Route path="templates" />
                 <Route path="catalog" />
+                <Route path="dashboard" />
               </Route>
             </Route>
             <Route path="/login" element={<Login />} />

--- a/apps/app/src/views/routes/Settings/index.tsx
+++ b/apps/app/src/views/routes/Settings/index.tsx
@@ -15,6 +15,7 @@ import { graphql } from 'apps/app/src/gql';
 import usePermissions from 'apps/app/src/hooks/usePermissions';
 import { Page } from '../../components/Page';
 import { usePhoton } from '@photonhealth/react';
+import { DashboardTab } from './views/DashboardTab';
 import { DevelopersTab } from './views/DevelopersTab';
 import { OrganizationTab } from './views/OrganizationTab';
 import { TeamTab } from './views/TeamTab';
@@ -47,7 +48,8 @@ const tabs = [
   '/settings/organization',
   '/settings/developers',
   '/settings/catalog',
-  '/settings/templates'
+  '/settings/templates',
+  '/settings/dashboard'
 ] as const;
 
 const canNavigate = (
@@ -65,6 +67,7 @@ const canNavigate = (
   if (route === '/settings/developers') return hasDeveloper;
   if (route === '/settings/team') return hasTeam;
   if (route === '/settings/organization') return canManageOrganization;
+  if (route === '/settings/dashboard') return canManageOrganization;
   return true;
 };
 
@@ -138,6 +141,7 @@ export const Settings = () => {
             <Tab hidden={!hasDeveloper}>Developers</Tab>
             <Tab>Catalog</Tab>
             <Tab>Templates</Tab>
+            <Tab hidden={!canManageOrganization}>Dashboard</Tab>
           </TabList>
           <TabPanels>
             <TabPanel display="flex" flexDir="column" gap={{ md: '4' }} px={0}>
@@ -157,6 +161,9 @@ export const Settings = () => {
             </TabPanel>
             <TabPanel display="flex" flexDir="column" gap={{ md: '4' }} px={0}>
               <TemplateTab />
+            </TabPanel>
+            <TabPanel display="flex" flexDir="column" gap={{ md: '4' }} px={0}>
+              <DashboardTab />
             </TabPanel>
           </TabPanels>
         </Tabs>

--- a/apps/app/src/views/routes/Settings/views/DashboardTab.tsx
+++ b/apps/app/src/views/routes/Settings/views/DashboardTab.tsx
@@ -73,8 +73,7 @@ export const DashboardTab = () => {
         title="Partner Value Dashboard"
         width="100%"
         height="800"
-        style={{ border: 'none' }}
-        allowTransparency
+        style={{ border: 'none', background: 'transparent' }}
       />
     </Box>
   );

--- a/apps/app/src/views/routes/Settings/views/DashboardTab.tsx
+++ b/apps/app/src/views/routes/Settings/views/DashboardTab.tsx
@@ -1,0 +1,81 @@
+import { useCallback, useEffect, useState } from 'react';
+import { Alert, AlertIcon, Box, Center, Spinner, Text } from '@chakra-ui/react';
+import { usePhoton } from '@photonhealth/react';
+
+const EMBED_URL = import.meta.env.VITE_METABASE_EMBED_URL;
+
+export const DashboardTab = () => {
+  const { getToken } = usePhoton();
+  const [iframeUrl, setIframeUrl] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const fetchEmbedUrl = useCallback(async () => {
+    if (!EMBED_URL) {
+      setError('Dashboard embedding is not configured.');
+      setLoading(false);
+      return;
+    }
+
+    try {
+      const token = await getToken();
+      const res = await fetch(EMBED_URL, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`
+        },
+        body: JSON.stringify({ dashboard_id: 179 })
+      });
+
+      if (!res.ok) {
+        throw new Error(`Failed to load dashboard (${res.status})`);
+      }
+
+      const data = await res.json();
+      setIframeUrl(data.url);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to load dashboard');
+    } finally {
+      setLoading(false);
+    }
+  }, [getToken]);
+
+  useEffect(() => {
+    fetchEmbedUrl();
+  }, [fetchEmbedUrl]);
+
+  if (loading) {
+    return (
+      <Center py={20}>
+        <Spinner size="xl" color="blue.500" />
+      </Center>
+    );
+  }
+
+  if (error) {
+    return (
+      <Alert status="warning" borderRadius="md">
+        <AlertIcon />
+        <Text>{error}</Text>
+      </Alert>
+    );
+  }
+
+  if (!iframeUrl) {
+    return null;
+  }
+
+  return (
+    <Box borderRadius="lg" bg="bg-surface" boxShadow="base" overflow="hidden" w="full">
+      <iframe
+        src={iframeUrl}
+        title="Partner Value Dashboard"
+        width="100%"
+        height="800"
+        style={{ border: 'none' }}
+        allowTransparency
+      />
+    </Box>
+  );
+};


### PR DESCRIPTION
## Summary

- Adds a **Dashboard** tab to Settings (visible to users with `manage:organization` permission)
- Renders Metabase's [Partner Value Dashboard (#179)](https://metrics.photon.health/dashboard/179-partner-value-dashboard) in an iframe via static embedding
- Frontend is ready to ship — **requires a backend endpoint** to sign Metabase embed JWTs (contract below)

## What this does

The `DashboardTab` component:
1. Reads `VITE_METABASE_EMBED_URL` from env
2. POSTs to that URL with the user's Auth0 bearer token and `{ dashboard_id: 179 }`
3. Receives `{ url: "https://metrics.photon.health/embed/dashboard/<signed-jwt>#bordered=true&titled=true" }`
4. Renders the URL in an iframe

If `VITE_METABASE_EMBED_URL` is not set, the tab shows a graceful "not configured" message. Zero impact on existing functionality.

## Backend endpoint contract

The frontend needs a single endpoint that:

1. **Verifies** the Auth0 bearer token from the `Authorization` header
2. **Extracts** `org_id` from the token claims
3. **Signs** a Metabase static embed JWT using the instance embedding secret key
4. **Returns** `{ url: "<metabase_url>/embed/dashboard/<signed-jwt>#bordered=true&titled=true" }`

### JWT payload to sign

```json
{
  "resource": { "dashboard": 179 },
  "params": {
    "partner_id": "<org_id from auth token>",
    "date_range": null,
    "labor_rate": null,
    "patient_id": null
  },
  "exp": <now + 10 minutes>
}
```

- `partner_id` is **locked** to the authenticated user's org — prevents cross-org data access
- `date_range`, `labor_rate`, `patient_id` are **unlocked** (null) — users can interact with these filters in the embedded dashboard

### Reference implementation (Node.js)

```typescript
import jwt from 'jsonwebtoken';

const METABASE_URL = 'https://metrics.photon.health';
const METABASE_SECRET = process.env.METABASE_EMBEDDING_SECRET;

function generateEmbedUrl(orgId: string, dashboardId: number): string {
  const payload = {
    resource: { dashboard: dashboardId },
    params: {
      partner_id: orgId,
      date_range: null,
      labor_rate: null,
      patient_id: null,
    },
    exp: Math.round(Date.now() / 1000) + 600, // 10 min
  };

  const token = jwt.sign(payload, METABASE_SECRET);
  return `${METABASE_URL}/embed/dashboard/${token}#bordered=true&titled=true`;
}
```

### Environment variables needed

| Variable | Where | Value |
|----------|-------|-------|
| `METABASE_EMBEDDING_SECRET` | Backend (Lambda/gateway) | Metabase instance embedding secret key |
| `VITE_METABASE_EMBED_URL` | Frontend (app env) | URL of the deployed backend endpoint |

### Metabase config (already done)

- Dashboard 179 has `enable_embedding: true` with `embedding_type: guest-embed`
- Instance-level embedding is enabled (`enable-embedding`, `enable-embedding-interactive`, `enable-embedding-static` all true)
- Embedding secret key is configured

## Dashboard contents (12 cards)

| Card | What it shows |
|------|--------------|
| Clinical Hours Saved | Hours saved based on resolved Zendesk tickets (15 min/ticket) |
| Estimated OpEx Saved | Clinical hours × configurable labor rate |
| Zero-Touch Resolution Rate | % of issues resolved without clinical staff |
| Rx Issues Handled by Photon | Issues resolved without contacting partner's clinical team |
| Order Fulfillment Status | Order state distribution |
| Issue Resolution Rate | % of issues resolved |
| Disruptions Resolved by Category | Daily breakdown by category (Patient, Pharmacy, Clinical, General) |
| Prescription Volume | Daily Rx volume time series |
| Weekly Trend: Rx Volume vs Issues | Dual-axis weekly trend |
| Top Medications Filled | Top 20 medications by order count |
| Top Medications by Pharmacy | Cross-tab: pharmacy × medication |
| Patient Status Lookup | Per-patient order status table |

## Files changed

- `apps/app/src/views/routes/Settings/views/DashboardTab.tsx` — **New.** Iframe embed component
- `apps/app/src/views/routes/Settings/index.tsx` — Added Dashboard tab + permission gate
- `apps/app/src/App.tsx` — Added `/settings/dashboard` route

## Test plan

- [ ] Verify existing Settings tabs (Team, User, Organization, Developers, Catalog, Templates) are unaffected
- [ ] Verify Dashboard tab is hidden for users without `manage:organization` permission
- [ ] Verify graceful fallback when `VITE_METABASE_EMBED_URL` is not set
- [ ] Deploy backend endpoint and verify dashboard renders with correct org-scoped data
- [ ] Verify org isolation — user from org A cannot see org B's data

🤖 Generated with [Claude Code](https://claude.com/claude-code)