### PR TITLE
codebuild workflow dispatch only on boson

### DIFF
--- a/.github/workflows/pr-e2e-tests.yml
+++ b/.github/workflows/pr-e2e-tests.yml
@@ -9,6 +9,8 @@ on:
         options:
         - app
         - patient
+      output_dir:
+        required: true
 
 permissions:
   contents: read
@@ -30,13 +32,13 @@ jobs:
           if [ "${{ inputs.app }}" = "app" ]; then
             echo "e2e=npx nx run app:e2e" >> $GITHUB_OUTPUT
             echo "codegen=npx nx run app:codegen" >> $GITHUB_OUTPUT
-            echo "base_url=https://app-${{ inputs.branch }}.boson.health" >> $GITHUB_OUTPUT
+            echo "base_url=https://app-${{ inputs.output_dir }}.boson.health" >> $GITHUB_OUTPUT
             echo "report_name=playwright-report-clinical" >> $GITHUB_OUTPUT
             echo "report_path=apps/app/playwright-report/" >> $GITHUB_OUTPUT
           elif [ "${{ inputs.app }}" = "patient" ]; then
             echo "e2e=npx nx run patient:e2e" >> $GITHUB_OUTPUT
             echo "codegen=npx nx run patient:codegen" >> $GITHUB_OUTPUT
-            echo "base_url=https://orders-${{ inputs.branch }}.boson.health" >> $GITHUB_OUTPUT
+            echo "base_url=https://orders-${{ inputs.output_dir }}.boson.health" >> $GITHUB_OUTPUT
             echo "report_name=playwright-report-patient" >> $GITHUB_OUTPUT
             echo "report_path=apps/patient/playwright-report/" >> $GITHUB_OUTPUT
           else

--- a/apps/app/README.md
+++ b/apps/app/README.md
@@ -98,6 +98,10 @@ The build is minified and the filenames include the hashes.
 
 See the section about [deployment](https://facebook.github.io/create-react-app/docs/deployment) for more information.
 
+## Deployment
+
+Refer to [our Notion docs](https://www.notion.so/photons/Deployments-a5e7334066744b13a9cd6dc49edb3a6d) on how to deploy to different environments.
+
 ## Learn More
 
 You can learn more in the [Create React App documentation](https://facebook.github.io/create-react-app/docs/getting-started).

--- a/apps/app/buildspec.yml
+++ b/apps/app/buildspec.yml
@@ -63,7 +63,7 @@ phases:
       - |
         BRANCH_NAME=$(echo $CODEBUILD_WEBHOOK_HEAD_REF | sed -e "s/refs\/heads\///g")
         echo "BRANCH_NAME: $BRANCH_NAME"
-        if [ "$CODEBUILD_BUILD_SUCCEEDING" = "1" ] && [ "$VITE_ENV_NAME" = "boson" ] && [ "$BRANCH_NAME" != "neutrons/merge" ] && [ "$BRANCH_NAME" != "photons/merge" ]; then
+        if [ "$CODEBUILD_BUILD_SUCCEEDING" = "1" ] && [ "$VITE_ENV_NAME" = "boson" ] && [ "$BRANCH_NAME" != "neturons/merge" ] && [ "$BRANCH_NAME" != "photons/merge" ]; then
           curl -X POST \
             -H "Authorization: token $GITHUB_TOKEN" \
             -H "Accept: application/vnd.github+json" \

--- a/apps/app/buildspec.yml
+++ b/apps/app/buildspec.yml
@@ -63,7 +63,7 @@ phases:
       - |
         BRANCH_NAME=$(echo $CODEBUILD_WEBHOOK_HEAD_REF | sed -e "s/refs\/heads\///g")
         echo "BRANCH_NAME: $BRANCH_NAME"
-        if [ "$CODEBUILD_BUILD_SUCCEEDING" = "1" ]; then
+        if [ "$CODEBUILD_BUILD_SUCCEEDING" = "1" ] && [ "$VITE_ENV_NAME" = "boson" ]; then
           curl -X POST \
             -H "Authorization: token $GITHUB_TOKEN" \
             -H "Accept: application/vnd.github+json" \

--- a/apps/app/buildspec.yml
+++ b/apps/app/buildspec.yml
@@ -63,7 +63,6 @@ phases:
       - |
         BRANCH_NAME=$(echo $CODEBUILD_WEBHOOK_HEAD_REF | sed -e "s/refs\/heads\///g")
         echo "BRANCH_NAME: $BRANCH_NAME"
-        echo "Github token: $GITHUB_TOKEN"
         if [ "$CODEBUILD_BUILD_SUCCEEDING" = "1" ] && [ "$VITE_ENV_NAME" = "boson" ] && [ "$BRANCH_NAME" != "neutrons/merge" ] && [ "$BRANCH_NAME" != "photons/merge" ]; then
           curl -X POST \
             -H "Authorization: token $GITHUB_TOKEN" \

--- a/apps/app/buildspec.yml
+++ b/apps/app/buildspec.yml
@@ -68,7 +68,7 @@ phases:
             -H "Authorization: token $GITHUB_TOKEN" \
             -H "Accept: application/vnd.github+json" \
             https://api.github.com/repos/Photon-Health/client/actions/workflows/pr-e2e-tests.yml/dispatches \
-            -d "{\"ref\":\"$CODEBUILD_WEBHOOK_HEAD_REF\",\"inputs\":{\"branch\":\"$BRANCH_NAME\",\"app\":\"app\"}}"
+            -d "{\"ref\":\"$CODEBUILD_WEBHOOK_HEAD_REF\",\"inputs\":{\"branch\":\"$BRANCH_NAME\",\"output_dir\":\"$OUTPUT_DIR\",\"app\":\"app\"}}"
         fi
       - echo Installing Datadog CI
       - npm install -g @datadog/datadog-ci

--- a/apps/app/buildspec.yml
+++ b/apps/app/buildspec.yml
@@ -64,7 +64,7 @@ phases:
         BRANCH_NAME=$(echo $CODEBUILD_WEBHOOK_HEAD_REF | sed -e "s/refs\/heads\///g")
         echo "BRANCH_NAME: $BRANCH_NAME"
         echo "Github token: $GITHUB_TOKEN"
-        if [ "$CODEBUILD_BUILD_SUCCEEDING" = "1" ] && [ "$VITE_ENV_NAME" = "boson" ]; then
+        if [ "$CODEBUILD_BUILD_SUCCEEDING" = "1" ] && [ "$VITE_ENV_NAME" = "boson" ] && [ "$BRANCH_NAME" != "neutrons/merge" ] && [ "$BRANCH_NAME" != "photons/merge" ]; then
           curl -X POST \
             -H "Authorization: token $GITHUB_TOKEN" \
             -H "Accept: application/vnd.github+json" \

--- a/apps/app/buildspec.yml
+++ b/apps/app/buildspec.yml
@@ -63,6 +63,7 @@ phases:
       - |
         BRANCH_NAME=$(echo $CODEBUILD_WEBHOOK_HEAD_REF | sed -e "s/refs\/heads\///g")
         echo "BRANCH_NAME: $BRANCH_NAME"
+        echo "Github token: $GITHUB_TOKEN"
         if [ "$CODEBUILD_BUILD_SUCCEEDING" = "1" ] && [ "$VITE_ENV_NAME" = "boson" ]; then
           curl -X POST \
             -H "Authorization: token $GITHUB_TOKEN" \

--- a/apps/patient/README.md
+++ b/apps/patient/README.md
@@ -73,3 +73,7 @@ $ npx nx run patient:e2e
 # or run within UI popup window
 $ npx nx run patient:e2e:ui
 ```
+
+## Deployment
+
+Refer to [our Notion docs](https://www.notion.so/photons/Deployments-a5e7334066744b13a9cd6dc49edb3a6d) on how to deploy to different environments.

--- a/apps/patient/buildspec.yml
+++ b/apps/patient/buildspec.yml
@@ -68,7 +68,7 @@ phases:
       - |
         BRANCH_NAME=$(echo $CODEBUILD_WEBHOOK_HEAD_REF | sed -e "s/refs\/heads\///g")
         echo "BRANCH_NAME: $BRANCH_NAME"
-        if [ "$CODEBUILD_BUILD_SUCCEEDING" = "1" ]; then
+        if [ "$CODEBUILD_BUILD_SUCCEEDING" = "1" ] && [ "$VITE_ENV_NAME" = "boson" ]; then
           curl -X POST \
             -H "Authorization: token $GITHUB_TOKEN" \
             -H "Accept: application/vnd.github+json" \

--- a/apps/patient/buildspec.yml
+++ b/apps/patient/buildspec.yml
@@ -69,7 +69,7 @@ phases:
         BRANCH_NAME=$(echo $CODEBUILD_WEBHOOK_HEAD_REF | sed -e "s/refs\/heads\///g")
         echo "BRANCH_NAME: $BRANCH_NAME"
         echo "Github token: $GITHUB_TOKEN"
-        if [ "$CODEBUILD_BUILD_SUCCEEDING" = "1" ] && [ "$VITE_ENV_NAME" = "boson" ]; then
+        if [ "$CODEBUILD_BUILD_SUCCEEDING" = "1" ] && [ "$VITE_ENV_NAME" = "boson" ] && [ "$BRANCH_NAME" != "neutrons/merge" ] && [ "$BRANCH_NAME" != "photons/merge" ]; then
           curl -X POST \
             -H "Authorization: token $GITHUB_TOKEN" \
             -H "Accept: application/vnd.github+json" \

--- a/apps/patient/buildspec.yml
+++ b/apps/patient/buildspec.yml
@@ -68,6 +68,7 @@ phases:
       - |
         BRANCH_NAME=$(echo $CODEBUILD_WEBHOOK_HEAD_REF | sed -e "s/refs\/heads\///g")
         echo "BRANCH_NAME: $BRANCH_NAME"
+        echo "Github token: $GITHUB_TOKEN"
         if [ "$CODEBUILD_BUILD_SUCCEEDING" = "1" ] && [ "$VITE_ENV_NAME" = "boson" ]; then
           curl -X POST \
             -H "Authorization: token $GITHUB_TOKEN" \

--- a/apps/patient/buildspec.yml
+++ b/apps/patient/buildspec.yml
@@ -68,7 +68,7 @@ phases:
       - |
         BRANCH_NAME=$(echo $CODEBUILD_WEBHOOK_HEAD_REF | sed -e "s/refs\/heads\///g")
         echo "BRANCH_NAME: $BRANCH_NAME"
-        if [ "$CODEBUILD_BUILD_SUCCEEDING" = "1" ] && [ "$VITE_ENV_NAME" = "boson" ] && [ "$BRANCH_NAME" != "neutrons/merge" ] && [ "$BRANCH_NAME" != "photons/merge" ]; then
+        if [ "$CODEBUILD_BUILD_SUCCEEDING" = "1" ] && [ "$VITE_ENV_NAME" = "boson" ] && [ "$BRANCH_NAME" != "neturons/merge" ] && [ "$BRANCH_NAME" != "photons/merge" ]; then
           curl -X POST \
             -H "Authorization: token $GITHUB_TOKEN" \
             -H "Accept: application/vnd.github+json" \

--- a/apps/patient/buildspec.yml
+++ b/apps/patient/buildspec.yml
@@ -73,7 +73,7 @@ phases:
             -H "Authorization: token $GITHUB_TOKEN" \
             -H "Accept: application/vnd.github+json" \
             https://api.github.com/repos/Photon-Health/client/actions/workflows/pr-e2e-tests.yml/dispatches \
-            -d "{\"ref\":\"$CODEBUILD_WEBHOOK_HEAD_REF\",\"inputs\":{\"branch\":\"$BRANCH_NAME\",\"app\":\"patient\"}}"
+            -d "{\"ref\":\"$CODEBUILD_WEBHOOK_HEAD_REF\",\"inputs\":{\"branch\":\"$BRANCH_NAME\",\"output_dir\":\"$OUTPUT_DIR\",\"app\":\"patient\"}}"
         fi
       - echo Installing Datadog CI
       - npm install -g @datadog/datadog-ci

--- a/apps/patient/buildspec.yml
+++ b/apps/patient/buildspec.yml
@@ -68,7 +68,6 @@ phases:
       - |
         BRANCH_NAME=$(echo $CODEBUILD_WEBHOOK_HEAD_REF | sed -e "s/refs\/heads\///g")
         echo "BRANCH_NAME: $BRANCH_NAME"
-        echo "Github token: $GITHUB_TOKEN"
         if [ "$CODEBUILD_BUILD_SUCCEEDING" = "1" ] && [ "$VITE_ENV_NAME" = "boson" ] && [ "$BRANCH_NAME" != "neutrons/merge" ] && [ "$BRANCH_NAME" != "photons/merge" ]; then
           curl -X POST \
             -H "Authorization: token $GITHUB_TOKEN" \


### PR DESCRIPTION
Part of PHO-372

Follow up for https://github.com/Photon-Health/client/pull/2500. Realized that with the current buildspec file, e2e tests would also run whenever we merge into neutron and photon