### PR TITLE
fix broken user settings page

### DIFF
--- a/apps/app/src/views/routes/Settings/components/profile/Profile.tsx
+++ b/apps/app/src/views/routes/Settings/components/profile/Profile.tsx
@@ -53,7 +53,9 @@ export const Profile = () => {
   const user = data?.me;
   const organization = data?.organization;
 
-  const canEdit = usePermissions(['edit:profile']) || usePermissions(['edit:profile_self']);
+  const hasEditProfile = usePermissions(['edit:profile']);
+  const hasEditProfileSelf = usePermissions(['edit:profile_self']);
+  const canEdit = hasEditProfile || hasEditProfileSelf;
 
   const initialValues: yup.InferType<typeof profileFormSchema> = {
     name: {


### PR DESCRIPTION
User page is busted if you have both admin and non-admin profile editing permissions, problem was conditional react hook called this fixes it by always calling both.