### PR TITLE
get feature flag value only when patient clicks Change Pharmacy

### DIFF
--- a/apps/patient/src/setupTests.ts
+++ b/apps/patient/src/setupTests.ts
@@ -50,3 +50,19 @@ if (typeof window !== 'undefined' && !('IntersectionObserver' in window)) {
 }
 
 vi.stubGlobal('scrollTo', vi.fn());
+
+// Fixes bug in Chakra UI https://github.com/chakra-ui/chakra-ui/issues/6036
+// useBreakpointValue causes bug during unit tests
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((query) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(), // deprecated
+    removeListener: vi.fn(), // deprecated
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn()
+  }))
+});

--- a/apps/patient/src/views/Status.tsx
+++ b/apps/patient/src/views/Status.tsx
@@ -30,7 +30,6 @@ export const Status = () => {
   const patientAnalytics = usePatientAnalytics();
   usePageAnalytics({ pageName: 'Order Status' });
   const { enablePatientRerouting } = order?.organization?.settings?.patientUx ?? {};
-  const [renderChangeReasons, setRenderChangeReasons] = useState(false);
   const { isOpen, onClose, onOpen } = useDisclosure();
 
   const [searchParams] = useSearchParams();
@@ -72,13 +71,6 @@ export const Status = () => {
       fulfillmentType: fulfillmentType
     });
   };
-
-  useEffect(() => {
-    if (canOrderReroute) {
-      const isEnabled = patientAnalytics.getFlagValueSync('change_pharmacy_reasons', false);
-      setRenderChangeReasons(isEnabled);
-    }
-  }, [canOrderReroute]);
 
   const handleDemoStatusPage = async (demoUserPhone: string, selectedDemoPharmacy: Pharmacy) => {
     const isMailOrder = !!order.pharmacy?.fulfillmentTypes?.includes('MAIL_ORDER');
@@ -164,7 +156,8 @@ export const Status = () => {
   };
 
   const handleReroute = () => {
-    if (renderChangeReasons) {
+    const isEnabled = patientAnalytics.getFlagValueSync('change_pharmacy_reasons', false);
+    if (isEnabled) {
       onOpen();
       return;
     }
@@ -366,9 +359,7 @@ export const Status = () => {
       <VStack w="full" pb={6}>
         <PoweredBy />
       </VStack>
-      {renderChangeReasons && (
-        <ChangePharmacyReasons isOpen={isOpen} onClose={onClose} onSelect={handleSelectReason} />
-      )}
+      <ChangePharmacyReasons isOpen={isOpen} onClose={onClose} onSelect={handleSelectReason} />
     </VStack>
   );
 };


### PR DESCRIPTION
I missed this line in the [Mixpanel docs](https://docs.mixpanel.com/docs/tracking-methods/sdks/javascript/javascript-flags#flag-evaluation):

> Lookup the assigned value for a feature flag. **This action triggers tracking an exposure event**, $experiment_started to your Mixpanel project.

With the current implementation, we send `$experiment_started` whenever a patient views the order Status page, which artificially inflates the number of users participating in the experiment. I did this because I thought `getFlagValueSync` sends the HTTP request to retrieve feature flags, but the flags are actually retrieved when we init Mixpanel. `getFlagValueSync` then references the flags object that's already been loaded in.

We should only consider the experiment started if they actually click the Change pharmacy button.