### PR TITLE
render DoB next to Patient name when searching for patients

### DIFF
--- a/packages/elements/src/photon-patient-select/photon-patient-select-component.tsx
+++ b/packages/elements/src/photon-patient-select/photon-patient-select-component.tsx
@@ -83,7 +83,7 @@ const Component = (props: {
           if (!p) return '';
           const element = (
             <div>
-              <span>{p.name?.full}</span> <span>{p.dateOfBirth}</span>
+              <span>{p.name?.full}</span> <span style="color:grey">{p.dateOfBirth}</span>
             </div>
           );
           return element;

--- a/packages/elements/src/photon-patient-select/photon-patient-select-component.tsx
+++ b/packages/elements/src/photon-patient-select/photon-patient-select-component.tsx
@@ -79,7 +79,15 @@ const Component = (props: {
         invalid={props.invalid}
         isLoading={store.patients.isLoading || store.selectedPatient.isLoading}
         hasMore={store.patients.data.length % 25 === 0 && !store.patients.finished}
-        displayAccessor={(p) => p?.name?.full || ''}
+        displayAccessor={(p) => {
+          if (!p) return '';
+          const element = (
+            <div>
+              <span>{p.name?.full}</span> <span>{p.dateOfBirth}</span>
+            </div>
+          );
+          return element;
+        }}
         onSearchChange={async (s: string) =>
           (fetchMore = await actions.getPatients(client!.getSDK(), {
             name: s

--- a/packages/elements/src/photon-patient-select/photon-patient-select-component.tsx
+++ b/packages/elements/src/photon-patient-select/photon-patient-select-component.tsx
@@ -82,8 +82,8 @@ const Component = (props: {
         displayAccessor={(p) => {
           if (!p) return '';
           const element = (
-            <div>
-              <span>{p.name?.full}</span> <span style="color:grey">{p.dateOfBirth}</span>
+            <div class="flex justify-between items-center">
+              <span>{p.name?.full}</span> <span class="text-sm text-gray-500">{p.dateOfBirth}</span>
             </div>
           );
           return element;

--- a/packages/elements/src/photon-patient-select/photon-patient-select-component.tsx
+++ b/packages/elements/src/photon-patient-select/photon-patient-select-component.tsx
@@ -11,6 +11,37 @@ import { createEffect, createMemo, onMount, untrack } from 'solid-js';
 import { PatientStore } from '../stores/patient';
 import { PhotonClient } from '@photonhealth/sdk';
 
+const monthNumberToAbreviation = new Map([
+  ['01', 'Jan'],
+  ['02', 'Feb'],
+  ['03', 'Mar'],
+  ['04', 'Apr'],
+  ['05', 'May'],
+  ['06', 'Jun'],
+  ['07', 'Jul'],
+  ['08', 'Aug'],
+  ['09', 'Sep'],
+  ['10', 'Oct'],
+  ['11', 'Nov'],
+  ['12', 'Dec']
+]);
+
+/**
+ * @param rawDate Patient AWSDate in the form of YYYY-MM-DD
+ * Change the ambiguous AWS Date form into something more human readable
+ * In the form of DD-MMM-YYYY
+ */
+function formatDate(rawDate: string): string {
+  const dateSplit = rawDate.split('-');
+  const day = dateSplit[2];
+  const month = dateSplit[1];
+  const year = dateSplit[0];
+  if (!monthNumberToAbreviation.has(month)) {
+    return 'Unknown';
+  }
+  return `${day}-${monthNumberToAbreviation.get(month)}-${year}`;
+}
+
 const Component = (props: {
   label?: string;
   required: boolean;
@@ -83,7 +114,8 @@ const Component = (props: {
           if (!p) return '';
           const element = (
             <div class="flex justify-between items-center">
-              <span>{p.name?.full}</span> <span class="text-sm text-gray-500">{p.dateOfBirth}</span>
+              <span>{p.name?.full}</span>{' '}
+              <span class="text-sm text-gray-500">{formatDate(String(p.dateOfBirth))}</span>
             </div>
           );
           return element;


### PR DESCRIPTION
Some prescribers have reported issues of mis-identifying patients when using the drop-down patient search. This update adds patient date of birth to the dropdown:

<img width="605" height="368" alt="Screenshot 2026-04-07 at 11 11 44 AM" src="https://github.com/user-attachments/assets/c762385c-c896-4c09-992d-1165e59ff453" />


