### PR TITLE
fix Add Prescription btn always hidden when creating a refill

### DIFF
--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@photonhealth/elements",
-  "version": "0.20.6",
+  "version": "0.20.7",
   "description": "",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/elements/src/photon-multirx-form/components/AddPrescriptionCard.tsx
+++ b/packages/elements/src/photon-multirx-form/components/AddPrescriptionCard.tsx
@@ -65,7 +65,6 @@ export const AddPrescriptionCard = (props: {
   enableCombineAndDuplicate?: boolean;
   screenDraftedPrescriptions: () => void;
   draftedPrescriptionChanged: () => void;
-  onDraftPrescriptionCreated: () => void;
   screeningAlerts: ScreeningAlertType[];
   catalogId?: string;
   allowOffCatalogSearch?: boolean;
@@ -130,9 +129,6 @@ export const AddPrescriptionCard = (props: {
         showSuccessToast: true
       };
       createdPrescription = await tryCreatePrescription(prescriptionFormData, options);
-      if (createdPrescription) {
-        props.onDraftPrescriptionCreated();
-      }
     } catch (err) {
       dispatchOrderError([err as GraphQLFormattedError]);
     } finally {

--- a/packages/elements/src/photon-multirx-form/components/DraftPrescriptionCard.tsx
+++ b/packages/elements/src/photon-multirx-form/components/DraftPrescriptionCard.tsx
@@ -1,5 +1,6 @@
-import { createSignal } from 'solid-js';
+import { createSignal, Show } from 'solid-js';
 import {
+  Button,
   Card,
   CoverageOption,
   DraftPrescriptionList,
@@ -23,6 +24,7 @@ export const DraftPrescriptionCard = (props: {
   screeningAlerts: ScreeningAlertType[];
   routingConstraints: RoutingConstraint[];
   enableOrder: boolean;
+  onAddDraft?: () => void;
 }) => {
   const { dispatchDraftPrescriptionDeleted, dispatchAnalyticsTrackEvent } =
     usePrescribeEventDispatch();
@@ -148,14 +150,21 @@ export const DraftPrescriptionCard = (props: {
         </p>
       </photon-dialog>
       <Card addChildrenDivider={true}>
-        <div class="flex items-center space-x-2 text-slate-500">
-          <Text color="gray" class="pr-2">
-            Draft Prescriptions
-          </Text>
-          <PhotonTooltip
-            maxWidth="300px"
-            tip="Each prescription will include the prescriber’s digital signature and the date it was written when the order is sent to the pharmacy."
-          />
+        <div class="flex items-center justify-between">
+          <div class="flex items-center space-x-2 text-slate-500">
+            <Text color="gray" class="pr-2">
+              Draft Prescriptions
+            </Text>
+            <PhotonTooltip
+              maxWidth="300px"
+              tip="Each prescription will include the prescriber’s digital signature and the date it was written when the order is sent to the pharmacy."
+            />
+          </div>
+          <Show when={props.onAddDraft}>
+            <Button variant="secondary" size="sm" onClick={props.onAddDraft}>
+              + Add
+            </Button>
+          </Show>
         </div>
         <DraftPrescriptionList
           handleDelete={(draftId: string) => {

--- a/packages/elements/src/photon-multirx-form/components/DraftPrescriptionCard.tsx
+++ b/packages/elements/src/photon-multirx-form/components/DraftPrescriptionCard.tsx
@@ -150,35 +150,40 @@ export const DraftPrescriptionCard = (props: {
         </p>
       </photon-dialog>
       <Card addChildrenDivider={true}>
-        <div class="flex items-center justify-between">
-          <div class="flex items-center space-x-2 text-slate-500">
-            <Text color="gray" class="pr-2">
-              Draft Prescriptions
-            </Text>
-            <PhotonTooltip
-              maxWidth="300px"
-              tip="Each prescription will include the prescriber’s digital signature and the date it was written when the order is sent to the pharmacy."
-            />
-          </div>
+        <div class="flex items-center space-x-2 text-slate-500">
+          <Text color="gray" class="pr-2">
+            Draft Prescriptions
+          </Text>
+          <PhotonTooltip
+            maxWidth="300px"
+            tip="Each prescription will include the prescriber's digital signature and the date it was written when the order is sent to the pharmacy."
+          />
+        </div>
+        <div>
+          <DraftPrescriptionList
+            handleDelete={(draftId: string) => {
+              setDeleteDialogOpen(true);
+              setDeleteDraftId(draftId);
+            }}
+            handleEdit={(draft) => {
+              checkEditPrescription(draft);
+            }}
+            handleSwapToOtherPrescription={handleSwapToOtherPrescription}
+            screeningAlerts={props.screeningAlerts}
+            routingConstraints={props.routingConstraints}
+            enableOrder={props.enableOrder}
+          />
           <Show when={props.onAddDraft}>
-            <Button variant="secondary" size="sm" onClick={props.onAddDraft}>
-              + Add
+            <Button
+              variant="secondary"
+              class="w-full xs:w-fit mt-5"
+              size="lg"
+              onClick={props.onAddDraft}
+            >
+              Add another
             </Button>
           </Show>
         </div>
-        <DraftPrescriptionList
-          handleDelete={(draftId: string) => {
-            setDeleteDialogOpen(true);
-            setDeleteDraftId(draftId);
-          }}
-          handleEdit={(draft) => {
-            checkEditPrescription(draft);
-          }}
-          handleSwapToOtherPrescription={handleSwapToOtherPrescription}
-          screeningAlerts={props.screeningAlerts}
-          routingConstraints={props.routingConstraints}
-          enableOrder={props.enableOrder}
-        />
       </Card>
     </div>
   );

--- a/packages/elements/src/photon-multirx-form/components/DraftPrescriptionCard.tsx
+++ b/packages/elements/src/photon-multirx-form/components/DraftPrescriptionCard.tsx
@@ -24,7 +24,7 @@ export const DraftPrescriptionCard = (props: {
   screeningAlerts: ScreeningAlertType[];
   routingConstraints: RoutingConstraint[];
   enableOrder: boolean;
-  onAddDraft?: () => void;
+  onAddAnotherClick?: () => void;
 }) => {
   const { dispatchDraftPrescriptionDeleted, dispatchAnalyticsTrackEvent } =
     usePrescribeEventDispatch();
@@ -34,7 +34,8 @@ export const DraftPrescriptionCard = (props: {
   const [editDraft, setEditDraft] = createSignal<PrescriptionFormData | undefined>(undefined);
   const [deleteDraftId, setDeleteDraftId] = createSignal<string | undefined>();
   const { selectOtherCoverageOption } = usePrescribe();
-  const { draftPrescriptions, prescriptionIds, deletePrescription } = useDraftPrescriptions();
+  const { draftPrescriptions, prescriptionIds, deletePrescription, isLoadingPrefills } =
+    useDraftPrescriptions();
 
   const editPrescription = () => {
     const formData = editDraft();
@@ -173,12 +174,12 @@ export const DraftPrescriptionCard = (props: {
             routingConstraints={props.routingConstraints}
             enableOrder={props.enableOrder}
           />
-          <Show when={props.onAddDraft}>
+          <Show when={props.onAddAnotherClick && !isLoadingPrefills()}>
             <Button
               variant="secondary"
               class="w-full xs:w-fit mt-5"
               size="lg"
-              onClick={props.onAddDraft}
+              onClick={props.onAddAnotherClick}
             >
               Add another
             </Button>

--- a/packages/elements/src/photon-multirx-form/components/PrescribeWorkflow.tsx
+++ b/packages/elements/src/photon-multirx-form/components/PrescribeWorkflow.tsx
@@ -692,7 +692,7 @@ export function PrescribeWorkflow(props: PrescribeProps) {
                   enableOrder={props.enableOrder}
                   // If rx form is hidden, we need a button to toggle it to visible
                   // If rx form is visible, we don't need the button
-                  onAddDraft={!showForm() ? () => setShowForm(true) : undefined}
+                  onAddAnotherClick={!showForm() ? () => setShowForm(true) : undefined}
                 />
                 <Show when={props.enableOrder && needsSupervisor()}>
                   <SupervisorCard actions={props.formActions} store={props.formStore} />

--- a/packages/elements/src/photon-multirx-form/components/PrescribeWorkflow.tsx
+++ b/packages/elements/src/photon-multirx-form/components/PrescribeWorkflow.tsx
@@ -100,6 +100,9 @@ export type PrescribeProps = {
   allowOffCatalogSearch?: boolean;
   disableList?: DisableList;
   groupId?: string;
+  /**
+   * This logic keeps the rx form closed when refilling a particular template/prescription
+   */
   initialShowForm: boolean;
 };
 
@@ -695,6 +698,9 @@ export function PrescribeWorkflow(props: PrescribeProps) {
                   screeningAlerts={screeningAlerts()}
                   routingConstraints={pharmacySelectionContext.routingConstraints()}
                   enableOrder={props.enableOrder}
+                  // If rx form is hidden, we need a button to toggle it to visible
+                  // If rx form is visible, we don't need the button
+                  onAddDraft={!showForm() ? () => setShowForm(true) : undefined}
                 />
                 <Show when={props.enableOrder && needsSupervisor()}>
                   <SupervisorCard actions={props.formActions} store={props.formStore} />
@@ -737,12 +743,7 @@ export function PrescribeWorkflow(props: PrescribeProps) {
                       </For>
                     </div>
                   </Show>
-                  <div class="flex flex-row justify-end gap-2">
-                    <Show when={!showForm()}>
-                      <Button variant="secondary" onClick={() => setShowForm(true)}>
-                        Add Prescription
-                      </Button>
-                    </Show>
+                  <div class="flex flex-row justify-end">
                     <Button loading={isLoadingPrefills() || isLoading()} onClick={combineOrSubmit}>
                       Send
                     </Button>

--- a/packages/elements/src/photon-multirx-form/components/PrescribeWorkflow.tsx
+++ b/packages/elements/src/photon-multirx-form/components/PrescribeWorkflow.tsx
@@ -155,7 +155,6 @@ export function PrescribeWorkflow(props: PrescribeProps) {
   const [showForm, setShowForm] = createSignal<boolean>(props.initialShowForm);
   const [errors, setErrors] = createSignal<FormError[]>([]);
   const [isLoading, setIsLoading] = createSignal<boolean>(true);
-  const [isEditing, setIsEditing] = createSignal<boolean>(false);
   const [authenticated, setAuthenticated] = createSignal<boolean>(
     client?.authentication.state.isAuthenticated || false
   );
@@ -562,12 +561,6 @@ export function PrescribeWorkflow(props: PrescribeProps) {
     );
   });
 
-  const handleDraftPrescriptionCreated = () => {
-    if (isEditing()) {
-      setIsEditing(false);
-    }
-  };
-
   return (
     <div ref={ref}>
       <Show
@@ -663,7 +656,7 @@ export function PrescribeWorkflow(props: PrescribeProps) {
                 <Show when={props.enableCombineAndDuplicate}>
                   <RecentOrders.Card />
                 </Show>
-                <Show when={showForm() || isEditing()}>
+                <Show when={showForm()}>
                   <div ref={prescriptionRef}>
                     <AddPrescriptionCard
                       hideAddToTemplates={props.hideTemplates}
@@ -679,7 +672,6 @@ export function PrescribeWorkflow(props: PrescribeProps) {
                       draftedPrescriptionChanged={function () {
                         screenDraftedPrescriptions();
                       }}
-                      onDraftPrescriptionCreated={handleDraftPrescriptionCreated}
                       screeningAlerts={screeningAlerts()}
                       catalogId={props.catalogId}
                       allowOffCatalogSearch={props.allowOffCatalogSearch}
@@ -691,7 +683,7 @@ export function PrescribeWorkflow(props: PrescribeProps) {
                   prescriptionRef={prescriptionRef}
                   actions={props.formActions}
                   store={props.formStore}
-                  setIsEditing={setIsEditing}
+                  setIsEditing={() => setShowForm(true)}
                   handleDraftPrescriptionsChange={function () {
                     screenDraftedPrescriptions();
                   }}

--- a/packages/elements/src/photon-multirx-form/photon-prescribe-workflow-component.tsx
+++ b/packages/elements/src/photon-multirx-form/photon-prescribe-workflow-component.tsx
@@ -109,7 +109,6 @@ export const PhotonPrescribeWorkflowComponent = (props: PrescribeWorkflowCompone
                 allowOffCatalogSearch={props.allowOffCatalogSearch}
                 disableList={props.disableList}
                 groupId={props.groupId}
-                // this logic keeps the rx form closed when refilling a particular template/prescription
                 initialShowForm={!props.templateIds && !props.prescriptionIds}
               />
             </PrescribeProvider>


### PR DESCRIPTION
Part of KLU-120

Solution here is to replace the "Add Prescription" button at the bottom of the prescribe element with a button inside `DraftPrescriptionCard`. The button is no longer tied to the `hideSubmit` prop, which was causing the bug.

<img width="374" height="667" alt="Screenshot 2026-04-08 at 11 16 43 AM" src="https://github.com/user-attachments/assets/2322df75-a5b2-4749-8554-98d7d6219a94" />
