### PR TITLE
Fix groupDisplay for patient rendering

### DIFF
--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@photonhealth/elements",
-  "version": "0.20.7",
+  "version": "0.20.6",
   "description": "",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@photonhealth/elements",
-  "version": "0.20.6",
+  "version": "0.20.7",
   "description": "",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/elements/src/photon-patient-select/photon-patient-select-component.tsx
+++ b/packages/elements/src/photon-patient-select/photon-patient-select-component.tsx
@@ -110,15 +110,19 @@ const Component = (props: {
         invalid={props.invalid}
         isLoading={store.patients.isLoading || store.selectedPatient.isLoading}
         hasMore={store.patients.data.length % 25 === 0 && !store.patients.finished}
-        displayAccessor={(p) => {
+        displayAccessor={(p, groupDisplay) => {
           if (!p) return '';
-          const element = (
-            <div class="flex justify-between items-center">
-              <span>{p.name?.full}</span>{' '}
-              <span class="text-sm text-gray-500">{formatDate(String(p.dateOfBirth))}</span>
-            </div>
-          );
-          return element;
+          // What to display if we're rending a list.
+          if (groupDisplay) {
+            return (
+              <div class="flex justify-between items-center">
+                <span>{p.name?.full}</span>{' '}
+                <span class="text-sm text-gray-500">{formatDate(String(p.dateOfBirth))}</span>
+              </div>
+            );
+          }
+
+          return p.name.full;
         }}
         onSearchChange={async (s: string) =>
           (fetchMore = await actions.getPatients(client!.getSDK(), {


### PR DESCRIPTION
The displayAccessor on Photon Dropdown has a setting for "groupDisplay" which is what we should render for showing the list of data. If it's "false" we are rendering the placeholder which must be a string and doesn't play nice with divs.

This changes the displayAccessor for patient dropdown which will now render DOB in a list and the name as a placeholder.