### PR TITLE
Mixpanel replay masking

### DIFF
--- a/apps/app/src/configs/providerAnalytics.ts
+++ b/apps/app/src/configs/providerAnalytics.ts
@@ -1,37 +1,61 @@
 import { ApiObject, IdentifyTraits, RudderAnalytics } from '@rudderstack/analytics-js';
+import mixpanel from 'mixpanel-browser';
 
 const RUDDERSTACK_WRITE_KEY = import.meta.env.VITE_RUDDERSTACK_WRITE_KEY;
 const RUDDERSTACK_DATA_PLANE_URL = import.meta.env.VITE_RUDDERSTACK_DATA_PLANE_URL;
+const MIXPANEL_TOKEN = import.meta.env.VITE_MIXPANEL_TOKEN;
 const ENVIRONMENT = import.meta.env.VITE_ENV_NAME || 'development';
 
 export class ProviderAnalytics {
   private rudderanalytics?: RudderAnalytics;
   private environment: string;
   private isInitialized = false;
+  private mixpanelEnabled = false;
+  private isNonProduction: boolean;
 
   constructor() {
     this.environment = ENVIRONMENT;
+    this.isNonProduction =
+      ENVIRONMENT === 'boson' ||
+      ENVIRONMENT === 'neutron' ||
+      ENVIRONMENT === 'tau' ||
+      ENVIRONMENT === 'local' ||
+      ENVIRONMENT === 'development';
 
     if (!RUDDERSTACK_WRITE_KEY || !RUDDERSTACK_DATA_PLANE_URL) {
       console.warn(
         'RudderStack write key and data plane URL are required for analytics. Analytics will be disabled.'
       );
-      return;
+    } else {
+      this.rudderanalytics = new RudderAnalytics();
+      this.rudderanalytics.load(RUDDERSTACK_WRITE_KEY, RUDDERSTACK_DATA_PLANE_URL);
+      this.isInitialized = true;
     }
 
-    this.rudderanalytics = new RudderAnalytics();
-    this.rudderanalytics.load(RUDDERSTACK_WRITE_KEY, RUDDERSTACK_DATA_PLANE_URL);
-    this.isInitialized = true;
+    if (MIXPANEL_TOKEN) {
+      mixpanel.init(MIXPANEL_TOKEN, {
+        debug: false, // floods the console, only turn on when needed
+        track_pageview: true,
+        persistence: 'localStorage',
+        record_sessions_percent: 100, // session replay
+        record_heatmap_data: true,
+        flags: true,
+        record_mask_all_text: false // reveal all text and mask individually; inputs are unaffected and remain masked
+      });
+      this.mixpanelEnabled = true;
+    }
   }
 
   /**
    * Identify the current user so all subsequent events are attributed to them.
    */
   identify(userId: string, traits: IdentifyTraits = {}) {
-    if (!this.rudderanalytics || !this.isInitialized) {
-      return;
+    if (this.rudderanalytics && this.isInitialized) {
+      this.rudderanalytics.identify(userId, traits);
     }
-    this.rudderanalytics.identify(userId, traits);
+    if (this.mixpanelEnabled) {
+      mixpanel.identify(userId);
+    }
   }
 
   /**
@@ -40,27 +64,24 @@ export class ProviderAnalytics {
    * @param properties - Event properties including context data
    */
   track(eventName: string, properties: ApiObject = {}) {
-    if (!this.rudderanalytics || !this.isInitialized) {
-      return;
-    }
-
     const trackProperties = {
       environment: this.environment,
       ...properties
     };
 
-    const isNonProductionEnvironment =
-      this.environment === 'boson' ||
-      this.environment === 'neutron' ||
-      this.environment === 'tau' ||
-      this.environment === 'local' ||
-      this.environment === 'development';
-
-    if (isNonProductionEnvironment) {
-      console.log(`📊 [Analytics] ${eventName}`, trackProperties);
+    if (this.rudderanalytics && this.isInitialized) {
+      if (this.isNonProduction) {
+        console.log(`📊 [Analytics] ${eventName}`, trackProperties);
+      }
+      this.rudderanalytics.track(eventName, trackProperties);
     }
 
-    this.rudderanalytics.track(eventName, trackProperties);
+    if (this.mixpanelEnabled) {
+      if (this.isNonProduction) {
+        console.log(`📊 [Analytics: To Mixpanel] ${eventName}`, trackProperties);
+      }
+      mixpanel.track(eventName, trackProperties);
+    }
   }
 }
 

--- a/apps/app/src/views/components/ContactView.tsx
+++ b/apps/app/src/views/components/ContactView.tsx
@@ -10,7 +10,7 @@ interface ContactViewProps {
 const ContactView = (props: ContactViewProps) => {
   const { phone, email } = props;
   return (
-    <VStack spacing="0" data-dd-privacy="mask" alignItems="start">
+    <VStack spacing="0" data-dd-privacy="mask" className="mp-mask" alignItems="start">
       <Link fontWeight="medium" href={`tel:${phone}`} isExternal>
         {formatPhone(phone)}
       </Link>

--- a/apps/app/src/views/components/NameView.tsx
+++ b/apps/app/src/views/components/NameView.tsx
@@ -13,13 +13,13 @@ const NameView = ({ name, sub = '', isPatient = false, patientId = '' }: NameVie
     <HStack spacing="3">
       <Box>
         {isPatient ? (
-          <Text fontWeight="medium" whiteSpace="nowrap" data-dd-privacy="mask">
+          <Text fontWeight="medium" whiteSpace="nowrap" data-dd-privacy="mask" className="mp-mask">
             <ChakraLink as={RouterLink} to={`/patients/${patientId}`} style={{ textWrap: 'wrap' }}>
               {name}
             </ChakraLink>
           </Text>
         ) : (
-          <Text fontWeight="medium" whiteSpace="nowrap" data-dd-privacy="mask">
+          <Text fontWeight="medium" whiteSpace="nowrap" data-dd-privacy="mask" className="mp-mask">
             {name}
           </Text>
         )}

--- a/apps/app/src/views/components/Nav.tsx
+++ b/apps/app/src/views/components/Nav.tsx
@@ -113,15 +113,25 @@ export const Nav = () => {
                 </MenuButton>
                 <MenuList py="0">
                   <VStack alignItems={'start'} py={'2.5'} px={'3'} roundedTop={'md'} gap={'1'}>
-                    <Text fontWeight="medium" fontSize="md">
+                    <Text
+                      fontWeight="medium"
+                      fontSize="md"
+                      data-dd-privacy="mask"
+                      className="mp-mask"
+                    >
                       {user?.name}
                     </Text>
-                    <Text color="muted" fontSize="sm">
+                    <Text color="muted" fontSize="sm" data-dd-privacy="mask" className="mp-mask">
                       {user?.email}
                     </Text>
                     {organization?.name &&
                       user?.name.toLowerCase() !== organization?.name.toLowerCase() && (
-                        <Text color="muted" fontSize="sm">
+                        <Text
+                          color="muted"
+                          fontSize="sm"
+                          data-dd-privacy="mask"
+                          className="mp-mask"
+                        >
                           {organization.name}
                         </Text>
                       )}

--- a/apps/app/src/views/components/UserProfile.tsx
+++ b/apps/app/src/views/components/UserProfile.tsx
@@ -13,10 +13,22 @@ export const UserProfile = () => {
         boxSize="10"
       />
       <Box>
-        <Text fontWeight="medium" fontSize="sm" wordBreak={'break-word'}>
+        <Text
+          fontWeight="medium"
+          fontSize="sm"
+          wordBreak={'break-word'}
+          data-dd-privacy="mask"
+          className="mp-mask"
+        >
           {user?.name}
         </Text>
-        <Text color="muted" fontSize="sm" wordBreak={'break-all'}>
+        <Text
+          color="muted"
+          fontSize="sm"
+          wordBreak={'break-all'}
+          data-dd-privacy="mask"
+          className="mp-mask"
+        >
           {user?.email}
         </Text>
       </Box>

--- a/apps/app/src/views/routes/NewOrder/components/PatientCard.tsx
+++ b/apps/app/src/views/routes/NewOrder/components/PatientCard.tsx
@@ -56,7 +56,9 @@ export const PatientCard = ({ loading, patient }: PatientCardProps) => {
                     skeletonHeight="4"
                   />
                 ) : (
-                  <Text data-dd-privacy="mask">{patient?.name.full}</Text>
+                  <Text data-dd-privacy="mask" className="mp-mask">
+                    {patient?.name.full}
+                  </Text>
                 )}
               </GridItem>
               <GridItem area="sexAtBirth" whiteSpace="nowrap">
@@ -72,7 +74,9 @@ export const PatientCard = ({ loading, patient }: PatientCardProps) => {
                     skeletonHeight="4"
                   />
                 ) : patient?.sex ? (
-                  <Text data-dd-privacy="mask">{patient?.sex}</Text>
+                  <Text data-dd-privacy="mask" className="mp-mask">
+                    {patient?.sex}
+                  </Text>
                 ) : (
                   <Text as="i">None</Text>
                 )}
@@ -90,7 +94,9 @@ export const PatientCard = ({ loading, patient }: PatientCardProps) => {
                     skeletonHeight="4"
                   />
                 ) : patient?.gender ? (
-                  <Text data-dd-privacy="mask">{patient?.gender}</Text>
+                  <Text data-dd-privacy="mask" className="mp-mask">
+                    {patient?.gender}
+                  </Text>
                 ) : (
                   <Text as="i">None</Text>
                 )}
@@ -116,7 +122,9 @@ export const PatientCard = ({ loading, patient }: PatientCardProps) => {
                     skeletonHeight="4"
                   />
                 ) : patient?.phone ? (
-                  <Text data-dd-privacy="mask">{formatPhone(patient.phone)}</Text>
+                  <Text data-dd-privacy="mask" className="mp-mask">
+                    {formatPhone(patient.phone)}
+                  </Text>
                 ) : (
                   <Text as="i">None</Text>
                 )}
@@ -134,7 +142,9 @@ export const PatientCard = ({ loading, patient }: PatientCardProps) => {
                     skeletonHeight="4"
                   />
                 ) : patient?.email ? (
-                  <Text data-dd-privacy="mask">{patient.email}</Text>
+                  <Text data-dd-privacy="mask" className="mp-mask">
+                    {patient.email}
+                  </Text>
                 ) : (
                   <Text as="i">None</Text>
                 )}

--- a/apps/app/src/views/routes/PatientDetails/index.tsx
+++ b/apps/app/src/views/routes/PatientDetails/index.tsx
@@ -156,7 +156,7 @@ export const Patient = () => {
     >
       <Card>
         <CardHeader>
-          <Text fontWeight="medium" data-dd-privacy="mask">
+          <Text fontWeight="medium" data-dd-privacy="mask" className="mp-mask">
             {loading ? (
               <SkeletonText skeletonHeight={5} noOfLines={1} width="200px" />
             ) : (
@@ -179,7 +179,7 @@ export const Patient = () => {
               {loading ? (
                 <SkeletonText skeletonHeight={5} noOfLines={1} width="100px" />
               ) : patient?.dateOfBirth ? (
-                <Text fontSize="md" data-dd-privacy="mask">
+                <Text fontSize="md" data-dd-privacy="mask" className="mp-mask">
                   {formatDateLong(patient.dateOfBirth)}
                 </Text>
               ) : (
@@ -193,7 +193,7 @@ export const Patient = () => {
               {loading ? (
                 <SkeletonText skeletonHeight={5} noOfLines={1} width="100px" />
               ) : patient?.sex ? (
-                <Text fontSize="md" data-dd-privacy="mask">
+                <Text fontSize="md" data-dd-privacy="mask" className="mp-mask">
                   {sexMap[patient.sex as keyof object]}{' '}
                 </Text>
               ) : (
@@ -207,7 +207,7 @@ export const Patient = () => {
               {loading ? (
                 <SkeletonText skeletonHeight={5} noOfLines={1} width="100px" />
               ) : patient?.gender ? (
-                <Text fontSize="md" data-dd-privacy="mask">
+                <Text fontSize="md" data-dd-privacy="mask" className="mp-mask">
                   {patient.gender}
                 </Text>
               ) : (
@@ -227,6 +227,7 @@ export const Patient = () => {
                   isExternal
                   textDecoration="underline"
                   data-dd-privacy="mask"
+                  className="mp-mask"
                 >
                   {formatPhone(patient.phone)}
                 </Link>
@@ -247,6 +248,7 @@ export const Patient = () => {
                   isExternal
                   textDecoration="underline"
                   data-dd-privacy="mask"
+                  className="mp-mask"
                 >
                   {patient.email}
                 </Link>

--- a/apps/app/src/views/routes/Settings/components/invites/InviteItem.tsx
+++ b/apps/app/src/views/routes/Settings/components/invites/InviteItem.tsx
@@ -49,7 +49,9 @@ export const InviteItem = ({ invite: data }: { invite: FragmentType<typeof invit
   return (
     <Tr key={invite.id}>
       <Td>
-        <Text>{invite.invitee}</Text>
+        <Text data-dd-privacy="mask" className="mp-mask">
+          {invite.invitee}
+        </Text>
       </Td>
       <Td>
         <Badge size="sm" colorScheme={invite.expired ? 'red' : 'green'}>

--- a/apps/app/src/views/routes/Settings/components/organization/Organization.tsx
+++ b/apps/app/src/views/routes/Settings/components/organization/Organization.tsx
@@ -136,7 +136,9 @@ export const Organization = () => {
       ].map(({ title, value }) => ({
         title,
         value: value ? (
-          <Text fontSize="sm">{value}</Text>
+          <Text fontSize="sm" data-dd-privacy="mask" className="mp-mask">
+            {value}
+          </Text>
         ) : (
           <Text fontSize="sm" color="gray.400" as="i">
             Not available

--- a/apps/app/src/views/routes/Settings/components/profile/Profile.tsx
+++ b/apps/app/src/views/routes/Settings/components/profile/Profile.tsx
@@ -110,7 +110,9 @@ export const Profile = () => {
       ]).map(({ title, value }) => ({
         title,
         value: value ? (
-          <Text fontSize="sm">{value}</Text>
+          <Text fontSize="sm" data-dd-privacy="mask" className="mp-mask">
+            {value}
+          </Text>
         ) : (
           <Text fontSize="sm" color="gray.400" as="i">
             Not available

--- a/apps/app/src/views/routes/Settings/components/users/UserItem.tsx
+++ b/apps/app/src/views/routes/Settings/components/users/UserItem.tsx
@@ -64,11 +64,15 @@ export const UserItem = ({
     <Tr>
       <Td>
         <Skeleton isLoaded={!loading}>
-          <Text>{user?.name?.full ?? 'Unknown'}</Text>
+          <Text data-dd-privacy="mask" className="mp-mask">
+            {user?.name?.full ?? 'Unknown'}
+          </Text>
         </Skeleton>
       </Td>
       <Td>
-        <Skeleton isLoaded={!loading}>{user?.email ?? 'EMAIL'}</Skeleton>
+        <Skeleton isLoaded={!loading} data-dd-privacy="mask" className="mp-mask">
+          {user?.email ?? 'EMAIL'}
+        </Skeleton>
       </Td>
       <Td textOverflow={'ellipsis'}>
         <Skeleton isLoaded={!loading}>{roles ?? 'ROLES'}</Skeleton>

--- a/apps/patient/src/components/AddressForm.tsx
+++ b/apps/patient/src/components/AddressForm.tsx
@@ -240,7 +240,7 @@ export const AddressForm = forwardRef<AddressFormHandle, AddressFormProps>(
                         <FormLabel htmlFor="street1" fontSize="sm">
                           Street address
                         </FormLabel>
-                        <Input {...field} id="street1" data-dd-privacy="mask" />
+                        <Input {...field} id="street1" data-dd-privacy="mask" className="mp-mask" />
                         <FormErrorMessage>{meta.error}</FormErrorMessage>
                       </FormControl>
                     )}
@@ -252,7 +252,7 @@ export const AddressForm = forwardRef<AddressFormHandle, AddressFormProps>(
                         <FormLabel htmlFor="street2" fontSize="sm">
                           Apartment, suite, etc. (optional)
                         </FormLabel>
-                        <Input {...field} id="street2" data-dd-privacy="mask" />
+                        <Input {...field} id="street2" data-dd-privacy="mask" className="mp-mask" />
                       </FormControl>
                     )}
                   </Field>
@@ -263,7 +263,7 @@ export const AddressForm = forwardRef<AddressFormHandle, AddressFormProps>(
                         <FormLabel htmlFor="city" fontSize="sm">
                           City
                         </FormLabel>
-                        <Input {...field} id="city" data-dd-privacy="mask" />
+                        <Input {...field} id="city" data-dd-privacy="mask" className="mp-mask" />
                         <FormErrorMessage>{meta.error}</FormErrorMessage>
                       </FormControl>
                     )}
@@ -301,7 +301,13 @@ export const AddressForm = forwardRef<AddressFormHandle, AddressFormProps>(
                           <FormLabel htmlFor="postalCode" fontSize="sm">
                             ZIP code
                           </FormLabel>
-                          <Input {...field} id="postalCode" maxLength={10} data-dd-privacy="mask" />
+                          <Input
+                            {...field}
+                            id="postalCode"
+                            maxLength={10}
+                            data-dd-privacy="mask"
+                            className="mp-mask"
+                          />
                           <FormErrorMessage>{meta.error}</FormErrorMessage>
                         </FormControl>
                       )}

--- a/apps/patient/src/components/PharmacyInfo.tsx
+++ b/apps/patient/src/components/PharmacyInfo.tsx
@@ -441,6 +441,7 @@ export const PharmacyInfo = ({
             fontWeight="medium"
             target="_blank"
             data-dd-privacy="mask"
+            className="mp-mask"
             ms={2}
           >
             {orderFulfillment.carrier} {orderFulfillment.trackingNumber}

--- a/apps/patient/src/components/PrescriptionsList.tsx
+++ b/apps/patient/src/components/PrescriptionsList.tsx
@@ -38,7 +38,12 @@ export const PrescriptionsList = () => {
                         onClick={() => {}}
                       >
                         <VStack me="auto" w="full" align="start">
-                          <Text align="start" data-dd-privacy="mask" fontWeight="semibold">
+                          <Text
+                            align="start"
+                            data-dd-privacy="mask"
+                            className="mp-mask"
+                            fontWeight="semibold"
+                          >
                             {treatment.name}
                           </Text>
                           <HStack>
@@ -55,21 +60,27 @@ export const PrescriptionsList = () => {
                         <HStack>
                           <HStack w="50%">
                             <Text color="gray.500">{t.quantity}</Text>
-                            <Text data-dd-privacy="mask">{prescription.dispenseQuantity}</Text>
+                            <Text data-dd-privacy="mask" className="mp-mask">
+                              {prescription.dispenseQuantity}
+                            </Text>
                           </HStack>
                           <HStack w="50%">
                             <Text color="gray.500">{t.daysSupply}</Text>
-                            <Text data-dd-privacy="mask">{prescription.daysSupply}</Text>
+                            <Text data-dd-privacy="mask" className="mp-mask">
+                              {prescription.daysSupply}
+                            </Text>
                           </HStack>
                         </HStack>
                         <HStack>
                           <HStack w="50%">
                             <Text color="gray.500">{t.refills}</Text>
-                            <Text data-dd-privacy="mask">{count - 1}</Text>
+                            <Text data-dd-privacy="mask" className="mp-mask">
+                              {count - 1}
+                            </Text>
                           </HStack>
                           <HStack w="50%">
                             <Text color="gray.500">{t.expires}</Text>
-                            <Text data-dd-privacy="mask">
+                            <Text data-dd-privacy="mask" className="mp-mask">
                               {formatDate(prescription.expirationDate)}
                             </Text>
                           </HStack>

--- a/apps/patient/src/components/StatusStepper.tsx
+++ b/apps/patient/src/components/StatusStepper.tsx
@@ -76,7 +76,10 @@ export const StatusStepper = ({ status, fulfillmentType, patientAddress }: Props
                   </StepIndicator>
                   <Box ml={1}>
                     <StepTitle>{title}</StepTitle>
-                    <StepDescription data-dd-privacy={isDelivery ? 'mask' : undefined}>
+                    <StepDescription
+                      data-dd-privacy={isDelivery ? 'mask' : undefined}
+                      className={isDelivery ? 'mp-mask' : undefined}
+                    >
                       {description}
                     </StepDescription>
                   </Box>

--- a/apps/patient/src/components/order-summary/OrderSummary.tsx
+++ b/apps/patient/src/components/order-summary/OrderSummary.tsx
@@ -128,7 +128,9 @@ const ExceptionsBlock = ({ exception }: { exception: ExceptionData }) => {
 const FulfillmentBlock = ({ fulfillment }: { fulfillment: FulfillmentData }) => {
   return (
     <VStack w="full" alignItems={'stretch'}>
-      <Text data-dd-privacy="mask">{fulfillment.rxName}</Text>
+      <Text data-dd-privacy="mask" className="mp-mask">
+        {fulfillment.rxName}
+      </Text>
       {fulfillment.exceptions.sort(exceptionCmp).map((e) => (
         <ExceptionsBlock key={`${fulfillment.rxName}-${e.exceptionType}`} exception={e} />
       ))}

--- a/apps/patient/src/configs/analytics.ts
+++ b/apps/patient/src/configs/analytics.ts
@@ -320,7 +320,8 @@ class RudderAndMixPanelPatientAnalytics implements PatientAnalytics {
         persistence: 'localStorage',
         record_sessions_percent: 100, // session replay
         record_heatmap_data: true,
-        flags: true
+        flags: true,
+        record_mask_all_text: false // reveal all text and mask individually; inputs are unaffected and remain masked
       });
       this.mixpanelEnabled = true;
     }

--- a/apps/patient/src/views/Pharmacy.tsx
+++ b/apps/patient/src/views/Pharmacy.tsx
@@ -1134,6 +1134,7 @@ export const Pharmacy = () => {
                       display="inline"
                       size="sm"
                       data-dd-privacy="mask"
+                      className="mp-mask"
                     >
                       <FiMapPin style={{ display: 'inline', marginRight: '4px' }} />
                       {cleanAddress}

--- a/apps/patient/src/views/Review.tsx
+++ b/apps/patient/src/views/Review.tsx
@@ -88,7 +88,7 @@ export const Review = () => {
               <Text display="inline" color="gray.500">
                 {t.patient}
               </Text>
-              <Text display="inline" data-dd-privacy="mask">
+              <Text display="inline" data-dd-privacy="mask" className="mp-mask">
                 {patient.name.full}
               </Text>
             </HStack>

--- a/packages/components/src/systems/PatientInfo/index.tsx
+++ b/packages/components/src/systems/PatientInfo/index.tsx
@@ -112,7 +112,7 @@ export default function PatientInfo(props: PatientInfoProps) {
           </Button>
         </Show>
       </div>
-      <div class="pt-2" data-dd-privacy="mask">
+      <div class="pt-2 mp-mask" data-dd-privacy="mask">
         <Text size="lg" bold loading={!patient()} sampleLoadingText="Sally Patient">
           {patient()?.name.full || 'N/A'}
         </Text>


### PR DESCRIPTION
- adding mixpanel to provider analytics so replays now work on both patient and provider flows
- defaulting mixpanel to mask all input fields but reveal all text fields...meaning we have to individually mask text. To start, I've masked allthe fields that were being masked in datadog rum sessions
- added more masking on provider side, for both datadog and mixpanel, to hide user and other provider names, emails, address, etc.

provider masking:
https://mixpanel.com/project/4007639/view/4503408/app/profile#distinct_id=usr_01KJR2QZY3V3AKJECZZGTH2GFA&replay_id=6be4fb13-c8e3-43e3-96c9-eed7f9a76116&replay_timestamp=9506.590600013733