### PR TITLE
Element emits user token

### DIFF
--- a/packages/elements/index.html
+++ b/packages/elements/index.html
@@ -7,6 +7,10 @@
     <script src="./src/index.ts" type="module"></script>
 
     <script>
+      window.addEventListener('photon-user-token', (e) => {
+        console.log('photon-user-token:', e.detail.token);
+      });
+
       window.addEventListener('photon-order-created', (e) => {
         console.log(e);
         const parent = document.getElementById('parent');
@@ -35,6 +39,7 @@
       audience="https://api.boson.health"
       uri="https://api.boson.health/graphql"
       auto-login="true"
+      emit-user-token="true"
     >
       <div style="padding: 15px" id="parent">
         <photon-prescribe-workflow

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@photonhealth/elements",
-  "version": "0.20.8",
+  "version": "0.20.9",
   "description": "",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/elements/src/photon-client/photon-client-component.tsx
+++ b/packages/elements/src/photon-client/photon-client-component.tsx
@@ -119,7 +119,6 @@ const Component = (props: PhotonClientProps) => {
   createEffect(() => {
     const isAuthenticated = store()?.authentication.state.isAuthenticated;
     const isLoading = store()?.authentication.state.isLoading;
-    console.log({ isAuthenticated, isLoading, emit: props.emitUserToken });
     if (props.emitUserToken && isAuthenticated && !isLoading) {
       sdk.authentication.getAccessToken().then((token) => {
         ref?.dispatchEvent(

--- a/packages/elements/src/photon-client/photon-client-component.tsx
+++ b/packages/elements/src/photon-client/photon-client-component.tsx
@@ -2,10 +2,10 @@ import { customElement } from 'solid-element';
 import { createEffect, createSignal } from 'solid-js';
 import { Env, PhotonClient } from '@photonhealth/sdk';
 import {
+  GoogleServiceProvider,
   PhotonClientStore,
   PhotonContext,
-  SDKProvider,
-  GoogleServiceProvider
+  SDKProvider
 } from '@photonhealth/components';
 import { makeTimer } from '@solid-primitives/timer';
 import queryString from 'query-string';
@@ -28,6 +28,7 @@ type PhotonClientProps = {
   toastBuffer?: number;
   env?: Env;
   externalUserId?: string;
+  emitUserToken?: boolean;
 };
 
 const version = pkg?.version ?? 'unknown';
@@ -112,6 +113,23 @@ const Component = (props: PhotonClientProps) => {
         }
         store()?.authentication.login(args);
       }
+    }
+  });
+
+  createEffect(() => {
+    const isAuthenticated = store()?.authentication.state.isAuthenticated;
+    const isLoading = store()?.authentication.state.isLoading;
+    console.log({ isAuthenticated, isLoading, emit: props.emitUserToken });
+    if (props.emitUserToken && isAuthenticated && !isLoading) {
+      sdk.authentication.getAccessToken().then((token) => {
+        ref?.dispatchEvent(
+          new CustomEvent('photon-user-token', {
+            composed: true,
+            bubbles: true,
+            detail: { token }
+          })
+        );
+      });
     }
   });
 
@@ -220,6 +238,13 @@ customElement(
       reflect: true,
       notify: true,
       parse: false
+    },
+    emitUserToken: {
+      attribute: 'emit-user-token',
+      value: false,
+      reflect: false,
+      notify: false,
+      parse: true
     }
   },
   Component

--- a/packages/sdk/src/auth.ts
+++ b/packages/sdk/src/auth.ts
@@ -164,7 +164,7 @@ export class AuthManager {
       };
       await this.authentication.loginWithRedirect(redirectOpts);
       if (throwIfFailure) {
-        throw new Error(); // Needed just because this needs to resolve to something
+        throw new Error('Unable to retrieve access token'); // Session likely expired
       } else {
         // Retry once
         return await this._getAccessToken({ audience }, true);

--- a/packages/sdk/src/lib.ts
+++ b/packages/sdk/src/lib.ts
@@ -173,7 +173,13 @@ export class PhotonClient {
   ) {
     const apollo = new ApolloClient({
       link: setContext(async (_, { headers: baseHeaders, ...rest }) => {
-        const token = await this.authentication.getAccessToken();
+        let token: string | undefined;
+        try {
+          token = await this.authentication.getAccessToken();
+        } catch {
+          // Session expired or auth unavailable — proceed without token
+          // so the request gets a proper 401 from the API
+        }
 
         const headers = {
           ...baseHeaders,


### PR DESCRIPTION
* `<photon-client>` now supports an optional configuration `emit-user-token="true"` that, when enabled, will emit the user token for making API calls.

Part of KLU-122