### PR TITLE
Fix iOS Webview bugs

### DIFF
--- a/apps/app/index.html
+++ b/apps/app/index.html
@@ -5,7 +5,7 @@
     <link rel="icon" href="/favicon.ico" />
     <meta
       name="viewport"
-      content="width=device-width, user-scalable=no, maximum-scale=1, initial-scale=1.0, viewport-fit=cover"
+      content="width=device-width, user-scalable=no, maximum-scale=1, initial-scale=1.0, viewport-fit=cover, interactive-widget=resizes-content"
     />
     <meta name="theme-color" content="#000000" />
     <meta name="description" content="Photon Health - Clinical App" />

--- a/apps/app/index.html
+++ b/apps/app/index.html
@@ -5,7 +5,7 @@
     <link rel="icon" href="/favicon.ico" />
     <meta
       name="viewport"
-      content="width=device-width, user-scalable=no, maximum-scale=1, initial-scale=1.0, viewport-fit=cover, interactive-widget=resizes-content"
+      content="width=device-width, user-scalable=no, maximum-scale=1, initial-scale=1.0, viewport-fit=cover"
     />
     <meta name="theme-color" content="#000000" />
     <meta name="description" content="Photon Health - Clinical App" />

--- a/apps/app/src/views/routes/Patients.tsx
+++ b/apps/app/src/views/routes/Patients.tsx
@@ -7,6 +7,7 @@ import {
   MenuButton,
   MenuItem,
   MenuList,
+  Portal,
   Skeleton,
   SkeletonText,
   Text
@@ -59,35 +60,37 @@ const EditView = (props: EditViewProps) => {
           icon={<FiMoreVertical fontSize="1.25rem" />}
           variant="ghost"
         />
-        <MenuList>
-          <MenuItem icon={<FiEye fontSize="1.2em" />} as={RouterLink} to={`/patients/${id}`}>
-            View patient
-          </MenuItem>
-          <MenuItem
-            icon={<FiEdit fontSize="1.2em" />}
-            as={RouterLink}
-            to={`/patients/update/${id}`}
-            onClick={() => {
-              setDisableScroll(true);
-            }}
-          >
-            Edit patient
-          </MenuItem>
-          <MenuItem
-            icon={<TbPrescription fontSize="1.2em" />}
-            as={RouterLink}
-            to={`/prescriptions/new?patientId=${id}`}
-          >
-            Create prescription
-          </MenuItem>
-          <MenuItem
-            icon={<FiShoppingCart fontSize="1.2em" />}
-            as={RouterLink}
-            to={`/orders/new?patientId=${id}`}
-          >
-            Create order
-          </MenuItem>
-        </MenuList>
+        <Portal>
+          <MenuList>
+            <MenuItem icon={<FiEye fontSize="1.2em" />} as={RouterLink} to={`/patients/${id}`}>
+              View patient
+            </MenuItem>
+            <MenuItem
+              icon={<FiEdit fontSize="1.2em" />}
+              as={RouterLink}
+              to={`/patients/update/${id}`}
+              onClick={() => {
+                setDisableScroll(true);
+              }}
+            >
+              Edit patient
+            </MenuItem>
+            <MenuItem
+              icon={<TbPrescription fontSize="1.2em" />}
+              as={RouterLink}
+              to={`/prescriptions/new?patientId=${id}`}
+            >
+              Create prescription
+            </MenuItem>
+            <MenuItem
+              icon={<FiShoppingCart fontSize="1.2em" />}
+              as={RouterLink}
+              to={`/orders/new?patientId=${id}`}
+            >
+              Create order
+            </MenuItem>
+          </MenuList>
+        </Portal>
       </Menu>
     </HStack>
   );

--- a/packages/elements/src/photon-form-wrapper/photon-form-wrapper.tsx
+++ b/packages/elements/src/photon-form-wrapper/photon-form-wrapper.tsx
@@ -13,12 +13,6 @@ export type PhotonFormWrapperProps = {
   checkShouldWarn?: () => boolean;
 };
 
-// only need certain styles for WebViews; they style slightly different than Safari
-const isIOSWebView =
-  typeof navigator !== 'undefined' &&
-  /iPad|iPhone|iPod/.test(navigator.userAgent) &&
-  !/Safari\//.test(navigator.userAgent);
-
 export const PhotonFormWrapper = (p: PhotonFormWrapperProps) => {
   const props = mergeProps(
     {
@@ -38,23 +32,8 @@ export const PhotonFormWrapper = (p: PhotonFormWrapperProps) => {
   const handleCancel = () => onCloseDialogOpen(false);
 
   return (
-    <div
-      ref={ref}
-      classList={{
-        'z-50 fixed inset-0 flex flex-col bg-[#F9FAFB]': true,
-        'photon-form-wrapper--webview': isIOSWebView // fix footer spacing on ios webviews that do not have the Safari spacing
-      }}
-    >
+    <div ref={ref} class="z-50 fixed inset-0 flex flex-col bg-[#F9FAFB]">
       <style>{tailwind}</style>
-      {/* fix iOS Home bar's reserved space from clipping the Footer buttons */}
-      <style>{`
-        .photon-form-wrapper__footer {
-          padding-bottom: calc(1rem + env(safe-area-inset-bottom));
-        }
-        .photon-form-wrapper--webview .photon-form-wrapper__footer {
-          padding-bottom: max(calc(1rem + env(safe-area-inset-bottom)), 2.5rem);
-        }
-      `}</style>
 
       {/* Close Wrapper Modal */}
       <photon-dialog
@@ -102,7 +81,7 @@ export const PhotonFormWrapper = (p: PhotonFormWrapperProps) => {
         <div class="px-4 pt-4 pb-4 md:px-4 w-full sm:w-[600px] xs:mx-auto">{props.form}</div>
       </main>
       <Show when={props.footer}>
-        <footer class="photon-form-wrapper__footer flex-shrink-0 bg-white shadow-card px-4 pt-4 md:px-8">
+        <footer class="flex-shrink-0 bg-white shadow-card px-4 py-4 md:px-8">
           <div class="flex flex-col xs:flex-row-reverse xs:justify-start gap-2 items-center w-full sm:w-[600px] xs:mx-auto sm:px-4">
             {props.footer}
           </div>

--- a/packages/elements/src/photon-form-wrapper/photon-form-wrapper.tsx
+++ b/packages/elements/src/photon-form-wrapper/photon-form-wrapper.tsx
@@ -13,6 +13,12 @@ export type PhotonFormWrapperProps = {
   checkShouldWarn?: () => boolean;
 };
 
+// only need certain styles for WebViews; they style slightly different than Safari
+const isIOSWebView =
+  typeof navigator !== 'undefined' &&
+  /iPad|iPhone|iPod/.test(navigator.userAgent) &&
+  !/Safari\//.test(navigator.userAgent);
+
 export const PhotonFormWrapper = (p: PhotonFormWrapperProps) => {
   const props = mergeProps(
     {
@@ -32,17 +38,21 @@ export const PhotonFormWrapper = (p: PhotonFormWrapperProps) => {
   const handleCancel = () => onCloseDialogOpen(false);
 
   return (
-    <div ref={ref} class="z-50 fixed inset-0 flex flex-col bg-[#F9FAFB]">
+    <div
+      ref={ref}
+      classList={{
+        'z-50 fixed inset-0 flex flex-col bg-[#F9FAFB]': true,
+        'photon-form-wrapper--webview': isIOSWebView // fix footer spacing on ios webviews that do not have the Safari spacing
+      }}
+    >
       <style>{tailwind}</style>
       {/* fix iOS Home bar's reserved space from clipping the Footer buttons */}
       <style>{`
         .photon-form-wrapper__footer {
           padding-bottom: calc(1rem + env(safe-area-inset-bottom));
         }
-        @supports (-webkit-touch-callout: none) {
-          .photon-form-wrapper__footer {
-            padding-bottom: max(calc(1rem + env(safe-area-inset-bottom)), 2.5rem);
-          }
+        .photon-form-wrapper--webview .photon-form-wrapper__footer {
+          padding-bottom: max(calc(1rem + env(safe-area-inset-bottom)), 2.5rem);
         }
       `}</style>
 

--- a/packages/elements/src/photon-form-wrapper/photon-form-wrapper.tsx
+++ b/packages/elements/src/photon-form-wrapper/photon-form-wrapper.tsx
@@ -32,12 +32,19 @@ export const PhotonFormWrapper = (p: PhotonFormWrapperProps) => {
   const handleCancel = () => onCloseDialogOpen(false);
 
   return (
-    <div
-      ref={ref}
-      class="z-50 fixed top-0 left-0 w-full h-screen overflow-y-auto overflow-x-hidden bg-[#F9FAFB]"
-      style={{ height: '100dvh', '-webkit-overflow-scrolling': 'touch', 'touch-action': 'pan-y' }}
-    >
+    <div ref={ref} class="z-50 fixed inset-0 flex flex-col bg-[#F9FAFB]">
       <style>{tailwind}</style>
+      {/* fix iOS Home bar's reserved space from clipping the Footer buttons */}
+      <style>{`
+        .photon-form-wrapper__footer {
+          padding-bottom: calc(1rem + env(safe-area-inset-bottom));
+        }
+        @supports (-webkit-touch-callout: none) {
+          .photon-form-wrapper__footer {
+            padding-bottom: max(calc(1rem + env(safe-area-inset-bottom)), 2.5rem);
+          }
+        }
+      `}</style>
 
       {/* Close Wrapper Modal */}
       <photon-dialog
@@ -52,8 +59,7 @@ export const PhotonFormWrapper = (p: PhotonFormWrapperProps) => {
         <p class="font-sans text-lg xs:text-base">{props.closeBody}</p>
       </photon-dialog>
 
-      {/* Wrapper */}
-      <header class="z-40 flex items-center px-4 py-2 md:px-8 md:py-3 bg-white fixed w-full shadow-card">
+      <header class="flex-shrink-0 flex items-center px-4 py-2 md:px-8 md:py-3 bg-white shadow-card">
         <div class="flex items-center">
           <Button
             variant="naked"
@@ -79,13 +85,14 @@ export const PhotonFormWrapper = (p: PhotonFormWrapperProps) => {
         </div>
         <div class="flex items-center w-[44px]" />
       </header>
-      <div class="z-30 w-full min-h-screen bg-[#F9FAFB] pt-14">
-        <div class="px-4 pb-40 md:pt-4 md:pb-52 md:px-4 w-full h-full sm:w-[600px] xs:mx-auto">
-          {props.form}
-        </div>
-      </div>
+      <main
+        class="flex-1 overflow-y-auto overscroll-contain"
+        style={{ '-webkit-overflow-scrolling': 'touch' }}
+      >
+        <div class="px-4 pt-4 pb-4 md:px-4 w-full sm:w-[600px] xs:mx-auto">{props.form}</div>
+      </main>
       <Show when={props.footer}>
-        <footer class="z-40 fixed bottom-0 w-full bg-white shadow-card px-4 py-4 md:px-8">
+        <footer class="photon-form-wrapper__footer flex-shrink-0 bg-white shadow-card px-4 pt-4 md:px-8">
           <div class="flex flex-col xs:flex-row-reverse xs:justify-start gap-2 items-center w-full sm:w-[600px] xs:mx-auto sm:px-4">
             {props.footer}
           </div>

--- a/packages/elements/src/photon-patient-dialog/photon-patient-dialog-component.tsx
+++ b/packages/elements/src/photon-patient-dialog/photon-patient-dialog-component.tsx
@@ -1,5 +1,6 @@
 import { customElement } from 'solid-element';
 import { createEffect, createSignal, onMount, Show } from 'solid-js';
+import { Portal } from 'solid-js/web';
 import {
   buildFieldSnapshot,
   Button,
@@ -220,77 +221,88 @@ const Component = (props: PatientDialogProps) => {
 
   return (
     <div ref={ref}>
-      <style>{photonStyles}</style>
       <Show when={props.open}>
-        <PhotonFormWrapper
-          onClosed={() => {
-            dispatchClosed();
-            actions().resetStores();
-            props.open = false;
-          }}
-          title={props?.patientId ? 'Edit patient' : 'New patient'}
-          titleIconName={props?.patientId ? 'pencil-square' : 'person-plus'}
-          footer={
-            <>
-              <Show when={!props?.hideCreatePrescription}>
-                <Button
-                  class="w-full xs:w-fit"
-                  size="lg"
-                  disabled={loading()}
-                  loading={loading() && isCreatePrescription()}
-                  onClick={() => submitForm(formStore(), actions(), selectedStore(), true)}
-                >
-                  {props?.patientId ? 'Save' : 'Create'} and start prescription
-                </Button>
-              </Show>
-              <Show when={!!hasPatients() || !!props?.hideCreatePrescription}>
-                <Button
-                  class="w-full xs:w-fit"
-                  size="lg"
-                  variant={props?.hideCreatePrescription ? 'primary' : 'secondary'}
-                  disabled={loading()}
-                  loading={loading() && !isCreatePrescription()}
-                  onClick={() => submitForm(formStore(), actions(), selectedStore(), false)}
-                >
-                  {props?.patientId ? 'Save' : 'Create'}
-                </Button>
-              </Show>
-            </>
-          }
-          form={
-            <>
-              <Show when={globalError()}>
-                <div
-                  class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative mb-4"
-                  role="alert"
-                >
-                  <span class="block sm:inline">{globalError()}</span>
-                </div>
-              </Show>
-              <photon-patient-form
-                slot="form"
-                on:photon-form-updated={(e: any) => {
-                  setFormStore(e.detail.form);
-                  setActions(Object.assign({}, e.detail.actions, { resetStores: e.detail.reset }));
-                  setSelectedStore(e.detail.selected);
-                  // Check if any address field has a value
-                  const form = e.detail.form;
-                  setHasAnyAddressField(
-                    !!(
-                      form['address_street1']?.value ||
-                      form['address_street2']?.value ||
-                      form['address_city']?.value ||
-                      form['address_state']?.value ||
-                      form['address_zip']?.value
-                    )
-                  );
-                }}
-                patient-id={props.patientId}
-                optional-patient-address={props.optionalPatientAddress}
-              />
-            </>
-          }
-        />
+        {/*
+          Portal to document.body so the wrapper escapes the prescribe workflow's
+          <main overflow-y-auto> scroll container. On iOS, a nested position:fixed
+          element inside an overflow:auto ancestor can be clipped to that ancestor,
+          leaving the prescribe footer visible through this dialog. useShadow scopes
+          photonStyles + the wrapper's Tailwind so they don't leak to document.body.
+        */}
+        <Portal mount={document.body} useShadow={true}>
+          <style>{photonStyles}</style>
+          <PhotonFormWrapper
+            onClosed={() => {
+              dispatchClosed();
+              actions().resetStores();
+              props.open = false;
+            }}
+            title={props?.patientId ? 'Edit patient' : 'New patient'}
+            titleIconName={props?.patientId ? 'pencil-square' : 'person-plus'}
+            footer={
+              <>
+                <Show when={!props?.hideCreatePrescription}>
+                  <Button
+                    class="w-full xs:w-fit"
+                    size="lg"
+                    disabled={loading()}
+                    loading={loading() && isCreatePrescription()}
+                    onClick={() => submitForm(formStore(), actions(), selectedStore(), true)}
+                  >
+                    {props?.patientId ? 'Save' : 'Create'} and start prescription
+                  </Button>
+                </Show>
+                <Show when={!!hasPatients() || !!props?.hideCreatePrescription}>
+                  <Button
+                    class="w-full xs:w-fit"
+                    size="lg"
+                    variant={props?.hideCreatePrescription ? 'primary' : 'secondary'}
+                    disabled={loading()}
+                    loading={loading() && !isCreatePrescription()}
+                    onClick={() => submitForm(formStore(), actions(), selectedStore(), false)}
+                  >
+                    {props?.patientId ? 'Save' : 'Create'}
+                  </Button>
+                </Show>
+              </>
+            }
+            form={
+              <>
+                <Show when={globalError()}>
+                  <div
+                    class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative mb-4"
+                    role="alert"
+                  >
+                    <span class="block sm:inline">{globalError()}</span>
+                  </div>
+                </Show>
+                <photon-patient-form
+                  slot="form"
+                  on:photon-form-updated={(e: any) => {
+                    setFormStore(e.detail.form);
+                    setActions(
+                      Object.assign({}, e.detail.actions, { resetStores: e.detail.reset })
+                    );
+                    setSelectedStore(e.detail.selected);
+                    // Check if any address field has a value
+                    const form = e.detail.form;
+                    setHasAnyAddressField(
+                      !!(
+                        form['address_street1']?.value ||
+                        form['address_street2']?.value ||
+                        form['address_city']?.value ||
+                        form['address_state']?.value ||
+                        form['address_zip']?.value
+                      )
+                    );
+                  }}
+                  patient-id={props.patientId}
+                  optional-patient-address={props.optionalPatientAddress}
+                />
+              </>
+            }
+          />
+        </Portal>
       </Show>
     </div>
   );


### PR DESCRIPTION
* Fix iOS WebView showing "New Prescriptions" footer bar above the "Edit Patient" footer bar when editing a patient on the new prescription screen
  * Implemented by wrapping the rendered PhotonFormWrapper in Solid's `<Portal mount={document.body} useShadow={true}>` to utilize shadow dom layering
* Reworked layout for `photon-form-wrapper` to improve scrolling on iOS
* Fix ellipsis menu on Patients page clipping behind tableview when there was only 1 or 2 patients worth of vertical height in the table 

Part of KLU-199