### PR TITLE
remove unnecessary mixpanel specific tracking for now

### DIFF
--- a/apps/app/src/configs/providerAnalytics.ts
+++ b/apps/app/src/configs/providerAnalytics.ts
@@ -81,7 +81,6 @@ export class ProviderAnalytics {
       if (this.isNonProduction) {
         console.log(`📊 [Analytics: To Mixpanel] ${eventName}`, trackProperties);
       }
-      mixpanel.track(eventName, trackProperties);
     }
   }
 }


### PR DESCRIPTION
on the patient side, we have some places where we only send to mixpanel, not rudderstack but this isn't necessary on clinical side. Removing this line that's adding duplicated event tracking in mixpanel 