### PR TITLE
fix source maps for elements/components/react packages

### DIFF
--- a/apps/app/vite.config.ts
+++ b/apps/app/vite.config.ts
@@ -2,12 +2,20 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import tsconfigPaths from 'vite-tsconfig-paths';
+import sourcemaps from 'rollup-plugin-sourcemaps2';
 import { execSync } from 'child_process';
 
 const commitHash = execSync('git rev-parse HEAD').toString().trim();
 
 export default defineConfig({
-  plugins: [react(), tsconfigPaths()],
+  // Rollup chains sourcemaps only for modules a plugin transforms (Vite's TS/JSX
+  // pipeline does this for source files). Pre-built deps like @photonhealth/elements'
+  // dist/index.mjs are read verbatim — their //# sourceMappingURL= comment is
+  // ignored and their sidecar .map is never loaded, so stack traces through them
+  // stay minified in Datadog. This plugin reads those comments and feeds the
+  // sidecar maps into the chain. Remove sourcemaps() once https://github.com/vitejs/vite/issues/11743
+  // ships native support.
+  plugins: [react(), tsconfigPaths(), sourcemaps()],
   define: {
     __COMMIT_HASH__: JSON.stringify(commitHash)
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -125,6 +125,7 @@
         "prettier": "^2.8.1",
         "react-test-renderer": "^18.2.0",
         "rimraf": "^5.0.1",
+        "rollup-plugin-sourcemaps2": "^0.5.6",
         "storybook": "^10.2.13",
         "tw-colors": "^1.2.6",
         "typescript-eslint": "^8.33.0",
@@ -27520,6 +27521,28 @@
         "@rollup/rollup-win32-x64-gnu": "4.59.0",
         "@rollup/rollup-win32-x64-msvc": "4.59.0",
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rollup-plugin-sourcemaps2": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-sourcemaps2/-/rollup-plugin-sourcemaps2-0.5.6.tgz",
+      "integrity": "sha512-oalmewAT4GLVsW6NugcDybx0ypet94vU0dUK3VofdYoWiN4ZjoX1L4dizFd0OhoJ78r/Am9sARTR9gMrX0cJ7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/pluginutils": "5.3.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18.0.0",
+        "rollup": ">=4"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/rollup-plugin-typescript2": {

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "prettier": "^2.8.1",
     "react-test-renderer": "^18.2.0",
     "rimraf": "^5.0.1",
+    "rollup-plugin-sourcemaps2": "^0.5.6",
     "storybook": "^10.2.13",
     "tw-colors": "^1.2.6",
     "typescript-eslint": "^8.33.0",

--- a/packages/components/vite.config.ts
+++ b/packages/components/vite.config.ts
@@ -19,6 +19,7 @@ export default defineConfig({
       fileName: 'index'
     },
     target: 'esnext',
+    sourcemap: true,
     rollupOptions: {
       external: ['solid-js']
     }

--- a/packages/elements/vite.config.ts
+++ b/packages/elements/vite.config.ts
@@ -4,6 +4,7 @@ import { defineConfig } from 'vite';
 import solidPlugin from 'vite-plugin-solid';
 import typescript from '@rollup/plugin-typescript';
 import replace from '@rollup/plugin-replace';
+import sourcemaps from 'rollup-plugin-sourcemaps2';
 
 // eslint-disable-next-line
 const resolvePath = (str: string) => path.resolve(__dirname, str);
@@ -17,7 +18,16 @@ export default defineConfig({
       declaration: true,
       declarationDir: resolvePath('./dist'),
       exclude: resolvePath('./node_modules/**')
-    })
+    }),
+    // Rollup chains sourcemaps only for modules a plugin transforms. The
+    // pre-built @photonhealth/components dist/index.js we import is read
+    // verbatim — its //# sourceMappingURL= comment is ignored and its sidecar
+    // .map never loaded, so components code ends up in our bundle with no
+    // original-source mapping. This plugin reads those comments and feeds the
+    // sidecar maps into the chain, so consumers of this package (the clinical
+    // app) can symbolicate stack traces all the way back to components' TS.
+    // Remove sourcemaps() once https://github.com/vitejs/vite/issues/11743 ships native support.
+    sourcemaps()
   ],
   build: {
     lib: {
@@ -39,7 +49,8 @@ export default defineConfig({
       ]
     },
     target: 'esnext',
-    minify: true
+    minify: true,
+    sourcemap: true
   },
   test: {
     environment: 'jsdom',

--- a/packages/react/vite.config.ts
+++ b/packages/react/vite.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
     })
   ],
   build: {
+    sourcemap: true,
     lib: {
       // eslint-disable-next-line
       entry: path.resolve(__dirname, 'src/index.ts'),


### PR DESCRIPTION
* noticed our webapp was showing bad stack traces for errors caused in elements
* adding sourcemaps for our packages to fix this

# example stacktrace pre-fix
```
TypeError: Proxy handler's 'get' result of a non-configurable and non-writable property should be the same value as the target's property
  at gW @ https://app.photon.health/assets/index-ho5SpQR4.js:3426:119169
  at Xh @ https://app.photon.health/assets/index-ho5SpQR4.js:3426:120318
```