### PR TITLE
Remove feature flag for `change_pharmacy_reasons`. Add it as default behavior now

### DIFF
--- a/apps/patient/src/configs/featureFlags.ts
+++ b/apps/patient/src/configs/featureFlags.ts
@@ -1,5 +1,4 @@
 export type FlagValues = {
-  change_pharmacy_reasons: boolean;
   remove_review_your_rx_page: {
     skipReviewPage: boolean;
     showRxSummaryOnPharmacyPage: boolean;
@@ -9,7 +8,6 @@ export type FlagValues = {
 export type FlagKeys = keyof FlagValues;
 
 export const FEATURE_FLAG_DEFAULTS: FlagValues = {
-  change_pharmacy_reasons: false,
   remove_review_your_rx_page: {
     skipReviewPage: false,
     showRxSummaryOnPharmacyPage: false

--- a/apps/patient/src/views/Status.test.tsx
+++ b/apps/patient/src/views/Status.test.tsx
@@ -33,24 +33,15 @@ vi.mock('@datadog/browser-rum');
 vi.mock('react-ga4');
 vi.mock('mixpanel-browser');
 
-let mockChangePharmacyReasonsFlag = false;
 vi.mock('../hooks/usePatientAnalytics', () => ({
   usePatientAnalytics: vi.fn(() => ({
     track: vi.fn(),
     page: vi.fn(),
     identify: vi.fn(),
     getFlagValue: vi.fn(async (flagName: string) => {
-      if (flagName === 'change_pharmacy_reasons') {
-        return mockChangePharmacyReasonsFlag;
-      }
-
       return FEATURE_FLAG_DEFAULTS[flagName as keyof typeof FEATURE_FLAG_DEFAULTS];
     }),
     getFlagValueSync: vi.fn((flagName: string) => {
-      if (flagName === 'change_pharmacy_reasons') {
-        return mockChangePharmacyReasonsFlag;
-      }
-
       return FEATURE_FLAG_DEFAULTS[flagName as keyof typeof FEATURE_FLAG_DEFAULTS];
     })
   })),
@@ -138,13 +129,6 @@ describe('Status page Rerouting', () => {
       }
     }
   };
-  beforeEach(() => {
-    mockChangePharmacyReasonsFlag = true;
-  });
-
-  afterEach(() => {
-    mockChangePharmacyReasonsFlag = false;
-  });
 
   test('navigates directly to pharmacy page without modal when unresolved ORDER_ERROR exists', async () => {
     const { memoryRouter } = await renderAppAtStatusView({

--- a/apps/patient/src/views/Status.tsx
+++ b/apps/patient/src/views/Status.tsx
@@ -29,7 +29,7 @@ export const Status = () => {
   const { order, setOrder, isDemo, setFaqModalIsOpen, setReason } = useOrderContext();
   const patientAnalytics = usePatientAnalytics();
   const { enablePatientRerouting } = order?.organization?.settings?.patientUx ?? {};
-  const { isOpen, onClose, onOpen } = useDisclosure();
+  const rerouteReasonDialog = useDisclosure();
 
   const [searchParams] = useSearchParams();
   const token = searchParams.get('token') ?? undefined;
@@ -161,7 +161,6 @@ export const Status = () => {
   };
 
   const handleReroute = () => {
-    const isEnabled = patientAnalytics.getFlagValueSync('change_pharmacy_reasons');
     const hasUnresolvedOrderError = order.exceptions.some(
       (e) => e.exceptionType === 'ORDER_ERROR' && !e.resolvedAt
     );
@@ -173,12 +172,8 @@ export const Status = () => {
       return;
     }
 
-    if (isEnabled) {
-      onOpen();
-      return;
-    }
-
-    navigateToReroute();
+    rerouteReasonDialog.onOpen();
+    return;
   };
 
   const handleSelectReason = (reason: string, otherReason?: string) => {
@@ -375,7 +370,11 @@ export const Status = () => {
       <VStack w="full" pb={6}>
         <PoweredBy />
       </VStack>
-      <ChangePharmacyReasons isOpen={isOpen} onClose={onClose} onSelect={handleSelectReason} />
+      <ChangePharmacyReasons
+        isOpen={rerouteReasonDialog.isOpen}
+        onClose={rerouteReasonDialog.onClose}
+        onSelect={handleSelectReason}
+      />
     </VStack>
   );
 };


### PR DESCRIPTION
Experiment is done! We'll be defaulting to this behavior now and always asking for a reroute reason when, unless the order has an error on it.
