### PR TITLE
Fix double minify of published packages obscuring function names

### DIFF
--- a/packages/components/src/particles/ComboBox/index.tsx
+++ b/packages/components/src/particles/ComboBox/index.tsx
@@ -1,13 +1,13 @@
 import {
+  createContext,
+  createEffect,
+  createMemo,
+  createSignal,
+  JSX,
   onMount,
   Show,
-  JSX,
-  useContext,
-  createContext,
-  createMemo,
-  createEffect,
   splitProps,
-  createSignal
+  useContext
 } from 'solid-js';
 import Icon from '../Icon';
 import clickOutside from '../../utils/clickOutside';
@@ -94,7 +94,11 @@ export function ComboBox<T extends ComboBoxValueBase>(props: ComboBoxProps<T>) {
 
   createEffect(() => {
     // update internal selected state when the passed value changes
-    setState('selected', props.value);
+    // we have to deep clone the value via JSON util because it can be a complex object Solidjs Store Proxy
+    // (i.e. PatientSelect passes in a Patient from a Solidjs Store)
+    // and the ComboBox's createStore() store above is now allowed to contain another Solidjs Store object
+    // without throwing "proxy must report the same value for the non-writable, non-configurable property 'Symbol("store-node")'" error
+    setState('selected', props.value ? JSON.parse(JSON.stringify(props.value)) : props.value);
   });
 
   return (

--- a/packages/components/vite.config.ts
+++ b/packages/components/vite.config.ts
@@ -20,6 +20,7 @@ export default defineConfig({
     },
     target: 'esnext',
     sourcemap: true,
+    minify: false,
     rollupOptions: {
       external: ['solid-js']
     }

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@photonhealth/elements",
-  "version": "0.20.9",
+  "version": "0.21.0",
   "description": "",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/elements/vite.config.ts
+++ b/packages/elements/vite.config.ts
@@ -49,7 +49,7 @@ export default defineConfig({
       ]
     },
     target: 'esnext',
-    minify: true,
+    minify: false,
     sourcemap: true
   },
   test: {

--- a/packages/react/vite.config.ts
+++ b/packages/react/vite.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
   ],
   build: {
     sourcemap: true,
+    minify: false,
     lib: {
       // eslint-disable-next-line
       entry: path.resolve(__dirname, 'src/index.ts'),


### PR DESCRIPTION
Fixing function names being obscured in sourcemaps because they were pre-minified by the package build process. Now, there is a single minify at App build time.

Published NPM packages will be not minified any longer, so our install size will go up. But most consumers are probably minifying their own app builds, any way.

This will allow us to see better stack traces in our logs, and for customers to report more clear stacktraces to us when using Elements.

* bonus: included a fix for combobox errors happening recently that lead me toward cleaning up our sourcemaps