### PR TITLE
Attempt to fix Script Error in logs

### DIFF
--- a/apps/app/index.html
+++ b/apps/app/index.html
@@ -10,7 +10,7 @@
     <meta name="theme-color" content="#000000" />
     <meta name="description" content="Photon Health - Clinical App" />
     <link rel="apple-touch-icon" href="/logo256.png" />
-    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAvuwwE6g2Bsmih66nu4dB7-H7U1_7KQ6g&callback=Function.prototype&libraries=places"></script>
+    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAvuwwE6g2Bsmih66nu4dB7-H7U1_7KQ6g&callback=Function.prototype&libraries=places" crossorigin="anonymous"></script>
     <link rel="manifest" href="/manifest.json" />
     <title>Photon</title>
   </head>

--- a/apps/app/index.html
+++ b/apps/app/index.html
@@ -10,7 +10,10 @@
     <meta name="theme-color" content="#000000" />
     <meta name="description" content="Photon Health - Clinical App" />
     <link rel="apple-touch-icon" href="/logo256.png" />
-    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAvuwwE6g2Bsmih66nu4dB7-H7U1_7KQ6g&callback=Function.prototype&libraries=places" crossorigin="anonymous"></script>
+    <script
+      src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAvuwwE6g2Bsmih66nu4dB7-H7U1_7KQ6g&callback=Function.prototype&libraries=places"
+      crossorigin="anonymous"
+    ></script>
     <link rel="manifest" href="/manifest.json" />
     <title>Photon</title>
   </head>


### PR DESCRIPTION
- added `crossorigin="anonymous"` to Google Maps `<script>` tag as an attempt to fix the large amount of untraceable "Script error." error logs 

> crossorigin="anonymous" tells the browser to make a CORS request for the Google Maps script, which means if that script throws an error, your window.onerror / Datadog RUM    
  will get the real error message and stack trace instead of just "Script error." (browsers redact error details from cross-origin scripts by default for security). Without it,
   any uncaught exception from that script shows up as an opaque "Script error." with no useful debugging info.

<img width="1249" height="739" alt="image" src="https://github.com/user-attachments/assets/8839fc75-f103-4250-8e6e-3ddbcab99521" />
