### PR TITLE
unified tailwind build for elements + components

### DIFF
--- a/packages/components/tailwind.base.cjs
+++ b/packages/components/tailwind.base.cjs
@@ -1,0 +1,71 @@
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const defaultTheme = require('tailwindcss/defaultTheme');
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { createThemes } = require('tw-colors');
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const colors = require('tailwindcss/colors');
+
+/** Shared Tailwind base config for components and elements packages. No `content` array — add that per-package. */
+module.exports = {
+  mode: 'jit',
+  theme: {
+    screens: {
+      xs: '475px',
+      ...defaultTheme.screens
+    },
+    extend: {
+      colors: {
+        'photon-blue': '#3182ce',
+        'photon-blue-dark': '#2b6cb0',
+        'photon-light': '#F7F4F4',
+        blue: {
+          25: '#EFF8FF',
+          50: '#D1E9FF',
+          100: '#B2DDFF',
+          200: '#84CAFF',
+          300: '#53B1FD',
+          400: '#2E90FA',
+          500: '#1570EF',
+          600: '#175CD3',
+          700: '#1849A9',
+          800: '#194185',
+          900: '#102A56',
+          950: '#102A56'
+        }
+      },
+      boxShadow: {
+        card: '0px 0px 1px rgba(48, 49, 51, 0.05),0px 2px 4px rgba(48, 49, 51, 0.1);'
+      },
+      zIndex: {
+        60: '60',
+        70: '70',
+        80: '80',
+        90: '90',
+        100: '100',
+        2000: '2000'
+      }
+    }
+  },
+  plugins: [
+    require('@tailwindcss/forms'),
+    require('@tailwindcss/typography'),
+    createThemes({
+      photon: {
+        primaryText: colors.gray[50],
+        primary500: colors.indigo[500],
+        primary600: colors.indigo[600],
+        secondaryText: colors.gray[900],
+        secondary50: colors.indigo[50],
+        secondary100: colors.indigo[100]
+      },
+      weekend: {
+        primaryText: colors.gray[50],
+        primary500: colors.sky[500],
+        primary600: colors.sky[600],
+        secondaryText: colors.gray[900],
+        secondary50: colors.sky[50],
+        secondary100: colors.sky[100]
+      }
+    })
+  ]
+};

--- a/packages/components/tailwind.config.cjs
+++ b/packages/components/tailwind.config.cjs
@@ -1,59 +1,9 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-const { createThemes } = require('tw-colors');
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const colors = require('tailwindcss/colors');
+const base = require('./tailwind.base.cjs');
 
 /** @type {import('tailwindcss').Config} */
 // eslint-disable-next-line no-undef
 module.exports = {
-  content: ['./src/**/*.{html,js,jsx,ts,tsx}'],
-  theme: {
-    extend: {
-      zIndex: {
-        60: '60',
-        70: '70',
-        80: '80',
-        90: '90',
-        100: '100'
-      },
-      colors: {
-        blue: {
-          25: '#EFF8FF',
-          50: '#D1E9FF',
-          100: '#B2DDFF',
-          200: '#84CAFF',
-          300: '#53B1FD',
-          400: '#2E90FA',
-          500: '#1570EF',
-          600: '#175CD3',
-          700: '#1849A9',
-          800: '#194185',
-          900: '#102A56',
-          950: '#102A56'
-        }
-      }
-    }
-  },
-  plugins: [
-    require('@tailwindcss/forms'),
-    require('@tailwindcss/typography'),
-    createThemes({
-      photon: {
-        primaryText: colors.gray[50],
-        primary500: colors.indigo[500],
-        primary600: colors.indigo[600],
-        secondaryText: colors.gray[900],
-        secondary50: colors.indigo[50],
-        secondary100: colors.indigo[100]
-      },
-      weekend: {
-        primaryText: colors.gray[50],
-        primary500: colors.sky[500],
-        primary600: colors.sky[600],
-        secondaryText: colors.gray[900],
-        secondary50: colors.sky[50],
-        secondary100: colors.sky[100]
-      }
-    })
-  ]
+  ...base,
+  content: ['./src/**/*.{html,js,jsx,ts,tsx}']
 };

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@photonhealth/elements",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "description": "",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/elements/src/PhotonFormWrapper/PhotonFormWrapper.tsx
+++ b/packages/elements/src/PhotonFormWrapper/PhotonFormWrapper.tsx
@@ -1,8 +1,7 @@
 import { createSignal, JSX, mergeProps, Show } from 'solid-js';
 import { Button, Icon } from '@photonhealth/components';
-import tailwind from '../tailwind.css?inline';
 
-export type PhotonFormWrapperProps = {
+type PhotonFormWrapperProps = {
   closeTitle?: string;
   closeBody?: string;
   footer?: JSX.Element;
@@ -33,8 +32,6 @@ export const PhotonFormWrapper = (p: PhotonFormWrapperProps) => {
 
   return (
     <div ref={ref} class="z-50 fixed inset-0 flex flex-col bg-[#F9FAFB]">
-      <style>{tailwind}</style>
-
       {/* Close Wrapper Modal */}
       <photon-dialog
         label={props.closeTitle}

--- a/packages/elements/src/PhotonFormWrapper/index.ts
+++ b/packages/elements/src/PhotonFormWrapper/index.ts
@@ -1,0 +1,1 @@
+export * from './PhotonFormWrapper';

--- a/packages/elements/src/photon-add-medication-history-dialog/photon-add-medication-history-dialog-component.tsx
+++ b/packages/elements/src/photon-add-medication-history-dialog/photon-add-medication-history-dialog-component.tsx
@@ -12,7 +12,6 @@ import '@shoelace-style/shoelace/dist/components/menu-item/menu-item';
 import '@shoelace-style/shoelace/dist/components/spinner/spinner';
 import { setBasePath } from '@shoelace-style/shoelace/dist/utilities/base-path.js';
 //Styles
-import photonStyles from '@photonhealth/components/dist/index.css?inline';
 import shoelaceDarkStyles from '@shoelace-style/shoelace/dist/themes/dark.css?inline';
 import shoelaceLightStyles from '@shoelace-style/shoelace/dist/themes/light.css?inline';
 import tailwind from '../tailwind.css?inline';
@@ -103,7 +102,6 @@ const Component = (props: AddMedicationHistoryDialogProps) => {
 
   return (
     <div ref={ref}>
-      <style>{photonStyles}</style>
       <style>{tailwind}</style>
       <style>{shoelaceDarkStyles}</style>
       <style>{shoelaceLightStyles}</style>

--- a/packages/elements/src/photon-dialog/photon-dialog-component.tsx
+++ b/packages/elements/src/photon-dialog/photon-dialog-component.tsx
@@ -11,7 +11,6 @@ import shoelaceLightStyles from '@shoelace-style/shoelace/dist/themes/light.css?
 import shoelaceDarkStyles from '@shoelace-style/shoelace/dist/themes/dark.css?inline';
 import styles from './style.css?inline';
 import { Show } from 'solid-js';
-import photonStyles from '@photonhealth/components/dist/index.css?inline';
 
 setBasePath('https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.4.0/dist/');
 
@@ -45,7 +44,6 @@ const Component = (props: DialogProps) => {
 
   return (
     <>
-      <style>{photonStyles}</style>
       <style>{tailwind}</style>
       <style>{shoelaceDarkStyles}</style>
       <style>{shoelaceLightStyles}</style>

--- a/packages/elements/src/photon-form-wrapper/index.ts
+++ b/packages/elements/src/photon-form-wrapper/index.ts
@@ -1,1 +1,0 @@
-export * from './photon-form-wrapper';

--- a/packages/elements/src/photon-med-history/photon-med-history.tsx
+++ b/packages/elements/src/photon-med-history/photon-med-history.tsx
@@ -1,6 +1,6 @@
 import { customElement } from 'solid-element';
 import { PatientMedHistory } from '@photonhealth/components';
-import photonStyles from '@photonhealth/components/dist/index.css?inline';
+import tailwind from '../tailwind.css?inline';
 
 interface PatientMedProps {
   patientId: string;
@@ -9,7 +9,7 @@ interface PatientMedProps {
 const PatientMedHistoryWrapper = (props: PatientMedProps) => {
   return (
     <div>
-      <style>{photonStyles}</style>
+      <style>{tailwind}</style>
       <PatientMedHistory
         patientId={props.patientId}
         enableLinks={false}

--- a/packages/elements/src/photon-medication-search/photon-medication-search-component.tsx
+++ b/packages/elements/src/photon-medication-search/photon-medication-search-component.tsx
@@ -17,6 +17,8 @@ import { DisableList } from '../photon-multirx-form/components/PrescribeWorkflow
 
 import { ApolloClient } from '@apollo/client';
 
+import tailwind from '../tailwind.css?inline';
+
 // Utility Functions
 
 function createBlockedMedsMap(disableList: DisableList | undefined) {
@@ -374,6 +376,7 @@ const Component = (props: ComponentProps) => {
         dispatchSearchTextChanged(ref, '');
       }}
     >
+      <style>{tailwind}</style>
       {/* Mobile */}
 
       {/* Full size search */}

--- a/packages/elements/src/photon-multirx-form-wrapper/photon-multirx-form-wrapper-component.tsx
+++ b/packages/elements/src/photon-multirx-form-wrapper/photon-multirx-form-wrapper-component.tsx
@@ -1,10 +1,10 @@
 import { Button, triggerToast, usePhoton } from '@photonhealth/components';
-import photonStyles from '@photonhealth/components/dist/index.css?inline';
+import tailwind from '../tailwind.css?inline';
 import { types } from '@photonhealth/sdk';
 import jwtDecode from 'jwt-decode';
 import { customElement } from 'solid-element';
 import { createMemo, createSignal, onMount } from 'solid-js';
-import { PhotonFormWrapper } from '../photon-form-wrapper';
+import { PhotonFormWrapper } from '../PhotonFormWrapper';
 import { PatientStore } from '../stores/patient';
 
 const shouldWarn = (form: any) => {
@@ -187,7 +187,7 @@ const Component = (props: {
 
   return (
     <div ref={ref}>
-      <style>{photonStyles}</style>
+      <style>{tailwind}</style>
       <photon-dialog
         label="Lose Unsaved Prescription?"
         open={continueSubmitOpen()}

--- a/packages/elements/src/photon-multirx-form/components/AddPrescriptionCard.tsx
+++ b/packages/elements/src/photon-multirx-form/components/AddPrescriptionCard.tsx
@@ -461,8 +461,8 @@ export const AddPrescriptionCard = (props: {
             }}
           />
         </InputGroup>
-        <div class="flex flex-col xs:flex-row mt-4">
-          <Show when={!props.hideAddToTemplates}>
+        <Show when={!props.hideAddToTemplates}>
+          <div class="flex flex-col mt-4 gap-y-2">
             <Checkbox
               mainText="Add To Personal Templates"
               showOptionalSubtext
@@ -481,9 +481,7 @@ export const AddPrescriptionCard = (props: {
                 });
               }}
             />
-          </Show>
-          <Show when={props.store.addToTemplates?.value ?? false}>
-            <div class="flex-1 mt-2">
+            <Show when={props.store.addToTemplates?.value ?? false}>
               <InputGroup label="Template Name" error={props.store.templateName?.error}>
                 <Input
                   value={props.store.templateName?.value ?? ''}
@@ -495,24 +493,24 @@ export const AddPrescriptionCard = (props: {
                   }
                 />
               </InputGroup>
-            </div>
-          </Show>
-          <div class="flex flex-grow justify-end">
-            <Button
-              class="w-full xs:!w-auto h-fit mt-6"
-              size="lg"
-              onClick={() => {
-                if (!isLoading()) {
-                  handleAddPrescription();
-                }
-              }}
-              loading={isLoading()}
-              variant="primary"
-              color="blue"
-            >
-              Add to drafts
-            </Button>
+            </Show>
           </div>
+        </Show>
+        <div class="flex flex-grow justify-end mt-6">
+          <Button
+            class="w-full xs:w-auto"
+            size="lg"
+            onClick={() => {
+              if (!isLoading()) {
+                handleAddPrescription();
+              }
+            }}
+            loading={isLoading()}
+            variant="primary"
+            color="blue"
+          >
+            Add to drafts
+          </Button>
         </div>
       </div>
     </Card>

--- a/packages/elements/src/photon-multirx-form/components/OrderCard.tsx
+++ b/packages/elements/src/photon-multirx-form/components/OrderCard.tsx
@@ -1,6 +1,5 @@
 import { createMemo } from 'solid-js';
 import { Card, PharmacySelect, Text } from '@photonhealth/components';
-import photonStyles from '@photonhealth/components/dist/index.css?inline';
 
 const hasUsableAddress = (address?: {
   street1?: string;
@@ -36,7 +35,6 @@ export const OrderCard = (props: { store: Record<string, any> }) => {
 
   return (
     <div>
-      <style>{photonStyles}</style>
       <Card addChildrenDivider={true}>
         <div class="flex items-center justify-between">
           <Text color="gray">Select Pharmacy</Text>

--- a/packages/elements/src/photon-multirx-form/photon-prescribe-workflow-component.tsx
+++ b/packages/elements/src/photon-multirx-form/photon-prescribe-workflow-component.tsx
@@ -13,7 +13,6 @@ import { onCleanup } from 'solid-js';
 import { PatientStore } from '../stores/patient';
 import tailwind from '../tailwind.css?inline';
 import styles from './style.css?inline';
-import photonStyles from '@photonhealth/components/dist/index.css?inline';
 import '@shoelace-style/shoelace/dist/components/alert/alert';
 import '@shoelace-style/shoelace/dist/components/icon-button/icon-button';
 import '@shoelace-style/shoelace/dist/components/icon/icon';
@@ -84,7 +83,6 @@ export const PhotonPrescribeWorkflowComponent = (props: PrescribeWorkflowCompone
               <style>{shoelaceDarkStyles}</style>
               <style>{shoelaceLightStyles}</style>
               <style>{styles}</style>
-              <style>{photonStyles}</style>
               <PrescribeWorkflow
                 patientId={props.patientId}
                 hideSubmit={props.hideSubmit}

--- a/packages/elements/src/photon-patient-dialog/photon-patient-dialog-component.tsx
+++ b/packages/elements/src/photon-patient-dialog/photon-patient-dialog-component.tsx
@@ -8,9 +8,9 @@ import {
   PATIENT_FORM_FIELDS,
   usePhoton
 } from '@photonhealth/components';
-import { PhotonFormWrapper } from '../photon-form-wrapper';
-import photonStyles from '@photonhealth/components/dist/index.css?inline';
+import tailwind from '../tailwind.css?inline';
 import gql from 'graphql-tag';
+import { PhotonFormWrapper } from '../PhotonFormWrapper';
 
 type PatientDialogProps = {
   patientId: string;
@@ -230,7 +230,7 @@ const Component = (props: PatientDialogProps) => {
           photonStyles + the wrapper's Tailwind so they don't leak to document.body.
         */}
         <Portal mount={document.body} useShadow={true}>
-          <style>{photonStyles}</style>
+          <style>{tailwind}</style>
           <PhotonFormWrapper
             onClosed={() => {
               dispatchClosed();

--- a/packages/elements/src/photon-patient-form/photon-patient-form-component.tsx
+++ b/packages/elements/src/photon-patient-form/photon-patient-form-component.tsx
@@ -22,7 +22,6 @@ import {
 import { createFormStore } from '../stores/form';
 import { PatientStore } from '../stores/patient';
 import tailwind from '../tailwind.css?inline';
-import photonStyles from '@photonhealth/components/dist/index.css?inline';
 import { email, empty, message, notFutureDate, zipString } from '../validators';
 
 import { isZip } from '../utils';
@@ -347,7 +346,6 @@ const PatientForm = (props: { patientId: string; optionalPatientAddress: boolean
   return (
     <div class="w-full h-full relative" ref={ref}>
       <style>{tailwind}</style>
-      <style>{photonStyles}</style>
       <Show when={pStore.selectedPatient.isLoading}>
         <div class="w-full flex justify-center">
           <Spinner color="green" />

--- a/packages/elements/src/photon-patient-form/photon-patient-form-component.tsx
+++ b/packages/elements/src/photon-patient-form/photon-patient-form-component.tsx
@@ -242,9 +242,7 @@ const PatientForm = (props: { patientId: string; optionalPatientAddress: boolean
     );
     return (
       <>
-        {/*Using !mt-8 because of tailwind issue in shadowDom elements */}
-        {/*when not using the !important modifier*/}
-        <p class="font-sans text-lg mt-4 md:!mt-8" role="heading" aria-level="3">
+        <p class="font-sans text-lg mt-4 md:mt-8" role="heading" aria-level="3">
           Address
           <Show when={props.optionalPatientAddress && !hasAnyAddressField()}>
             <span class="text-gray-500 text-sm font-normal"> (optional)</span>

--- a/packages/elements/tailwind.config.js
+++ b/packages/elements/tailwind.config.js
@@ -1,9 +1,13 @@
 /* eslint-disable */
 const defaultTheme = require('tailwindcss/defaultTheme');
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { createThemes } = require('tw-colors');
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const colors = require('tailwindcss/colors');
 
 module.exports = {
   mode: 'jit',
-  content: ['./src/**/*.{html,jsx,js,tsx,ts}'],
+  content: ['./src/**/*.{html,jsx,js,tsx,ts}', '../components/src/**/*.{html,jsx,js,tsx,ts}'],
   theme: {
     screens: {
       xs: '475px',
@@ -41,5 +45,27 @@ module.exports = {
         2000: '2000'
       }
     }
-  }
+  },
+  plugins: [
+    require('@tailwindcss/forms'),
+    require('@tailwindcss/typography'),
+    createThemes({
+      photon: {
+        primaryText: colors.gray[50],
+        primary500: colors.indigo[500],
+        primary600: colors.indigo[600],
+        secondaryText: colors.gray[900],
+        secondary50: colors.indigo[50],
+        secondary100: colors.indigo[100]
+      },
+      weekend: {
+        primaryText: colors.gray[50],
+        primary500: colors.sky[500],
+        primary600: colors.sky[600],
+        secondaryText: colors.gray[900],
+        secondary50: colors.sky[50],
+        secondary100: colors.sky[100]
+      }
+    })
+  ]
 };

--- a/packages/elements/tailwind.config.js
+++ b/packages/elements/tailwind.config.js
@@ -1,71 +1,9 @@
-/* eslint-disable */
-const defaultTheme = require('tailwindcss/defaultTheme');
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-const { createThemes } = require('tw-colors');
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const colors = require('tailwindcss/colors');
+const base = require('../components/tailwind.base.cjs');
 
 module.exports = {
-  mode: 'jit',
-  content: ['./src/**/*.{html,jsx,js,tsx,ts}', '../components/src/**/*.{html,jsx,js,tsx,ts}'],
-  theme: {
-    screens: {
-      xs: '475px',
-      ...defaultTheme.screens
-    },
-    extend: {
-      colors: {
-        'photon-blue': '#3182ce',
-        'photon-blue-dark': '#2b6cb0',
-        'photon-light': '#F7F4F4',
-        blue: {
-          25: '#EFF8FF',
-          50: '#D1E9FF',
-          100: '#B2DDFF',
-          200: '#84CAFF',
-          300: '#53B1FD',
-          400: '#2E90FA',
-          500: '#1570EF',
-          600: '#175CD3',
-          700: '#1849A9',
-          800: '#194185',
-          900: '#102A56',
-          950: '#102A56'
-        }
-      },
-      boxShadow: {
-        card: '0px 0px 1px rgba(48, 49, 51, 0.05),0px 2px 4px rgba(48, 49, 51, 0.1);'
-      },
-      zIndex: {
-        60: '60',
-        70: '70',
-        80: '80',
-        90: '90',
-        100: '100',
-        2000: '2000'
-      }
-    }
-  },
-  plugins: [
-    require('@tailwindcss/forms'),
-    require('@tailwindcss/typography'),
-    createThemes({
-      photon: {
-        primaryText: colors.gray[50],
-        primary500: colors.indigo[500],
-        primary600: colors.indigo[600],
-        secondaryText: colors.gray[900],
-        secondary50: colors.indigo[50],
-        secondary100: colors.indigo[100]
-      },
-      weekend: {
-        primaryText: colors.gray[50],
-        primary500: colors.sky[500],
-        primary600: colors.sky[600],
-        secondaryText: colors.gray[900],
-        secondary50: colors.sky[50],
-        secondary100: colors.sky[100]
-      }
-    })
-  ]
+  ...base,
+  // components is a helper library for elements
+  // so elements tailwind also needs to build styles for components
+  content: ['./src/**/*.{html,jsx,js,tsx,ts}', '../components/src/**/*.{html,jsx,js,tsx,ts}']
 };


### PR DESCRIPTION
### Problem

In our current setup, elements need to import two stylesheets:
```typescript
// Generated by components:build, needed in case the element imports anything from components
import photonStyles from '@photonhealth/components/dist/index.css?inline';

// Generated by elements:build
import tailwind from '../tailwind.css?inline';

// Later in the component....
  return (
    <>
      <style>{photonStyles}</style>
      <style>{tailwind}</style>
```

This creates unexpected behavior from these two stylesheets "cascading" into each other and the bottom stylesheet overriding the previous one, creating bugs like these:
```typescript
    return (
      <>
        {/*Using !mt-8 because of tailwind issue in shadowDom elements */}
        {/*when not using the !important modifier*/}
        <p class="font-sans text-lg mt-4 md:!mt-8" role="heading" aria-level="3">
```
### Solution
Since components is basically a helper library for elements and is never rendered on its own, we can resolve this issue by having elements own the Tailwind build process for both elements and components. Then, Tailwind is able to correctly resolve and order the utility classes into a single stylesheet, which we continue importing into each element.