### PR TITLE
Stop adding photonhealth/ packages as direct deps

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@photonhealth/components",
-  "private": "true",
+  "private": true,
   "version": "0.0.0",
   "files": [
     "dist"

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@photonhealth/elements",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "description": "",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",
@@ -31,6 +31,8 @@
   "devDependencies": {
     "@babel/core": "^7.18.13",
     "@csstools/postcss-sass": "^5.0.1",
+    "@photonhealth/components": "*",
+    "@photonhealth/sdk": "*",
     "@rollup/plugin-typescript": "^11.0.0",
     "@types/lodash": "^4.14.185",
     "@types/node": "^18.7.18",
@@ -46,8 +48,6 @@
     "vite-plugin-solid": "^2.3.0"
   },
   "dependencies": {
-    "@photonhealth/components": "*",
-    "@photonhealth/sdk": "*",
     "@shoelace-style/shoelace": "^2.4.0",
     "@solid-primitives/scheduled": "^1.5.0",
     "@solid-primitives/timer": "^1.4.0",


### PR DESCRIPTION
Components and SDK are built directly into the elements dist artifact; this will fix them being detected by consumers scanners (particularly components stuck at v0.0.0 as an unlicensed package)

Bumping version to 0.22.0 because it changes our dependencies significantly.

Tested the Element locally in system-tests successfully; these dependencies are redundant, as they are included in the Elements build into `dist`, and thus can be moved to dev deps (and thus excluded from npm deps)