### PR TITLE
Use credentials instead of title

### DIFF
--- a/apps/app/src/views/routes/Settings/components/profile/Profile.tsx
+++ b/apps/app/src/views/routes/Settings/components/profile/Profile.tsx
@@ -97,7 +97,7 @@ export const Profile = () => {
   const rows = useMemo(
     () =>
       compact([
-        { title: 'Full Name', value: formatName(user?.name) },
+        { title: 'Full Name', value: formatName(user?.name, user?.credentials) },
         orgNameMatchesUserName && {
           title: 'Organization',
           value: organization?.name
@@ -121,6 +121,7 @@ export const Profile = () => {
       })),
     [
       user?.name,
+      user?.credentials,
       user?.email,
       user?.phone,
       user?.fax,
@@ -301,7 +302,8 @@ function formatName(
         title?: string | null;
       }
     | null
-    | undefined
+    | undefined,
+  credentials?: string | null
 ): string {
   if (!name) return '';
   const { first, middle, last, title } = name;
@@ -311,16 +313,33 @@ function formatName(
   if (last) parts.push(last.trim());
   let fullName = parts.join(' ');
 
-  if (title && title.trim().length <= 4) {
-    const normalized = title.trim().toLowerCase();
-    if (normalized === 'dr' || normalized === 'dr.') {
-      fullName = `Dr. ${fullName}`;
-    } else {
-      fullName += `, ${title.trim().toUpperCase()}`;
-    }
+  if (title && ALLOWED_HONORIFICS.has(title.trim().toLowerCase())) {
+    fullName = `${formatTitleHonorific(title)} ${fullName}`;
+  }
+
+  if (credentials && credentials.trim()) {
+    fullName += `, ${credentials.trim().toUpperCase()}`;
   }
 
   return fullName;
+}
+
+const ALLOWED_HONORIFICS = new Set([
+  'dr',
+  'dr.',
+  'mr',
+  'mr.',
+  'mrs',
+  'mrs.',
+  'ms',
+  'ms.',
+  'mx',
+  'mx.'
+]);
+function formatTitleHonorific(title: string): string {
+  const normalized = title.trim().toLowerCase().replace(/\.$/, '');
+  const capitalized = normalized.charAt(0).toUpperCase() + normalized.slice(1);
+  return `${capitalized}.`;
 }
 
 const profileQuery = graphql(/* GraphQL */ `
@@ -331,6 +350,7 @@ const profileQuery = graphql(/* GraphQL */ `
       phone
       fax
       email
+      credentials
       address {
         street1
         street2

--- a/apps/app/src/views/routes/Settings/components/profile/Profile.tsx
+++ b/apps/app/src/views/routes/Settings/components/profile/Profile.tsx
@@ -313,8 +313,8 @@ function formatName(
   if (last) parts.push(last.trim());
   let fullName = parts.join(' ');
 
-  if (title && ALLOWED_HONORIFICS.has(title.trim().toLowerCase())) {
-    fullName = `${formatTitleHonorific(title)} ${fullName}`;
+  if (title && ALLOWED_TITLES.has(title.trim().toLowerCase())) {
+    fullName = `${formatDoctorTitle(title)} ${fullName}`;
   }
 
   if (credentials && credentials.trim()) {
@@ -324,19 +324,8 @@ function formatName(
   return fullName;
 }
 
-const ALLOWED_HONORIFICS = new Set([
-  'dr',
-  'dr.',
-  'mr',
-  'mr.',
-  'mrs',
-  'mrs.',
-  'ms',
-  'ms.',
-  'mx',
-  'mx.'
-]);
-function formatTitleHonorific(title: string): string {
+const ALLOWED_TITLES = new Set(['dr', 'dr.']);
+function formatDoctorTitle(title: string): string {
   const normalized = title.trim().toLowerCase().replace(/\.$/, '');
   const capitalized = normalized.charAt(0).toUpperCase() + normalized.slice(1);
   return `${capitalized}.`;

--- a/package-lock.json
+++ b/package-lock.json
@@ -31632,11 +31632,9 @@
     },
     "packages/elements": {
       "name": "@photonhealth/elements",
-      "version": "0.21.0",
+      "version": "0.22.0",
       "license": "ISC",
       "dependencies": {
-        "@photonhealth/components": "*",
-        "@photonhealth/sdk": "*",
         "@shoelace-style/shoelace": "^2.4.0",
         "@solid-primitives/scheduled": "^1.5.0",
         "@solid-primitives/timer": "^1.4.0",
@@ -31653,6 +31651,8 @@
         "@babel/core": "^7.18.13",
         "@csstools/postcss-sass": "^5.0.1",
         "@csstools/selector-specificity": "^2.0.1",
+        "@photonhealth/components": "*",
+        "@photonhealth/sdk": "*",
         "@rollup/plugin-typescript": "^11.0.0",
         "@types/lodash": "^4.14.185",
         "@types/node": "^18.7.18",

--- a/packages/elements/src/photon-multirx-form/components/PrescribeWorkflow.tsx
+++ b/packages/elements/src/photon-multirx-form/components/PrescribeWorkflow.tsx
@@ -121,10 +121,16 @@ export const ScreenDraftedPrescriptionsQuery = gql`
   }
 `;
 
-const calculateNeedsSupervisor = ({ title, state }: { title?: string; state?: string }) =>
-  !!title &&
+const calculateNeedsSupervisor = ({
+  credentials,
+  state
+}: {
+  credentials?: string;
+  state?: string;
+}) =>
+  !!credentials &&
   !!state &&
-  ['NP', 'PA'].includes(title) &&
+  ['NP', 'PA'].includes(credentials) &&
   ['CA', 'FL', 'GA', 'MI', 'MO', 'NC', 'OK', 'SC', 'TN', 'TX', 'VA'].includes(state.toUpperCase());
 
 export function PrescribeWorkflow(props: PrescribeProps) {
@@ -206,7 +212,7 @@ export function PrescribeWorkflow(props: PrescribeProps) {
       query: MeUserQuery
     });
     const needsSupervisorResult = calculateNeedsSupervisor({
-      title: me.name?.title || undefined,
+      credentials: me.credentials || undefined,
       state: me.address?.state || undefined
     });
     setNeedsSupervisor(needsSupervisorResult);

--- a/packages/sdk/src/graphql/clinical-api/query.ts
+++ b/packages/sdk/src/graphql/clinical-api/query.ts
@@ -22,9 +22,7 @@ export const SearchTreatmentOptionsQuery = graphql(`
 export const MeUserQuery = graphql(`
   query MeUserQuery {
     me {
-      name {
-        title
-      }
+      credentials
       address {
         state
       }

--- a/packages/sdk/src/test-utils/fixtures.ts
+++ b/packages/sdk/src/test-utils/fixtures.ts
@@ -10,7 +10,7 @@ export const PATIENT = {
     first: 'Sally',
     middle: null,
     last: 'Patient',
-    title: 'MD'
+    title: 'Ms.'
   },
   dateOfBirth: '1990-01-01',
   sex: 'FEMALE',
@@ -36,12 +36,13 @@ export const DISPENSE_UNIT = {
 export const PROVIDER = {
   id: 'prov_1',
   email: 'doc@test.com',
+  credentials: 'MD',
   name: {
     first: 'Test',
     full: 'Test Doc',
     last: 'Doc',
     middle: null,
-    title: 'MD'
+    title: 'Dr. '
   }
 };
 

--- a/packages/sdk/src/test-utils/msw-handlers.ts
+++ b/packages/sdk/src/test-utils/msw-handlers.ts
@@ -40,7 +40,7 @@ const servicesHandlers = [
 
   clinicalGql.query('MeUserQuery', () =>
     HttpResponse.json({
-      data: { me: { name: { title: 'MD' }, address: { state: 'NY' } } }
+      data: { me: { credentials: 'MD', address: { state: 'NY' } } }
     })
   ),
 


### PR DESCRIPTION
* After backfilling titles to credentials for relevant users, we can now use credentials for the supervisor check
* Only showing titles for expected honorific-style titles, since we haven't removed the `MD/DO/NP/PA`-like titles from the data (yet). Most users do not have a valid title set currently (outside users with credentials).

Part of KLU-202