### PR TITLE
hide Cancel button on DraftPrescriptionForm if in-progress draft

### DIFF
--- a/packages/elements/src/photon-multirx-form/components/PrescriptionCard/DraftPrescriptionForm.tsx
+++ b/packages/elements/src/photon-multirx-form/components/PrescriptionCard/DraftPrescriptionForm.tsx
@@ -498,7 +498,18 @@ export const DraftPrescriptionForm = (props: {
         >
           Add to drafts
         </Button>
-        <Show when={draftPrescriptions().length > 0}>
+        {/* Can only hide form if provider has added at least 1 draft */}
+        {/*
+          Can only hide and clear form if there is no in-progress prescription.
+          This is a quick patch to address this flow:
+          - Provider clicks edit button on a draft - form populated with draft, draft is discarded entirely
+          - Provider clicks Cancel button - the current UI implies that Cancel button "cancels" the
+            editing of the draft
+          - Code hides and clears form > draft info is totally lost, which is unexpected behavior
+          This patch means the provider cannot hide and clear form once they start filling it out,
+          so if we get complaints we should implement a more robust solution.
+        */}
+        <Show when={draftPrescriptions().length > 0 && !props.store.treatment?.value}>
           <Button class="w-full xs:w-auto" size="lg" onClick={handleCancel} variant="secondary">
             Cancel
           </Button>

--- a/packages/elements/src/photon-multirx-form/components/PrescriptionCard/DraftPrescriptions.tsx
+++ b/packages/elements/src/photon-multirx-form/components/PrescriptionCard/DraftPrescriptions.tsx
@@ -191,16 +191,16 @@ export const DraftPrescriptions = (props: {
       </div>
       <photon-dialog
         open={editDialogOpen()}
-        label="Overwrite in progress prescription?"
-        confirm-text="Yes, Overwrite"
-        cancel-text="No, Cancel"
+        label="Discard in-progress prescription?"
+        confirm-text="Yes, discard"
+        cancel-text="Go back"
         on:photon-dialog-confirmed={handleEditConfirm}
         on:photon-dialog-canceled={handleEditCancel}
         on:photon-dialog-alt={handleEditCancel}
       >
         <p class="font-sans text-lg xs:text-base">
-          You are editing a prescription that has not been added. This will be overwritten if you
-          edit another prescription.
+          You are editing a prescription that has not been added to your drafts. Your in-progress
+          prescription will be discarded if you edit another prescription.
         </p>
       </photon-dialog>
       <photon-dialog
@@ -213,7 +213,7 @@ export const DraftPrescriptions = (props: {
         on:photon-dialog-alt={handleDeleteCancel}
       >
         <p class="font-sans text-lg xs:text-base">
-          Deleting this prescription will remove it from your pending prescriptions. This action
+          Deleting this prescription will remove it from your draft prescriptions. This action
           cannot be undone.
         </p>
       </photon-dialog>


### PR DESCRIPTION
Part of KLU-170

Reasoning for this patch is documented in a code comment, please check that as well.

The more robust solution mentioned in the comment would be to save the draft currently being edited somewhere in state instead of deleting it. Since our designer is working on a more serious redesign of the prescribe flow, this patch is good enough and brings the UX to parity with what we had before. 