### PR TITLE
Hide "Send" button in prescribe element, when drafts are empty

### DIFF
--- a/apps/app/e2e/create_prescription.spec.ts
+++ b/apps/app/e2e/create_prescription.spec.ts
@@ -1,10 +1,10 @@
 import { expect, test } from '@playwright/test';
 import { setupAnalyticsCapture } from './utils/analytics_intercept';
 import {
+  expectCtaCount,
   expectEventCount,
   expectEventProperties,
   expectFieldInteraction,
-  expectCtaCount,
   findByEventName
 } from './utils/analytics_expect';
 
@@ -78,7 +78,7 @@ test('user can create patient then add, edit, and delete a draft prescription', 
   await expectFieldInteraction(page, 'daysSupply', 1);
   await expectFieldInteraction(page, 'refills', 1);
   await expectFieldInteraction(page, 'instructions', 1);
-  await page.getByRole('button', { name: 'Add to drafts' }).click();
+  await page.getByRole('button', { name: 'Add prescription' }).click();
   await expectCtaCount(page, 'Draft Prescription Added', 1);
   const draftAddedEvents = await findByEventName(page, 'Draft Prescription Added');
   const firstDraftAdded = draftAddedEvents[0];
@@ -107,7 +107,7 @@ test('user can create patient then add, edit, and delete a draft prescription', 
   await expectCtaCount(page, 'Draft Prescription Edited', 1);
   await expect(medSearchInput).toHaveValue(/Amoxicillin/i);
   await page.getByLabel('Quantity').fill('60');
-  await page.getByRole('button', { name: 'Add to drafts' }).click();
+  await page.getByRole('button', { name: 'Add prescription' }).click();
   await expectFieldInteraction(page, 'dispenseQuantity', 2);
   await expect(page.getByText(/60 Capsule, 0 Refills - test-instructions-text/i)).toBeVisible();
   await expect(page.getByRole('button', { name: /\+ Add another/i })).toBeVisible({

--- a/apps/patient/e2e/setup-new-order.spec.ts
+++ b/apps/patient/e2e/setup-new-order.spec.ts
@@ -71,7 +71,7 @@ async function createDraftPrescription(page: Page, medicationName: string) {
   await page.getByLabel('Refills').fill('0');
   await page.getByLabel('Patient Instructions (SIG)').fill('e2e test notes sig');
 
-  await page.getByRole('button', { name: 'Add to drafts' }).click();
+  await page.getByRole('button', { name: 'Add prescription' }).click();
   await expect(page.getByRole('button', { name: /\+ Add another/i })).toBeVisible({
     timeout: 10_000
   });

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@photonhealth/elements",
-  "version": "0.23.0",
+  "version": "0.23.1",
   "description": "",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/elements/src/photon-multirx-form/components/PrescribeWorkflow.tsx
+++ b/packages/elements/src/photon-multirx-form/components/PrescribeWorkflow.tsx
@@ -696,7 +696,7 @@ export function PrescribeWorkflow(props: PrescribeProps) {
                 <Show when={props.enableOrder && pharmacySelectionContext.isAutoRouted()}>
                   <PharmacyCard pharmacyId={pharmacySelectionContext.autoRoutedPharmacyId()} />
                 </Show>
-                <Show when={!props.hideSubmit}>
+                <Show when={!props.hideSubmit && draftPrescriptions().length > 0}>
                   {/* We're hiding this alert message if enable-order is set, a rough way to let us know this is not in the App.
             The issue we're having is when props are passed and cards are hidden, the form is not showing validation errors. */}
                   <Show when={errors().length > 0 && props.enableOrder}>

--- a/packages/elements/src/photon-multirx-form/components/PrescriptionCard/DraftPrescriptionForm.tsx
+++ b/packages/elements/src/photon-multirx-form/components/PrescriptionCard/DraftPrescriptionForm.tsx
@@ -496,7 +496,7 @@ export const DraftPrescriptionForm = (props: {
           variant="primary"
           color="blue"
         >
-          Add to drafts
+          Add prescription
         </Button>
         {/* Can only hide form if provider has added at least 1 draft */}
         {/*

--- a/packages/elements/src/photon-multirx-form/prescribe-workflow-analytics.test.tsx
+++ b/packages/elements/src/photon-multirx-form/prescribe-workflow-analytics.test.tsx
@@ -385,7 +385,7 @@ async function waitForSignatureAttestationModal() {
 }
 
 async function waitForPrescribeForm() {
-  await screen.findByRole('button', { name: /add to drafts/i }), { timeout: 3000 };
+  await screen.findByRole('button', { name: /add prescription/i }), { timeout: 3000 };
 }
 
 async function addDraftPrescription(user: ReturnType<typeof userEvent.setup>) {
@@ -398,7 +398,7 @@ async function addDraftPrescription(user: ReturnType<typeof userEvent.setup>) {
     screen.getByLabelText(/patient instructions/i),
     'Take one capsule by mouth daily'
   );
-  await user.click(screen.getByRole('button', { name: /add to drafts/i }));
+  await user.click(screen.getByRole('button', { name: /add prescription/i }));
 }
 
 const isFieldInteraction = (filter: Record<string, unknown> = {}) => {


### PR DESCRIPTION
* Hide "Send" button in embed when drafts are empty
* Replace "Add to drafts" copy with "Add prescription", since there is no longer a "Draft Prescriptions" card

Part of KLU-238