### PR TITLE
Fix bug for Form where additional-notes are ignored in templated rx creation

### DIFF
--- a/packages/components/src/systems/DraftPrescriptions/DraftPrescriptionsProvider.tsx
+++ b/packages/components/src/systems/DraftPrescriptions/DraftPrescriptionsProvider.tsx
@@ -26,12 +26,14 @@ import {
   UpdatePrescriptionStates
 } from '../../fetch';
 import triggerToast from '../../utils/toastTriggers';
+import { formatPatientWeight } from './utils/formatters';
 
 export type DraftPrescriptionsContextType = {
   // values
   draftPrescriptions: Accessor<Prescription[]>;
   prescriptionIds: Accessor<string[]>;
   isLoadingPrefills: Accessor<boolean>;
+  rxNotesPrefill: Accessor<string | undefined>;
 
   // actions
   setDraftPrescriptions: Setter<Prescription[]>;
@@ -53,6 +55,9 @@ interface DraftPrescriptionProviderProps {
   templateOverrides: TemplateOverrides;
   prescriptionIdsPrefill: string[];
   enableCombineAndDuplicate: boolean;
+  additionalNotes?: string;
+  weight?: number;
+  weightUnit?: string;
 }
 
 export type TemplateOverrides = {
@@ -118,21 +123,30 @@ function isTreatmentInDraftPrescriptions(
 
 const createPrefillPrescriptionsOnApi = async ({
   client,
-  props
+  props,
+  rxNotesPrefill
 }: {
   client: PhotonClient;
   props: DraftPrescriptionProviderProps;
+  rxNotesPrefill?: string;
 }) => {
   let rxToCreate: MutationCreatePrescriptionsArgs['prescriptions'] = [];
 
   // Create prescriptions from template ids with a few optional override values
   if (props.templateIdsPrefill.length > 0) {
     const dedupedTemplateIds = Array.from(new Set(props.templateIdsPrefill));
-    const templatedCreateRxList = dedupedTemplateIds.map((templateId) => ({
-      ...props.templateOverrides?.[templateId],
-      patientId: props.patientId,
-      templateId
-    }));
+    const templatedCreateRxList = dedupedTemplateIds.map((templateId) => {
+      const templateOverrideNotes = props.templateOverrides?.[templateId]?.notes;
+      const notes = templateOverrideNotes
+        ? `${templateOverrideNotes}\n\n${rxNotesPrefill}`
+        : rxNotesPrefill;
+      return {
+        ...props.templateOverrides?.[templateId],
+        patientId: props.patientId,
+        templateId,
+        notes
+      };
+    });
     rxToCreate = rxToCreate.concat(templatedCreateRxList);
   }
 
@@ -175,6 +189,14 @@ export const DraftPrescriptionsProvider = (props: DraftPrescriptionProviderProps
     draftPrescriptions().map((prescription) => prescription.id)
   );
 
+  const rxNotesPrefill = createMemo(() => {
+    const patientWeightText = props.weight
+      ? formatPatientWeight(props.weight, props.weightUnit)
+      : '';
+
+    return `${props.additionalNotes}\n\n${patientWeightText}`;
+  });
+
   // Prefill new prescriptions based on templateIds or prescriptionIds when we get a patientId
   createEffect(async () => {
     if (
@@ -189,7 +211,11 @@ export const DraftPrescriptionsProvider = (props: DraftPrescriptionProviderProps
       setIsLoadingPrefills(true);
 
       try {
-        const newRxs = await createPrefillPrescriptionsOnApi({ client, props });
+        const newRxs = await createPrefillPrescriptionsOnApi({
+          client,
+          props,
+          rxNotesPrefill: rxNotesPrefill()
+        });
         if (newRxs) {
           setDraftPrescriptions((prev) => [...prev, ...newRxs]);
           newRxs.forEach((rx) => {
@@ -365,6 +391,7 @@ export const DraftPrescriptionsProvider = (props: DraftPrescriptionProviderProps
     draftPrescriptions,
     prescriptionIds,
     isLoadingPrefills,
+    rxNotesPrefill,
 
     // actions
     setDraftPrescriptions,

--- a/packages/components/src/systems/DraftPrescriptions/DraftPrescriptionsProvider.tsx
+++ b/packages/components/src/systems/DraftPrescriptions/DraftPrescriptionsProvider.tsx
@@ -190,11 +190,12 @@ export const DraftPrescriptionsProvider = (props: DraftPrescriptionProviderProps
   );
 
   const rxNotesPrefill = createMemo(() => {
-    const patientWeightText = props.weight
-      ? formatPatientWeight(props.weight, props.weightUnit)
-      : '';
+    let notesPrefill = '';
+    if (props.additionalNotes) notesPrefill = `${props.additionalNotes}\n\n`;
+    if (props.weight)
+      notesPrefill = `${notesPrefill}${formatPatientWeight(props.weight, props.weightUnit)}`;
 
-    return `${props.additionalNotes}\n\n${patientWeightText}`;
+    return notesPrefill || undefined;
   });
 
   // Prefill new prescriptions based on templateIds or prescriptionIds when we get a patientId

--- a/packages/components/src/systems/DraftPrescriptions/utils/formatters.ts
+++ b/packages/components/src/systems/DraftPrescriptions/utils/formatters.ts
@@ -1,0 +1,2 @@
+export const formatPatientWeight = (weight: number, weightUnit = 'lb') =>
+  `Patient weight: ${weight} ${weightUnit}`;

--- a/packages/components/src/systems/TestMocks/MockDraftPrescriptionsProvider.tsx
+++ b/packages/components/src/systems/TestMocks/MockDraftPrescriptionsProvider.tsx
@@ -9,6 +9,7 @@ export const mockDraftPrescriptionsContextValues = () => {
     draftPrescriptions: () => [],
     prescriptionIds: () => [],
     isLoadingPrefills: () => false,
+    rxNotesPrefill: () => undefined,
     deletePrescription: vi.fn(),
     tryCreatePrescription: vi.fn(),
     tryUpdatePrescriptionStates: vi.fn(),

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@photonhealth/elements",
-  "version": "0.23.1",
+  "version": "0.23.2",
   "description": "",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/elements/src/photon-multirx-form/components/PrescribeWorkflow.tsx
+++ b/packages/elements/src/photon-multirx-form/components/PrescribeWorkflow.tsx
@@ -6,7 +6,6 @@ import { OrderCard } from './OrderCard';
 import { PatientCard } from './PatientCard';
 import { PharmacyCard } from './PharmacyCard';
 import clearForm from './PrescriptionCard/util/clearForm';
-import { formatPatientWeight } from './PrescriptionCard/util/formatPatientWeight';
 import {
   AddressForm,
   Alert,
@@ -136,8 +135,13 @@ const calculateNeedsSupervisor = ({
 export function PrescribeWorkflow(props: PrescribeProps) {
   let ref: Ref<any> | undefined;
 
-  const { draftPrescriptions, prescriptionIds, tryUpdatePrescriptionStates, isLoadingPrefills } =
-    useDraftPrescriptions();
+  const {
+    draftPrescriptions,
+    prescriptionIds,
+    tryUpdatePrescriptionStates,
+    isLoadingPrefills,
+    rxNotesPrefill
+  } = useDraftPrescriptions();
   const pharmacySelectionContext = usePharmacySelectionContext();
   const {
     dispatchFormValidate,
@@ -180,15 +184,6 @@ export function PrescribeWorkflow(props: PrescribeProps) {
   });
   const [isScreeningAlertWarningOpen, setIsScreeningAlertWarningOpen] = createSignal(false);
 
-  // we can ignore the warnings to put inside of a createEffect, the additionalNotes or weight shouldn't be updating
-  let prefillNotes = '';
-  if (props.additionalNotes) {
-    prefillNotes = `${props.additionalNotes}\n\n`;
-  }
-  if (props.weight) {
-    prefillNotes = `${prefillNotes}${formatPatientWeight(props.weight, props.weightUnit)}`;
-  }
-
   onMount(async () => {
     if (props.address) {
       // if manually overriding address, update the store on mount
@@ -200,7 +195,7 @@ export function PrescribeWorkflow(props: PrescribeProps) {
 
     ref.addEventListener('photon-ticket-created-duplicate', () => {
       // need to reset all the form data
-      clearForm(props.formActions, { notes: prefillNotes });
+      clearForm(props.formActions, { notes: rxNotesPrefill() });
       pharmacySelectionContext.setFulfillmentType(undefined);
       pharmacySelectionContext.setPharmacyId(undefined);
       pharmacySelectionContext.setUpdatePreferredPharmacy(false);
@@ -659,7 +654,7 @@ export function PrescribeWorkflow(props: PrescribeProps) {
                   store={props.formStore}
                   weight={props.weight}
                   weightUnit={props.weightUnit}
-                  prefillNotes={prefillNotes}
+                  prefillNotes={rxNotesPrefill()}
                   screenDraftedPrescriptions={screenDraftedPrescriptions}
                   screeningAlerts={screeningAlerts()}
                   enableOrder={props.enableOrder}

--- a/packages/elements/src/photon-multirx-form/photon-prescribe-workflow-component.tsx
+++ b/packages/elements/src/photon-multirx-form/photon-prescribe-workflow-component.tsx
@@ -61,6 +61,9 @@ export const PhotonPrescribeWorkflowComponent = (props: PrescribeWorkflowCompone
           templateOverrides={props.templateOverrides || {}}
           prescriptionIdsPrefill={props.prescriptionIds?.split(',').map((id) => id.trim()) || []}
           enableCombineAndDuplicate={props.enableCombineAndDuplicate}
+          additionalNotes={props.additionalNotes}
+          weight={props.weight}
+          weightUnit={props.weightUnit}
         >
           <PharmacySelectionProvider
             pharmacyIdProp={props.pharmacyId}

--- a/packages/elements/src/photon-multirx-form/prescribe-workflow-template-prefill.test.tsx
+++ b/packages/elements/src/photon-multirx-form/prescribe-workflow-template-prefill.test.tsx
@@ -1,0 +1,143 @@
+import { cleanup, render, waitFor } from '@solidjs/testing-library';
+import { GoogleServiceProvider, PhotonContext, SDKProvider } from '@photonhealth/components';
+import { afterAll, afterEach, beforeAll, expect, test, vi } from 'vitest';
+import { setupServer } from 'msw/node';
+import { HttpResponse } from 'msw';
+import { PatientStore } from '../stores/patient';
+import {
+  PhotonPrescribeWorkflowComponent,
+  type PrescribeWorkflowComponentProps
+} from './photon-prescribe-workflow-component';
+import { createTestClient, createTestClientStore } from '../test-utils/createTestClient';
+import { defaultHandlers, lambdasGql, TREATMENT } from '@photonhealth/sdk/test-utils';
+import { MockMedicationSearchElement } from '../test-utils/mock-medication-search.element';
+
+vi.mock('solid-element', () => ({
+  customElement: vi.fn()
+}));
+
+const server = setupServer(...defaultHandlers);
+
+beforeAll(() => {
+  server.listen({ onUnhandledRequest: 'warn' });
+
+  window.HTMLElement.prototype.scrollIntoView = vi.fn();
+
+  if (!customElements.get('photon-medication-search')) {
+    customElements.define('photon-medication-search', MockMedicationSearchElement);
+  }
+
+  Object.defineProperty(window, 'google', {
+    configurable: true,
+    writable: true,
+    value: {
+      maps: {
+        Geocoder: class Geocoder {},
+        places: { AutocompleteService: class AutocompleteService {} }
+      }
+    }
+  });
+});
+
+afterEach(async () => {
+  cleanup();
+  server.resetHandlers();
+  vi.clearAllMocks();
+  await PatientStore.actions.reset();
+});
+
+afterAll(() => server.close());
+
+type PrescriptionInput = {
+  templateId?: string;
+  patientId?: string;
+  notes?: string;
+};
+
+test('additionalNotes are merged into prescriptions prefilled from templateIds', async () => {
+  const capturedPrescriptions: PrescriptionInput[] = [];
+
+  server.use(
+    lambdasGql.mutation('CreatePrescriptions', ({ variables }) => {
+      const prescriptions = variables.prescriptions as PrescriptionInput[];
+      capturedPrescriptions.push(...prescriptions);
+      return HttpResponse.json({
+        data: {
+          createPrescriptions: prescriptions.map((p, i) => ({
+            __typename: 'Prescription',
+            id: `rx_tpl_${i}`,
+            externalId: null,
+            dispenseAsWritten: false,
+            dispenseQuantity: 30,
+            dispenseUnit: 'Tablet',
+            fillsAllowed: 1,
+            daysSupply: 30,
+            instructions: 'Take one daily',
+            notes: p.notes ?? '',
+            doNotFillBeforeDate: null,
+            diagnoses: [],
+            treatment: TREATMENT
+          }))
+        }
+      });
+    })
+  );
+
+  renderPrescribeWorkflow({
+    templateIds: 'tpl_1',
+    templateOverrides: { tpl_1: { notes: 'Template override note' } },
+    additionalNotes: 'Clinical additional note from host app'
+  });
+
+  await waitFor(
+    () => {
+      expect(capturedPrescriptions).toHaveLength(1);
+    },
+    { timeout: 3000 }
+  );
+
+  const [sent] = capturedPrescriptions;
+  expect(sent.templateId).toBe('tpl_1');
+  // Bug: additionalNotes never reach the CreatePrescriptions mutation for
+  // template-prefilled rxs — only templateOverrides notes make it through.
+  expect(sent.notes).toContain('Clinical additional note from host app');
+});
+
+function renderPrescribeWorkflow(props: Partial<PrescribeWorkflowComponentProps> = {}) {
+  const client = createTestClient();
+  const clientStore = createTestClientStore(client);
+  const host = document.createElement('div');
+  document.body.append(host);
+
+  const baseProps: PrescribeWorkflowComponentProps = {
+    patientId: 'pat_123',
+    hideSubmit: false,
+    hideTemplates: false,
+    hidePatientCard: false,
+    enableOrder: false,
+    enableMedHistory: false,
+    enableMedHistoryLinks: false,
+    enableMedHistoryRefillButton: false,
+    enableCombineAndDuplicate: false,
+    optionalPatientAddress: false,
+    triggerSubmit: false,
+    toastBuffer: 0,
+    enableCoverageCheck: false,
+    enableLocalPickup: false,
+    enableSendToPatient: false,
+    enableDeliveryPharmacies: false
+  };
+
+  return render(
+    () => (
+      <PhotonContext.Provider value={clientStore as never}>
+        <SDKProvider client={client as never}>
+          <GoogleServiceProvider>
+            <PhotonPrescribeWorkflowComponent {...{ ...baseProps, ...props }} />
+          </GoogleServiceProvider>
+        </SDKProvider>
+      </PhotonContext.Provider>
+    ),
+    { container: host }
+  );
+}


### PR DESCRIPTION
Per form bug

<img width="561" height="359" alt="Screenshot 2026-04-24 at 3 19 37 PM" src="https://github.com/user-attachments/assets/64090208-51b1-4cbf-a80b-5f6fac422580" />
<img width="963" height="303" alt="Screenshot 2026-04-24 at 3 19 51 PM" src="https://github.com/user-attachments/assets/6d5f80e3-bba3-4f27-9eb6-dbde4aedc936" />


