### PR TITLE
Fix boson redirect

### DIFF
--- a/apps/app/src/views/routes/SSOLogin.spec.ts
+++ b/apps/app/src/views/routes/SSOLogin.spec.ts
@@ -1,0 +1,45 @@
+import { isCurrentOriginAllowed } from './SSOLogin';
+
+type TestCase = {
+  origin: string;
+  expectedAllowed: boolean;
+};
+const testCases = [
+  {
+    origin: 'app.boson.health',
+    expectedAllowed: true
+  },
+  {
+    origin: 'app.neutron.health',
+    expectedAllowed: true
+  },
+  {
+    origin: 'app.photon.health',
+    expectedAllowed: true
+  },
+  {
+    origin: 'app-test-branch-name.boson.health',
+    expectedAllowed: true
+  },
+  {
+    origin: 'app-1234.boson.health',
+    expectedAllowed: true
+  },
+  // Bad ones
+  {
+    origin: 'app.boson.me',
+    expectedAllowed: false
+  },
+  {
+    origin: 'photon.health',
+    expectedAllowed: false
+  },
+  {
+    origin: 'app.failing.health',
+    expectedAllowed: false
+  }
+] as TestCase[];
+
+test.each(testCases)('isCurrentOriginAllowed', (testCase) => {
+  expect(isCurrentOriginAllowed(testCase.origin)).toBe(testCase.expectedAllowed);
+});

--- a/apps/app/src/views/routes/SSOLogin.spec.ts
+++ b/apps/app/src/views/routes/SSOLogin.spec.ts
@@ -6,40 +6,46 @@ type TestCase = {
 };
 const testCases = [
   {
-    origin: 'app.boson.health',
+    origin: 'https://app.boson.health',
     expectedAllowed: true
   },
   {
-    origin: 'app.neutron.health',
+    origin: 'https://app.neutron.health',
     expectedAllowed: true
   },
   {
-    origin: 'app.photon.health',
+    origin: 'https://app.photon.health',
     expectedAllowed: true
   },
   {
-    origin: 'app-test-branch-name.boson.health',
+    origin: 'https://app-test-branch-name.boson.health',
     expectedAllowed: true
   },
   {
-    origin: 'app-1234.boson.health',
+    origin: 'https://app-1234.boson.health',
     expectedAllowed: true
   },
   // Bad ones
   {
-    origin: 'app.boson.me',
+    origin: 'https://app.boson.me',
     expectedAllowed: false
   },
   {
-    origin: 'photon.health',
+    origin: 'https://photon.health',
     expectedAllowed: false
   },
   {
-    origin: 'app.failing.health',
+    origin: 'https://app.failing.health',
+    expectedAllowed: false
+  },
+  {
+    origin: 'app.boson.health',
     expectedAllowed: false
   }
 ] as TestCase[];
 
-test.each(testCases)('isCurrentOriginAllowed', (testCase) => {
-  expect(isCurrentOriginAllowed(testCase.origin)).toBe(testCase.expectedAllowed);
+describe.each(testCases)('isCurrentOriginAllowed', (testCase) => {
+  test(`When origin is ${testCase.origin} allowed should be ${testCase.expectedAllowed}`, () => {
+    expect(isCurrentOriginAllowed(testCase.origin)).toBe(testCase.expectedAllowed);
+  });
 });

--- a/apps/app/src/views/routes/SSOLogin.tsx
+++ b/apps/app/src/views/routes/SSOLogin.tsx
@@ -81,7 +81,10 @@ function isCurrentOriginAllowed(): boolean {
     const currentOrigin = window.location.origin;
     return (
       currentOrigin === 'http://localhost:3000' ||
+      // Test for generated builds from PRs in the form of
+      // app-[something here].boson.health
       /^https:\/\/app(-.*)\.boson\.health$/.test(currentOrigin) ||
+      currentOrigin === 'https://app.boson.health' ||
       currentOrigin === 'https://app.neutron.health' ||
       currentOrigin === 'https://app.photon.health'
     );

--- a/apps/app/src/views/routes/SSOLogin.tsx
+++ b/apps/app/src/views/routes/SSOLogin.tsx
@@ -44,8 +44,9 @@ export const SSOLogin = () => {
       logout({ federated: false, returnTo: url.toString() });
       return;
     }
+    const currentOrigin = window.location.origin;
 
-    if (isCurrentOriginAllowed()) {
+    if (isCurrentOriginAllowed(currentOrigin)) {
       if (returnTo) {
         localStorage.setItem('authReturnTo', returnTo);
       }
@@ -76,9 +77,9 @@ export const SSOLogin = () => {
   );
 };
 
-function isCurrentOriginAllowed(): boolean {
+// This is only exported for a test.
+export function isCurrentOriginAllowed(currentOrigin: string): boolean {
   try {
-    const currentOrigin = window.location.origin;
     return (
       currentOrigin === 'http://localhost:3000' ||
       // Test for generated builds from PRs in the form of

--- a/apps/app/src/views/routes/SSOLogin.tsx
+++ b/apps/app/src/views/routes/SSOLogin.tsx
@@ -83,8 +83,7 @@ function isCurrentOriginAllowed(): boolean {
       currentOrigin === 'http://localhost:3000' ||
       // Test for generated builds from PRs in the form of
       // app-[something here].boson.health
-      /^https:\/\/app(-.*)\.boson\.health$/.test(currentOrigin) ||
-      currentOrigin === 'https://app.boson.health' ||
+      /^https:\/\/app(-.*)?\.boson\.health$/.test(currentOrigin) ||
       currentOrigin === 'https://app.neutron.health' ||
       currentOrigin === 'https://app.photon.health'
     );


### PR DESCRIPTION
The change I made to the redirect check on SSO login made `app.boson.health` not a viable base URL to redirect from, this fixes that by making the **-your-branch-name** section of the URL optional.