### PR TITLE
bugfix order date display in clinical app

### DIFF
--- a/apps/app/src/views/routes/Prescription.tsx
+++ b/apps/app/src/views/routes/Prescription.tsx
@@ -28,7 +28,6 @@ import {
 } from '@chakra-ui/react';
 import { FiChevronRight, FiPlus, FiRepeat } from 'react-icons/fi';
 import { GraphQLClient } from 'graphql-request';
-import dayjs from 'dayjs';
 
 import { formatAddress, FormatAddressProps, formatDate } from '../../utils';
 
@@ -485,7 +484,7 @@ export const Prescription = () => {
                             <Text fontSize="sm" color="gray.500">
                               {addressString}
                               {addressString ? <br /> : null}
-                              Created: {dayjs(fill?.order?.createdAt).format('MMM D, YYYY, h:mm A')}
+                              Created: {formatDate(fill?.order?.createdAt)}
                             </Text>
                           </VStack>
                           <Box alignItems="end">

--- a/packages/components/src/systems/RecentOrders/RecentOrdersDuplicateDialog.tsx
+++ b/packages/components/src/systems/RecentOrders/RecentOrdersDuplicateDialog.tsx
@@ -6,6 +6,7 @@ import Icon from '../../particles/Icon';
 import Text from '../../particles/Text';
 import { dispatchDatadogAction } from '../../utils/dispatchDatadogAction';
 import formatRxString from '../../utils/formatRxString';
+import formatDate from '../../utils/formatDate';
 
 export default function RecentOrdersDuplicateDialog() {
   let ref: Ref<any> | undefined;
@@ -57,7 +58,7 @@ export default function RecentOrdersDuplicateDialog() {
           </Text>
           <Text size="sm" color="gray">
             Written by {state?.duplicateFill?.prescription?.prescriber?.name?.full} on{' '}
-            {new Date(state?.duplicateFill?.prescription?.writtenAt).toLocaleDateString()}
+            {formatDate(state?.duplicateFill?.prescription?.writtenAt)}
           </Text>
         </div>
 


### PR DESCRIPTION
Part of KLU-253

In the clinical app and elements, we should be aiming to use the `formatDate` util to consistently display all dates in UTC.

Whether we should display in the user's local timezone is a different issue, this just fixes the discrepancy our customer reported.