### PR TITLE
format order and prescription related dates in clinical app in local time

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -437,3 +437,20 @@ All new utility functions, views, and components must include tests. Match the t
 - **Test files** are excluded from linting (configured in `.eslintrc.json` ignorePatterns)
 - **TypeScript strict mode** enabled; type check with `npx nx run <project>:tsc:boson`
 - **Shared types** belong in `packages/sdk/src/types.ts` since all packages already depend on `@photonhealth/sdk`. For GraphQL response shapes, always use generated types from codegen (`gql/` or `graphql/` directories) rather than defining them manually.
+
+## Date Formatting
+
+Always use standardaized `formatDate*` utils — never format dates inline with `toLocaleDateString`, `toISOString`, `date-fns`, `dayjs`, or `Intl.DateTimeFormat`.
+
+NOTE: The code in `apps/app/patient` does not currently use formatting utils, and should not be taken as an example of standardized patterns.
+
+| Function | Use when |
+|----------|----------|
+| `formatDate(date?)` | Timestamps — fields that record *when an event occurred* (e.g. `createdAt`, `writtenAt`) |
+| `formatDateUTC(date?)` | Dates that should display literally as stored, not shifted to the user's timezone (e.g. `dateOfBirth`) |
+| `formatDateLong(date?)` | Same as `formatDate` but long-form month name |
+| `formatDateLongUTC(date?)` | Same as `formatDateUTC` but long-form month name |
+
+**Why UTC for certain dates?** Some dates should be shown exactly as stored regardless of the user's timezone — e.g. a date of birth of January 15 should always display as January 15. Without `timeZone: 'UTC'`, the API value `2024-01-15T00:00:00Z` renders as January 14 for users in timezones behind UTC.
+
+**Why local timezone for order and prescription related dates?** Fields like `createdAt` represent a moment in time and should appear in the user's local time so they match the user's clock.

--- a/apps/app/src/utils.ts
+++ b/apps/app/src/utils.ts
@@ -15,8 +15,8 @@ function titleCase(str: string) {
 /**
  * Format date to client's local date string (MM/DD/YYYY)
  */
-function formatDate(date: string) {
-  return new Date(date)?.toLocaleDateString('en-US');
+function formatDate(date?: string) {
+  return date ? new Date(date)?.toLocaleDateString('en-US') : '';
 }
 
 /**
@@ -24,20 +24,20 @@ function formatDate(date: string) {
  * Use for any dates that should NOT be shifted to the
  * client's local timezone
  */
-function formatDateUTC(date: string) {
-  return new Date(date)?.toLocaleDateString('en-US', { timeZone: 'UTC' });
+function formatDateUTC(date?: string) {
+  return date ? new Date(date)?.toLocaleDateString('en-US', { timeZone: 'UTC' }) : '';
 }
 
 /**
  * Format date to Month D, Yr
  */
-function formatDateLong(date: string | Date) {
+function formatDateLong(date?: string | Date) {
   const options: Intl.DateTimeFormatOptions = {
     year: 'numeric',
     month: 'long',
     day: 'numeric'
   };
-  return new Date(date)?.toLocaleDateString([], options);
+  return date ? new Date(date)?.toLocaleDateString([], options) : '';
 }
 
 /**
@@ -45,14 +45,14 @@ function formatDateLong(date: string | Date) {
  * Use for any dates that should NOT be shifted to the
  * client's local timezone
  */
-function formatDateLongUTC(date: string | Date) {
+function formatDateLongUTC(date?: string | Date) {
   const options: Intl.DateTimeFormatOptions = {
     year: 'numeric',
     month: 'long',
     day: 'numeric',
     timeZone: 'UTC'
   };
-  return new Date(date)?.toLocaleDateString([], options);
+  return date ? new Date(date)?.toLocaleDateString([], options) : '';
 }
 
 // Format phone number to (###) ###-####

--- a/apps/app/src/utils.ts
+++ b/apps/app/src/utils.ts
@@ -12,13 +12,40 @@ function titleCase(str: string) {
     .join(' ');
 }
 
-// Format date to local date string (MM/DD/YYYY)
+/**
+ * Format date to client's local date string (MM/DD/YYYY)
+ */
 function formatDate(date: string) {
+  return new Date(date)?.toLocaleDateString('en-US');
+}
+
+/**
+ * Format date to a UTC date string (MM/DD/YYYY)
+ * Use for any dates that should NOT be shifted to the
+ * client's local timezone
+ */
+function formatDateUTC(date: string) {
   return new Date(date)?.toLocaleDateString('en-US', { timeZone: 'UTC' });
 }
 
-// Format date to Month D, Yr
+/**
+ * Format date to Month D, Yr
+ */
 function formatDateLong(date: string | Date) {
+  const options: Intl.DateTimeFormatOptions = {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric'
+  };
+  return new Date(date)?.toLocaleDateString([], options);
+}
+
+/**
+ * Format date to UTC Month D, Yr
+ * Use for any dates that should NOT be shifted to the
+ * client's local timezone
+ */
+function formatDateLongUTC(date: string | Date) {
   const options: Intl.DateTimeFormatOptions = {
     year: 'numeric',
     month: 'long',
@@ -143,7 +170,9 @@ function getUnitAbbreviation(quantity: string): string {
 
 export {
   formatDate,
+  formatDateUTC,
   formatDateLong,
+  formatDateLongUTC,
   getMedicationNames,
   formatPhone,
   formatAddress,

--- a/apps/app/src/views/routes/PatientDetails/index.tsx
+++ b/apps/app/src/views/routes/PatientDetails/index.tsx
@@ -22,7 +22,7 @@ import {
 import { FiChevronRight, FiEdit, FiPlus } from 'react-icons/fi';
 import { usePhoton } from '@photonhealth/react';
 import { useEffect, useMemo, useState } from 'react';
-import { formatDate, formatDateLong, formatPhone, getMedicationNames } from '../../../utils';
+import { formatDate, formatDateLongUTC, formatPhone, getMedicationNames } from '../../../utils';
 import { Page } from '../../components/Page';
 import { PatientPrescriptions } from './components/PatientPrescriptions';
 import OrderStatusBadge, { OrderFulfillmentState } from '../../components/OrderStatusBadge';
@@ -180,7 +180,7 @@ export const Patient = () => {
                 <SkeletonText skeletonHeight={5} noOfLines={1} width="100px" />
               ) : patient?.dateOfBirth ? (
                 <Text fontSize="md" data-dd-privacy="mask" className="mp-mask">
-                  {formatDateLong(patient.dateOfBirth)}
+                  {formatDateLongUTC(patient.dateOfBirth)}
                 </Text>
               ) : (
                 <Text fontSize="md" as="i" color="gray.500">

--- a/apps/app/src/views/routes/Settings/components/invites/InviteItem.tsx
+++ b/apps/app/src/views/routes/Settings/components/invites/InviteItem.tsx
@@ -6,6 +6,7 @@ import { InvitesQueryDocument } from 'apps/app/src/gql/graphql';
 import { FiSend, FiTrash } from 'react-icons/fi';
 import { confirmWrapper } from '../../../../components/GuardDialog';
 import { StyledToast } from 'apps/app/src/views/components/StyledToast';
+import { formatDate } from 'apps/app/src/utils';
 
 export const inviteFragment = graphql(/* GraphQL */ `
   fragment InviteFragment on Invite {
@@ -55,7 +56,7 @@ export const InviteItem = ({ invite: data }: { invite: FragmentType<typeof invit
       </Td>
       <Td>
         <Badge size="sm" colorScheme={invite.expired ? 'red' : 'green'}>
-          {invite.expired ? 'Expired' : `${new Date(invite.expires_at).toLocaleDateString()}`}
+          {invite.expired ? 'Expired' : `${formatDate(invite.expires_at)}`}
         </Badge>
       </Td>
       <Td>

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -61,7 +61,7 @@ import {
 import triggerToast from './utils/toastTriggers';
 import generateString from './utils/generateString';
 import { createQuery } from './utils/createQuery';
-import formatDate, { CALENDAR_DATE_FORMAT } from './utils/formatDate';
+import { formatDate, CALENDAR_DATE_FORMAT } from './utils/formatDate';
 import { formatPrescriptionDetails } from './utils/formatPrescriptionDetail';
 
 import { SignatureAttestationModal } from './systems/SignatureAttestation';

--- a/packages/components/src/systems/PatientInfo/index.tsx
+++ b/packages/components/src/systems/PatientInfo/index.tsx
@@ -6,7 +6,7 @@ import { usePhotonClient } from '../SDKProvider';
 import Button from '../../particles/Button';
 import Text from '../../particles/Text';
 import Card from '../../particles/Card';
-import formatDate from '../../utils/formatDate';
+import { formatDateUTC } from '../../utils/formatDate';
 import Collapsible from '../../particles/Collapsible';
 
 const GET_PATIENT = gql`
@@ -166,7 +166,7 @@ export default function PatientInfo(props: PatientInfoProps) {
               <tbody>
                 <InfoRow label="DOB">
                   <Text size="sm" loading={!patient()} sampleLoadingText="female">
-                    {formatDate(patient()?.dateOfBirth || 'N/A')}
+                    {patient()?.dateOfBirth ? formatDateUTC(patient()?.dateOfBirth) : 'N/A'}
                   </Text>
                 </InfoRow>
                 <InfoRow label="Weight">

--- a/packages/components/src/systems/PatientSelect.tsx
+++ b/packages/components/src/systems/PatientSelect.tsx
@@ -5,7 +5,7 @@ import { Patient } from '@photonhealth/sdk/dist/types';
 import { createMemo, For, Show } from 'solid-js';
 import { debounce } from '@solid-primitives/scheduled';
 import clsx from 'clsx';
-import formatDate from '../utils/formatDate';
+import { formatDateUTC } from '../utils/formatDate';
 
 export const PatientSelect = (props: {
   selectedPatient?: Patient;
@@ -73,7 +73,7 @@ const PatientOption = (props: { value: Patient; active: boolean }) => (
     {/* Styling accounts for wrapping long names on mobile */}
     <span class="min-w-0 whitespace-normal">{props.value.name.full}</span>
     <span class={clsx('shrink-0', props.active ? 'text-white' : 'text-gray-500')}>
-      {formatDate(props.value.dateOfBirth)}
+      {formatDateUTC(props.value.dateOfBirth)}
     </span>
   </div>
 );

--- a/packages/components/src/systems/RecentOrders/RecentOrdersCard.tsx
+++ b/packages/components/src/systems/RecentOrders/RecentOrdersCard.tsx
@@ -1,6 +1,6 @@
 import { For, Show } from 'solid-js';
 import { useRecentOrders } from '.';
-import formatDate from '../../utils/formatDate';
+import { formatDate } from '../../utils/formatDate';
 import Banner from '../../particles/Banner';
 import Button from '../../particles/Button';
 import Card from '../../particles/Card';

--- a/packages/components/src/systems/RecentOrders/RecentOrdersDuplicateDialog.tsx
+++ b/packages/components/src/systems/RecentOrders/RecentOrdersDuplicateDialog.tsx
@@ -6,7 +6,7 @@ import Icon from '../../particles/Icon';
 import Text from '../../particles/Text';
 import { dispatchDatadogAction } from '../../utils/dispatchDatadogAction';
 import formatRxString from '../../utils/formatRxString';
-import formatDate from '../../utils/formatDate';
+import { formatDate } from '../../utils/formatDate';
 
 export default function RecentOrdersDuplicateDialog() {
   let ref: Ref<any> | undefined;

--- a/packages/components/src/utils/formatDate.ts
+++ b/packages/components/src/utils/formatDate.ts
@@ -1,9 +1,17 @@
-export default function formatDate(dateString: string): string {
-  if (!dateString) {
-    return '';
-  }
+/**
+ * Format date to client's local date string (MM/DD/YYYY)
+ */
+export function formatDate(date?: string) {
+  return date ? new Date(date)?.toLocaleDateString('en-US') : '';
+}
 
-  return new Date(dateString).toLocaleDateString('en-US', { timeZone: 'UTC' });
+/**
+ * Format date to a UTC date string (MM/DD/YYYY)
+ * Use for any dates that should NOT be shifted to the
+ * client's local timezone
+ */
+export function formatDateUTC(date?: string) {
+  return date ? new Date(date)?.toLocaleDateString('en-US', { timeZone: 'UTC' }) : '';
 }
 
 export const CALENDAR_DATE_FORMAT = 'yyyy-MM-dd';

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@photonhealth/elements",
-  "version": "0.23.2",
+  "version": "0.23.3",
   "description": "",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/elements/src/utils.ts
+++ b/packages/elements/src/utils.ts
@@ -33,13 +33,6 @@ export const isZip = (zip: string) => {
   return /^\d{5}(-\d{4})?$/.test(zip);
 };
 
-// Takes a date string in the format 'YYYY-MM-DD'
-// and returns it in the format 'MM-DD-YYYY'.
-export const formatDate = (dateString: string) => {
-  const [year, month, day] = dateString.split('-');
-  return `${month}-${day}-${year}`;
-};
-
 export function checkHasPermission(subset: Permission[], superset: Permission[]) {
   return subset.every((permission) => superset.includes(permission));
 }


### PR DESCRIPTION
Part of KLU-253

Fixes the fact that we were displaying order and prescription related dates in UTC. This may have caused confusion for orders created after 9pm EST because they would display as the next calendar date in UTC (e.g. 4/23 instead of 4/22).

We need to maintain a separate util `formatDateUTC` for formatting date of birth, which should not shift based on the user's timezone.