### PR TITLE
next steps copy for AP orders

### DIFF
--- a/apps/patient/src/components/FAQ.tsx
+++ b/apps/patient/src/components/FAQ.tsx
@@ -6,35 +6,13 @@ import {
   AccordionPanel,
   Container,
   HStack,
-  Link,
   Text
 } from '@chakra-ui/react';
-import { ReactNode } from 'react';
+import { renderWithLinks } from '../utils/text';
 
 export type FAQEntry = {
   question: string;
   answer: string;
-};
-
-// Renders the answer text with inline markdown-style links: [label](url).
-// Anything outside the link syntax is rendered as plain text.
-// If we need more complex markdown rendering, we can consider adding react-markdown.
-const LINK_PATTERN = /\[([^\]]+)\]\(([^)]+)\)/g;
-const renderAnswersWithLinks = (answer: string): ReactNode[] => {
-  // Split [label](url) groupings into parts: [text, label, url, text, label, url, ...]
-  const parts = answer.split(LINK_PATTERN);
-  const nodes: ReactNode[] = [];
-  for (let i = 0; i < parts.length; i += 3) {
-    if (parts[i]) nodes.push(parts[i]);
-    if (i + 2 < parts.length) {
-      nodes.push(
-        <Link key={i} href={parts[i + 2]}>
-          {parts[i + 1]}
-        </Link>
-      );
-    }
-  }
-  return nodes;
 };
 
 export const FAQContents = ({ faqs }: { faqs: FAQEntry[] }) => {
@@ -56,7 +34,7 @@ export const FAQContents = ({ faqs }: { faqs: FAQEntry[] }) => {
           </AccordionButton>
           <AccordionPanel px={0} pb={4}>
             <Text align="start" color="gray.900">
-              {renderAnswersWithLinks(answer)}
+              {renderWithLinks(answer)}
             </Text>
           </AccordionPanel>
         </AccordionItem>

--- a/apps/patient/src/components/order-details/OrderDetailsModal.tsx
+++ b/apps/patient/src/components/order-details/OrderDetailsModal.tsx
@@ -3,6 +3,7 @@ import {
   Container,
   HStack,
   Icon,
+  Image,
   Modal,
   ModalBody,
   ModalCloseButton,
@@ -28,7 +29,7 @@ export interface PrescriptionData {
 export interface OrderDetailsProps {
   pharmacyName: string;
   pharmacyId?: string;
-  pharmacyLogo?: ReactNode;
+  pharmacyLogo?: string;
   prescriptions: PrescriptionData[];
 }
 
@@ -99,7 +100,19 @@ export const OrderDetailsModal = (props: OrderDetailsProps & OrderDetailsModalPr
                 spacing={5}
                 w="full"
               >
-                {props.pharmacyLogo ?? defaultIcon}
+                {props.pharmacyLogo ? (
+                  <Box boxSize="32px" overflow="hidden">
+                    <Image
+                      src={props.pharmacyLogo}
+                      width="auto"
+                      height="32px"
+                      boxSize="100%"
+                      objectFit="contain"
+                    />
+                  </Box>
+                ) : (
+                  defaultIcon
+                )}
                 <Box>
                   <Text fontSize="xl" as="h4">
                     This is your order summary for <b>{props.pharmacyName}</b>

--- a/apps/patient/src/components/order-details/OrderDetailsModal.tsx
+++ b/apps/patient/src/components/order-details/OrderDetailsModal.tsx
@@ -40,7 +40,7 @@ export interface OrderDetailsModalProps {
 
 const NEXT_STEPS_BY_PHARMACY: Record<string, string> = {
   [import.meta.env.VITE_AMAZON_PHARMACY_ID as string]:
-    'Amazon Pharmacy will text you shortly — no action needed.\n\nNo text? Log in at [amazon.com/pharmacy](https://amazon.com/pharmacy) to view your prescription or create an account.\n\nStill having trouble? Contact support. You can also switch pharmacies if needed.'
+    'Amazon Pharmacy will text you shortly — no action needed.\n\nNo text? Log in at [amazon.com/pharmacy](https://amazon.com/pharmacy) to view your prescription or create an account. Your prescription should show up soon.\n\nStill have trouble? Contact support. You can also switch pharmacies if needed.'
 };
 
 const Row = ({ k, value }: { k: string; value: ReactNode }) => {

--- a/apps/patient/src/components/order-details/OrderDetailsModal.tsx
+++ b/apps/patient/src/components/order-details/OrderDetailsModal.tsx
@@ -1,20 +1,21 @@
 import {
-  Container,
-  VStack,
-  Text,
-  HStack,
-  Modal,
-  ModalOverlay,
-  ModalContent,
-  ModalCloseButton,
-  ModalHeader,
-  ModalBody,
   Box,
-  Icon
+  Container,
+  HStack,
+  Icon,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalHeader,
+  ModalOverlay,
+  Text,
+  VStack
 } from '@chakra-ui/react';
 import dayjs from 'dayjs';
 import { ReactNode } from 'react';
 import { MdOutlineLocalPharmacy } from 'react-icons/md';
+import { renderWithLinks } from '../../utils/text';
 
 export interface PrescriptionData {
   rxName: string;
@@ -26,14 +27,20 @@ export interface PrescriptionData {
 
 export interface OrderDetailsProps {
   pharmacyName: string;
+  pharmacyId?: string;
   pharmacyLogo?: ReactNode;
-
   prescriptions: PrescriptionData[];
 }
+
 export interface OrderDetailsModalProps {
   isOpen: boolean;
   onClose: () => void;
 }
+
+const NEXT_STEPS_BY_PHARMACY: Record<string, string> = {
+  [import.meta.env.VITE_AMAZON_PHARMACY_ID as string]:
+    'Amazon Pharmacy will text you shortly — no action needed.\n\nNo text? Log in at [amazon.com/pharmacy](https://amazon.com/pharmacy) to view your prescription or create an account.\n\nStill having trouble? Contact support. You can also switch pharmacies if needed.'
+};
 
 const Row = ({ k, value }: { k: string; value: ReactNode }) => {
   return (
@@ -70,6 +77,7 @@ const defaultIcon = (
 );
 
 export const OrderDetailsModal = (props: OrderDetailsProps & OrderDetailsModalProps) => {
+  const nextSteps = props.pharmacyId ? NEXT_STEPS_BY_PHARMACY[props.pharmacyId] : undefined;
   const handleClose = () => {
     props.onClose();
   };
@@ -110,6 +118,16 @@ export const OrderDetailsModal = (props: OrderDetailsProps & OrderDetailsModalPr
                   <PrescriptionBlock key={`${p.rxName}-${i}`} rx={p} />
                 ))}
               </VStack>
+              {nextSteps && (
+                <VStack alignItems="stretch" spacing={2} w="full">
+                  <Text fontWeight="bold" fontSize="lg">
+                    Next Steps
+                  </Text>
+                  <Box bgColor="blue.50" borderRadius="xl" p={4}>
+                    <Text whiteSpace="pre-wrap">{renderWithLinks(nextSteps)}</Text>
+                  </Box>
+                </VStack>
+              )}
             </VStack>
           </Container>
         </ModalBody>

--- a/apps/patient/src/utils/text.tsx
+++ b/apps/patient/src/utils/text.tsx
@@ -3,6 +3,23 @@ import { FulfillmentState } from 'packages/sdk/src/types';
 import React, { ReactNode } from 'react';
 import { ExtendedFulfillmentType } from './models';
 
+const LINK_PATTERN = /\[([^\]]+)\]\(([^)]+)\)/g;
+export const renderWithLinks = (copy: string): ReactNode[] => {
+  const parts = copy.split(LINK_PATTERN);
+  const nodes: ReactNode[] = [];
+  for (let i = 0; i < parts.length; i += 3) {
+    if (parts[i]) nodes.push(parts[i]);
+    if (i + 2 < parts.length) {
+      nodes.push(
+        <Link key={i} href={parts[i + 2]} isExternal color="blue.500">
+          {parts[i + 1]}
+        </Link>
+      );
+    }
+  }
+  return nodes;
+};
+
 export const text = {
   askForBestPrice: 'Ask your pharmacist to help you find the best possible price.',
   bin: 'BIN',

--- a/apps/patient/src/views/Status.tsx
+++ b/apps/patient/src/views/Status.tsx
@@ -272,8 +272,9 @@ export const Status = () => {
       <OrderDetailsModal
         isOpen={orderDetailsIsOpen}
         onClose={() => setOrderDetailsIsOpen(false)}
-        pharmacyName={order.pharmacy?.name ?? 'My Pharmacy'}
-        pharmacyId={order.pharmacy?.id}
+        pharmacyName={displayPharmacy?.name ?? 'My Pharmacy'}
+        pharmacyId={displayPharmacy?.id}
+        pharmacyLogo={displayPharmacy?.logo}
         prescriptions={prescriptions}
       />
       <Helmet>

--- a/apps/patient/src/views/Status.tsx
+++ b/apps/patient/src/views/Status.tsx
@@ -273,6 +273,7 @@ export const Status = () => {
         isOpen={orderDetailsIsOpen}
         onClose={() => setOrderDetailsIsOpen(false)}
         pharmacyName={order.pharmacy?.name ?? 'My Pharmacy'}
+        pharmacyId={order.pharmacy?.id}
         prescriptions={prescriptions}
       />
       <Helmet>


### PR DESCRIPTION
<img width="332" height="726" alt="Screenshot 2026-05-13 at 1 06 15 PM" src="https://github.com/user-attachments/assets/3c38f974-0463-418f-9d1c-e194309a5cca" />

Adding a "next steps" copy just for amazon pharmacy orders. For the sake of not over-engineering, I'm keeping the copy on the frontend as opposed to pulling from a new endpoint that reads from custom-copies collection for the following reasons:
1. custom copy config could make more sense if we had a copy for everyone but needed overrides for specific orgs/pharmacies
2. we'd be making an api call and reading from dynamo every time someone hits order details when only AP orders would be the only one responding with data. According to MP, this button was hit 12.13K in the last week.
3. this text shouldn't change much

if down the road, “Next steps” copy becomes common across all pharmacies, we can revisit and use the custom-copies table and it'll be minimal effort to transition