### PR TITLE
Backfill RTPB test coverage

### DIFF
--- a/packages/components/src/fetch/queries.ts
+++ b/packages/components/src/fetch/queries.ts
@@ -57,7 +57,7 @@ export const GetPatient = gql`
 `;
 
 export const GetPatientPreferredPharmaciesAndAddress = gql`
-  query GetPatient($id: ID!) {
+  query GetPatientPreferredPharmaciesAndAddress($id: ID!) {
     patient(id: $id) {
       preferredPharmacies {
         id

--- a/packages/components/src/systems/SignatureAttestation/SignatureAttestationModal.tsx
+++ b/packages/components/src/systems/SignatureAttestation/SignatureAttestationModal.tsx
@@ -12,6 +12,7 @@ import { usePrescribeEventDispatch } from '../PrescribeEventDispatchProvider';
 const GetCurrentUserSignatureAttestationStatus = gql`
   query GetCurrentUserSignatureAttestationStatus {
     me {
+      id
       signatureAttestationStatus {
         ... on NeedsSignatureAttestation {
           version

--- a/packages/elements/src/photon-multirx-form/prescribe-workflow-analytics.test.tsx
+++ b/packages/elements/src/photon-multirx-form/prescribe-workflow-analytics.test.tsx
@@ -11,6 +11,7 @@ import {
 } from '@photonhealth/sdk/test-utils';
 import { MockMedicationSearchElement } from '../test-utils/mock-medication-search.element';
 import { renderPrescribeWorkflow } from './test-utils/test-element-setup';
+import { stubGoogleMaps } from './test-utils/stub-google-maps';
 
 vi.mock('solid-element', () => ({
   customElement: vi.fn()
@@ -28,16 +29,7 @@ beforeAll(() => {
     customElements.define('photon-medication-search', MockMedicationSearchElement);
   }
 
-  Object.defineProperty(window, 'google', {
-    configurable: true,
-    writable: true,
-    value: {
-      maps: {
-        Geocoder: class Geocoder {},
-        places: { AutocompleteService: class AutocompleteService {} }
-      }
-    }
-  });
+  stubGoogleMaps();
 });
 
 afterEach(async () => {

--- a/packages/elements/src/photon-multirx-form/prescribe-workflow-analytics.test.tsx
+++ b/packages/elements/src/photon-multirx-form/prescribe-workflow-analytics.test.tsx
@@ -1,15 +1,8 @@
-import { cleanup, render, screen, waitFor } from '@solidjs/testing-library';
-import userEvent from '@testing-library/user-event';
-import { GoogleServiceProvider, PhotonContext, SDKProvider } from '@photonhealth/components';
+import { cleanup, screen, waitFor } from '@solidjs/testing-library';
 import { afterAll, afterEach, beforeAll, expect, test, vi } from 'vitest';
-import { setupServer } from 'msw/node';
+import { setupServer, type SetupServer } from 'msw/node';
 import { HttpResponse } from 'msw';
 import { PatientStore } from '../stores/patient';
-import {
-  PhotonPrescribeWorkflowComponent,
-  type PrescribeWorkflowComponentProps
-} from './photon-prescribe-workflow-component';
-import { createTestClient, createTestClientStore } from '../test-utils/createTestClient';
 import {
   clinicalGql,
   defaultHandlers,
@@ -17,6 +10,7 @@ import {
   TREATMENT
 } from '@photonhealth/sdk/test-utils';
 import { MockMedicationSearchElement } from '../test-utils/mock-medication-search.element';
+import { renderPrescribeWorkflow } from './test-utils/test-element-setup';
 
 vi.mock('solid-element', () => ({
   customElement: vi.fn()
@@ -58,7 +52,8 @@ afterAll(() => server.close());
 type AnalyticsDetail = Record<string, unknown>;
 
 test('page views', async () => {
-  const { analyticsEvents } = renderPrescribeWorkflow({}, { attestationStatus: 'NEEDS' });
+  useNeedsSignatureAttestation(server);
+  const { analyticsEvents, waitForSignatureAttestationModal } = renderPrescribeWorkflow();
 
   await waitForSignatureAttestationModal();
   const event = analyticsEvents.find(isPageView('Signature Attestation Page Viewed'));
@@ -71,7 +66,7 @@ test('page views', async () => {
 });
 
 test('field interactions', async () => {
-  const { analyticsEvents, user } = renderPrescribeWorkflow();
+  const { analyticsEvents, user, waitForPrescribeForm } = renderPrescribeWorkflow();
 
   await waitForPrescribeForm();
 
@@ -129,7 +124,7 @@ test('field interactions', async () => {
 });
 
 test('pharmacy tab field interactions', async () => {
-  const { analyticsEvents, user } = renderPrescribeWorkflow({
+  const { analyticsEvents, user, waitForPrescribeForm } = renderPrescribeWorkflow({
     enableOrder: true,
     enableSendToPatient: true,
     enableLocalPickup: true,
@@ -179,16 +174,17 @@ test('pharmacy tab field interactions', async () => {
 });
 
 test('Send Order CTAs', async () => {
-  const { analyticsEvents, user } = renderPrescribeWorkflow({
-    enableOrder: true,
-    enableSendToPatient: true,
-    optionalPatientAddress: true
-  });
+  const { analyticsEvents, user, waitForPrescribeForm, addDraftPrescription } =
+    renderPrescribeWorkflow({
+      enableOrder: true,
+      enableSendToPatient: true,
+      optionalPatientAddress: true
+    });
 
   await waitForPrescribeForm();
 
   // 1. Add a draft prescription
-  await addDraftPrescription(user);
+  await addDraftPrescription();
 
   const draftAddedEvent = analyticsEvents.find(isCTA('Draft Prescription Added'));
   expect(draftAddedEvent?.detail).toEqual(
@@ -228,7 +224,8 @@ test('Send Order CTAs', async () => {
 });
 
 test('attestation CTA', async () => {
-  const { analyticsEvents, user } = renderPrescribeWorkflow({}, { attestationStatus: 'NEEDS' });
+  useNeedsSignatureAttestation(server);
+  const { analyticsEvents, user, waitForSignatureAttestationModal } = renderPrescribeWorkflow();
 
   await waitForSignatureAttestationModal();
 
@@ -261,10 +258,9 @@ test('photon-signature-attestation-resolved fires when no attestation needed', a
 });
 
 test('photon-signature-attestation-resolved does not fire before user agrees when attestation required', async () => {
-  const { attestationResolvedEvents, user } = renderPrescribeWorkflow(
-    {},
-    { attestationStatus: 'NEEDS' }
-  );
+  useNeedsSignatureAttestation(server);
+  const { attestationResolvedEvents, user, waitForSignatureAttestationModal } =
+    renderPrescribeWorkflow();
 
   await waitForSignatureAttestationModal();
 
@@ -279,10 +275,9 @@ test('photon-signature-attestation-resolved does not fire before user agrees whe
 });
 
 test('Signature Attestation Page Viewed fires before photon-signature-attestation-resolved when attestation required', async () => {
-  const { analyticsEvents, attestationResolvedEvents, user } = renderPrescribeWorkflow(
-    {},
-    { attestationStatus: 'NEEDS' }
-  );
+  useNeedsSignatureAttestation(server);
+  const { analyticsEvents, attestationResolvedEvents, user, waitForSignatureAttestationModal } =
+    renderPrescribeWorkflow();
 
   await waitForSignatureAttestationModal();
 
@@ -297,111 +292,6 @@ test('Signature Attestation Page Viewed fires before photon-signature-attestatio
     expect(attestationResolvedEvents.length).toEqual(1);
   });
 });
-
-function renderPrescribeWorkflow(
-  props: Partial<PrescribeWorkflowComponentProps> = {},
-  options: { attestationStatus?: 'COMPLETE' | 'NEEDS' } = {}
-) {
-  if (options.attestationStatus === 'NEEDS') {
-    // Per-test MSW overrides
-    server.use(
-      clinicalGql.query('GetCurrentUserSignatureAttestationStatus', () =>
-        HttpResponse.json({
-          data: {
-            me: {
-              __typename: 'User',
-              id: 'usr_1',
-              signatureAttestationStatus: {
-                __typename: 'NeedsSignatureAttestation',
-                version: 'v1',
-                content: 'Please attest to your signature'
-              }
-            }
-          }
-        })
-      )
-    );
-  }
-
-  const client = createTestClient();
-  const clientStore = createTestClientStore(client);
-  const eventListenerHost = document.createElement('div');
-
-  const analyticsEvents: CustomEvent[] = [];
-  const attestationResolvedEvents: Event[] = [];
-
-  eventListenerHost.addEventListener('photon-analytics-track-event', (event: Event) => {
-    analyticsEvents.push(event as CustomEvent);
-  });
-
-  eventListenerHost.addEventListener('photon-signature-attestation-resolved', (event: Event) => {
-    attestationResolvedEvents.push(event);
-  });
-
-  document.body.append(eventListenerHost);
-
-  const baseProps: PrescribeWorkflowComponentProps = {
-    patientId: 'pat_123',
-    hideSubmit: false,
-    hideTemplates: false,
-    hidePatientCard: false,
-    enableOrder: false,
-    enableMedHistory: false,
-    enableMedHistoryLinks: false,
-    enableMedHistoryRefillButton: false,
-    enableCombineAndDuplicate: false,
-    optionalPatientAddress: false,
-    triggerSubmit: false,
-    toastBuffer: 0,
-    enableCoverageCheck: false,
-    enableLocalPickup: false,
-    enableSendToPatient: false,
-    enableDeliveryPharmacies: false
-  };
-
-  const mergedProps = { ...baseProps, ...props };
-
-  const view = render(
-    () => (
-      <PhotonContext.Provider value={clientStore as never}>
-        <SDKProvider client={client as never}>
-          <GoogleServiceProvider>
-            <PhotonPrescribeWorkflowComponent {...mergedProps} />
-          </GoogleServiceProvider>
-        </SDKProvider>
-      </PhotonContext.Provider>
-    ),
-    { container: eventListenerHost }
-  );
-
-  return {
-    ...view,
-    analyticsEvents,
-    attestationResolvedEvents,
-    user: userEvent.setup()
-  };
-}
-
-async function waitForSignatureAttestationModal() {
-  await screen.findByText('Prescriber Signature Attestation');
-}
-
-async function waitForPrescribeForm() {
-  await screen.findByRole('button', { name: /add prescription/i }), { timeout: 3000 };
-}
-
-async function addDraftPrescription(user: ReturnType<typeof userEvent.setup>) {
-  await user.selectOptions(screen.getByLabelText(/search for treatment/i), TREATMENT.id);
-  await user.type(screen.getByLabelText(/quantity/i), '30');
-  await user.selectOptions(screen.getByLabelText(/dispense unit/i), DISPENSE_UNIT.name);
-  await user.type(screen.getByLabelText(/days supply/i), '10');
-  await user.type(screen.getByLabelText(/^refills/i), '0');
-  await user.type(
-    screen.getByLabelText(/patient instructions/i),
-    'Take one capsule by mouth daily'
-  );
-  await user.click(screen.getByRole('button', { name: /add prescription/i }));
-}
 
 const isFieldInteraction = (filter: Record<string, unknown> = {}) => {
   return (event: CustomEvent) => {
@@ -432,3 +322,23 @@ const isCTA = (ctaName: string, filter: Record<string, unknown> = {}) => {
     return Object.entries(filter).every(([key, value]) => detail[key] === value);
   };
 };
+
+function useNeedsSignatureAttestation(mswServer: SetupServer) {
+  mswServer.use(
+    clinicalGql.query('GetCurrentUserSignatureAttestationStatus', () =>
+      HttpResponse.json({
+        data: {
+          me: {
+            __typename: 'User',
+            id: 'usr_1',
+            signatureAttestationStatus: {
+              __typename: 'NeedsSignatureAttestation',
+              version: 'v1',
+              content: 'Please attest to your signature'
+            }
+          }
+        }
+      })
+    )
+  );
+}

--- a/packages/elements/src/photon-multirx-form/prescribe-workflow-analytics.test.tsx
+++ b/packages/elements/src/photon-multirx-form/prescribe-workflow-analytics.test.tsx
@@ -309,6 +309,7 @@ function renderPrescribeWorkflow(
         HttpResponse.json({
           data: {
             me: {
+              id: 'prov_1',
               signatureAttestationStatus: {
                 __typename: 'NeedsSignatureAttestation',
                 version: 'v1',

--- a/packages/elements/src/photon-multirx-form/prescribe-workflow-analytics.test.tsx
+++ b/packages/elements/src/photon-multirx-form/prescribe-workflow-analytics.test.tsx
@@ -309,7 +309,8 @@ function renderPrescribeWorkflow(
         HttpResponse.json({
           data: {
             me: {
-              id: 'prov_1',
+              __typename: 'User',
+              id: 'usr_1',
               signatureAttestationStatus: {
                 __typename: 'NeedsSignatureAttestation',
                 version: 'v1',

--- a/packages/elements/src/photon-multirx-form/prescribe-workflow-rtpb.test.tsx
+++ b/packages/elements/src/photon-multirx-form/prescribe-workflow-rtpb.test.tsx
@@ -8,6 +8,7 @@ import { clinicalGql, defaultHandlers, lambdasGql, TREATMENT } from '@photonheal
 import { MockMedicationSearchElement } from '../test-utils/mock-medication-search.element';
 import { renderPrescribeWorkflow } from './test-utils/test-element-setup';
 import { generateAddress, generatePatient, generatePharmacy } from './test-utils/generators';
+import { makeGeocodeResult, stubGoogleMaps } from './test-utils/stub-google-maps';
 
 vi.mock('solid-element', () => ({
   customElement: vi.fn()
@@ -24,20 +25,9 @@ beforeAll(() => {
     customElements.define('photon-medication-search', MockMedicationSearchElement);
   }
 
-  // Default Geocoder stub. The local-pharmacy test overrides `geocode` to
-  // return real coordinates so fetchLocalPharmacies proceeds.
-  Object.defineProperty(window, 'google', {
-    configurable: true,
-    writable: true,
-    value: {
-      maps: {
-        Geocoder: class Geocoder {
-          geocode = vi.fn(async () => ({ results: [] }));
-        },
-        places: { AutocompleteService: class AutocompleteService {} }
-      }
-    }
-  });
+  // Default Geocoder stub. The local-pharmacy test overrides with real
+  // coordinates so fetchLocalPharmacies proceeds.
+  stubGoogleMaps();
 });
 
 beforeEach(() => {
@@ -125,26 +115,7 @@ test("uses the patient's preferred pharmacy when one is set", async () => {
 });
 
 test('falls back to a nearby pharmacy when no preferred pharmacy', async () => {
-  // Make the geocoder return a real lat/lng so fetchLocalPharmacies proceeds.
-  Object.defineProperty(window, 'google', {
-    configurable: true,
-    writable: true,
-    value: {
-      maps: {
-        Geocoder: class Geocoder {
-          geocode = vi.fn(async () => ({
-            results: [
-              {
-                geometry: { location: { lat: () => 40.7128, lng: () => -74.006 } },
-                formatted_address: '1 Main, NY, NY 10001'
-              }
-            ]
-          }));
-        },
-        places: { AutocompleteService: class AutocompleteService {} }
-      }
-    }
-  });
+  stubGoogleMaps([makeGeocodeResult(40.7128, -74.006, '1 Main, NY, NY 10001')]);
 
   server.use(
     lambdasGql.query('GetPatientPreferredPharmaciesAndAddress', () =>

--- a/packages/elements/src/photon-multirx-form/prescribe-workflow-rtpb.test.tsx
+++ b/packages/elements/src/photon-multirx-form/prescribe-workflow-rtpb.test.tsx
@@ -41,7 +41,6 @@ beforeAll(() => {
 });
 
 beforeEach(() => {
-  // Re-register file-level overrides after server.resetHandlers() in afterEach.
   server.use(
     lambdasGql.query('patient', () => HttpResponse.json({ data: { patient: generatePatient() } })),
     lambdasGql.query('GetPatientPreferredPharmaciesAndAddress', () =>
@@ -78,8 +77,9 @@ test('does not fire GenerateCoverageOptions when enableCoverageCheck is false', 
   await addDraftPrescription();
   await screen.findByText(TREATMENT.name, {}, { timeout: 3000 });
 
-  // Give any in-flight effects a chance to settle; assertion stays negative.
+  // Give any in-flight effects a chance to settle...
   await new Promise((r) => setTimeout(r, 50));
+
   expect(generateCoverageSpy).not.toHaveBeenCalled();
 });
 
@@ -234,10 +234,8 @@ test('silently ignores errors from GenerateCoverageOptions (current behavior)', 
   await waitForPrescribeForm();
   await addDraftPrescription();
 
-  // The mutation was invoked
   await waitFor(() => expect(generateCoverageSpy).toHaveBeenCalled(), { timeout: 3000 });
 
-  // The draft still renders
   await screen.findByText(TREATMENT.name);
 
   // No user-facing error UI today

--- a/packages/elements/src/photon-multirx-form/prescribe-workflow-rtpb.test.tsx
+++ b/packages/elements/src/photon-multirx-form/prescribe-workflow-rtpb.test.tsx
@@ -1,59 +1,17 @@
-import { cleanup, render, screen, waitFor } from '@solidjs/testing-library';
-import userEvent from '@testing-library/user-event';
-import { GoogleServiceProvider, PhotonContext, SDKProvider } from '@photonhealth/components';
-import { afterAll, afterEach, beforeAll, expect, test, vi } from 'vitest';
+import { cleanup, screen, waitFor } from '@solidjs/testing-library';
+import { afterAll, afterEach, beforeAll, beforeEach, expect, test, vi } from 'vitest';
 import { setupServer } from 'msw/node';
 import { HttpResponse } from 'msw';
 import { GraphQLError } from 'graphql';
 import { PatientStore } from '../stores/patient';
-import {
-  PhotonPrescribeWorkflowComponent,
-  type PrescribeWorkflowComponentProps
-} from './photon-prescribe-workflow-component';
-import { createTestClient, createTestClientStore } from '../test-utils/createTestClient';
-import {
-  clinicalGql,
-  defaultHandlers,
-  DISPENSE_UNIT,
-  lambdasGql,
-  TREATMENT
-} from '@photonhealth/sdk/test-utils';
+import { clinicalGql, defaultHandlers, lambdasGql, TREATMENT } from '@photonhealth/sdk/test-utils';
 import { MockMedicationSearchElement } from '../test-utils/mock-medication-search.element';
+import { renderPrescribeWorkflow } from './test-utils/test-element-setup';
+import { generateAddress, generatePatient, generatePharmacy } from './test-utils/generators';
 
 vi.mock('solid-element', () => ({
   customElement: vi.fn()
 }));
-
-// Apollo's InMemoryCache writes every field present in a response into the
-// cache, regardless of the query's selection set. The shared `PATIENT` fixture
-// over-returns fields (e.g. `preferredPharmacies`, `address`) that the SDK's
-// `patient` query doesn't actually select — so cached values from that initial
-// call satisfy the downstream `GetPatientPreferredPharmaciesAndAddress` query
-// via cache-first, and per-test overrides of that query never reach the
-// network. To keep the cache honest, we override the default `patient` handler
-// here with a fixture that contains ONLY the fields PATIENT_FIELDS selects.
-const PATIENT_SDK_FIXTURE = {
-  __typename: 'Patient',
-  id: 'pat_123',
-  externalId: 'ext_pat_123',
-  name: { __typename: 'Name', full: 'Sally Patient' },
-  dateOfBirth: '1990-01-01',
-  sex: 'FEMALE',
-  gender: 'female',
-  email: 'sally@example.com',
-  phone: '+17185551234',
-  address: null
-};
-
-// Default response for GetPatientPreferredPharmaciesAndAddress — no preferred
-// pharmacies, no address. Per-test overrides replace this when they need a
-// preferred pharmacy or a local-pharmacy-with-address scenario.
-const EMPTY_PREFERRED_PHARMACIES_FIXTURE = {
-  __typename: 'Patient',
-  id: 'pat_123',
-  preferredPharmacies: [],
-  address: null
-};
 
 const server = setupServer(...defaultHandlers);
 
@@ -85,11 +43,11 @@ beforeAll(() => {
 beforeEach(() => {
   // Re-register file-level overrides after server.resetHandlers() in afterEach.
   server.use(
-    lambdasGql.query('patient', () =>
-      HttpResponse.json({ data: { patient: PATIENT_SDK_FIXTURE } })
-    ),
+    lambdasGql.query('patient', () => HttpResponse.json({ data: { patient: generatePatient() } })),
     lambdasGql.query('GetPatientPreferredPharmaciesAndAddress', () =>
-      HttpResponse.json({ data: { patient: EMPTY_PREFERRED_PHARMACIES_FIXTURE } })
+      HttpResponse.json({
+        data: { patient: generatePatient({ preferredPharmacies: [], address: null }) }
+      })
     )
   );
 });
@@ -112,10 +70,12 @@ test('does not fire GenerateCoverageOptions when enableCoverageCheck is false', 
     })
   );
 
-  const { user } = renderPrescribeWorkflow({ enableCoverageCheck: false });
+  const { waitForPrescribeForm, addDraftPrescription } = renderPrescribeWorkflow({
+    enableCoverageCheck: false
+  });
 
   await waitForPrescribeForm();
-  await addDraftPrescription(user);
+  await addDraftPrescription();
   await screen.findByText(TREATMENT.name, {}, { timeout: 3000 });
 
   // Give any in-flight effects a chance to settle; assertion stays negative.
@@ -128,24 +88,12 @@ test("uses the patient's preferred pharmacy when one is set", async () => {
     lambdasGql.query('GetPatientPreferredPharmaciesAndAddress', () =>
       HttpResponse.json({
         data: {
-          patient: {
-            __typename: 'Patient',
-            id: 'pat_123',
+          patient: generatePatient({
             preferredPharmacies: [
-              {
-                __typename: 'Pharmacy',
-                id: 'phr_preferred',
-                name: 'Preferred Pharmacy',
-                address: {
-                  __typename: 'Address',
-                  street1: '1 Main',
-                  city: 'NY',
-                  state: 'NY'
-                }
-              }
+              generatePharmacy({ id: 'phr_preferred', name: 'Preferred Pharmacy' })
             ],
             address: null
-          }
+          })
         }
       })
     )
@@ -159,10 +107,12 @@ test("uses the patient's preferred pharmacy when one is set", async () => {
     })
   );
 
-  const { user } = renderPrescribeWorkflow({ enableCoverageCheck: true });
+  const { waitForPrescribeForm, addDraftPrescription } = renderPrescribeWorkflow({
+    enableCoverageCheck: true
+  });
 
   await waitForPrescribeForm();
-  await addDraftPrescription(user);
+  await addDraftPrescription();
 
   await waitFor(
     () => {
@@ -200,36 +150,24 @@ test('falls back to a nearby pharmacy when no preferred pharmacy', async () => {
     lambdasGql.query('GetPatientPreferredPharmaciesAndAddress', () =>
       HttpResponse.json({
         data: {
-          patient: {
-            __typename: 'Patient',
-            id: 'pat_123',
+          patient: generatePatient({
             preferredPharmacies: [],
-            address: {
-              __typename: 'Address',
+            address: generateAddress({
               id: 'addr_1',
-              name: null,
               street1: '1 Main',
-              street2: null,
               city: 'NY',
               state: 'NY',
               postalCode: '10001',
               country: 'US'
-            }
-          }
+            })
+          })
         }
       })
     ),
     lambdasGql.query('GetPharmacies', () =>
       HttpResponse.json({
         data: {
-          pharmacies: [
-            {
-              __typename: 'Pharmacy',
-              id: 'phr_walgreens',
-              name: 'Walgreens #123',
-              address: { street1: '99 Main', city: 'NY', state: 'NY' }
-            }
-          ]
+          pharmacies: [generatePharmacy({ id: 'phr_walgreens', name: 'Walgreens #123' })]
         }
       })
     )
@@ -243,10 +181,12 @@ test('falls back to a nearby pharmacy when no preferred pharmacy', async () => {
     })
   );
 
-  const { user } = renderPrescribeWorkflow({ enableCoverageCheck: true });
+  const { waitForPrescribeForm, addDraftPrescription } = renderPrescribeWorkflow({
+    enableCoverageCheck: true
+  });
 
   await waitForPrescribeForm();
-  await addDraftPrescription(user);
+  await addDraftPrescription();
 
   await waitFor(
     () => {
@@ -259,12 +199,7 @@ test('falls back to a nearby pharmacy when no preferred pharmacy', async () => {
 });
 
 test('silently ignores errors from GenerateCoverageOptions (current behavior)', async () => {
-  // TODO: This test backfills today's silent-failure behavior. The follow-up PR
-  // that adds the error Banner will flip the assertions here.
-  //
-  // PrescribeProvider awaits the mutation without a .catch, so a rejection
-  // surfaces as an unhandled Promise rejection. Capture it here so vitest
-  // doesn't fail the run on what is today's intended behavior.
+  // TODO: show error instead of ignore in KLU-275
   const unhandledRejections: unknown[] = [];
   const rejectionHandler = (reason: unknown) => unhandledRejections.push(reason);
   process.on('unhandledRejection', rejectionHandler);
@@ -273,24 +208,12 @@ test('silently ignores errors from GenerateCoverageOptions (current behavior)', 
     lambdasGql.query('GetPatientPreferredPharmaciesAndAddress', () =>
       HttpResponse.json({
         data: {
-          patient: {
-            __typename: 'Patient',
-            id: 'pat_123',
+          patient: generatePatient({
             preferredPharmacies: [
-              {
-                __typename: 'Pharmacy',
-                id: 'phr_preferred',
-                name: 'Preferred Pharmacy',
-                address: {
-                  __typename: 'Address',
-                  street1: '1 Main',
-                  city: 'NY',
-                  state: 'NY'
-                }
-              }
+              generatePharmacy({ id: 'phr_preferred', name: 'Preferred Pharmacy' })
             ],
             address: null
-          }
+          })
         }
       })
     )
@@ -304,10 +227,12 @@ test('silently ignores errors from GenerateCoverageOptions (current behavior)', 
     })
   );
 
-  const { user } = renderPrescribeWorkflow({ enableCoverageCheck: true });
+  const { waitForPrescribeForm, addDraftPrescription } = renderPrescribeWorkflow({
+    enableCoverageCheck: true
+  });
 
   await waitForPrescribeForm();
-  await addDraftPrescription(user);
+  await addDraftPrescription();
 
   // The mutation was invoked
   await waitFor(() => expect(generateCoverageSpy).toHaveBeenCalled(), { timeout: 3000 });
@@ -324,63 +249,3 @@ test('silently ignores errors from GenerateCoverageOptions (current behavior)', 
   await waitFor(() => expect(unhandledRejections.length).toBeGreaterThan(0));
   process.off('unhandledRejection', rejectionHandler);
 });
-
-function renderPrescribeWorkflow(props: Partial<PrescribeWorkflowComponentProps> = {}) {
-  const client = createTestClient();
-  const clientStore = createTestClientStore(client);
-  const eventListenerHost = document.createElement('div');
-  document.body.append(eventListenerHost);
-
-  const baseProps: PrescribeWorkflowComponentProps = {
-    patientId: 'pat_123',
-    hideSubmit: false,
-    hideTemplates: false,
-    hidePatientCard: false,
-    enableOrder: false,
-    enableMedHistory: false,
-    enableMedHistoryLinks: false,
-    enableMedHistoryRefillButton: false,
-    enableCombineAndDuplicate: false,
-    optionalPatientAddress: false,
-    triggerSubmit: false,
-    toastBuffer: 0,
-    enableCoverageCheck: false,
-    enableLocalPickup: false,
-    enableSendToPatient: false,
-    enableDeliveryPharmacies: false
-  };
-
-  const mergedProps = { ...baseProps, ...props };
-
-  const view = render(
-    () => (
-      <PhotonContext.Provider value={clientStore as never}>
-        <SDKProvider client={client as never}>
-          <GoogleServiceProvider>
-            <PhotonPrescribeWorkflowComponent {...mergedProps} />
-          </GoogleServiceProvider>
-        </SDKProvider>
-      </PhotonContext.Provider>
-    ),
-    { container: eventListenerHost }
-  );
-
-  return { ...view, user: userEvent.setup() };
-}
-
-async function waitForPrescribeForm() {
-  await screen.findByRole('button', { name: /add prescription/i }, { timeout: 3000 });
-}
-
-async function addDraftPrescription(user: ReturnType<typeof userEvent.setup>) {
-  await user.selectOptions(screen.getByLabelText(/search for treatment/i), TREATMENT.id);
-  await user.type(screen.getByLabelText(/quantity/i), '30');
-  await user.selectOptions(screen.getByLabelText(/dispense unit/i), DISPENSE_UNIT.name);
-  await user.type(screen.getByLabelText(/days supply/i), '10');
-  await user.type(screen.getByLabelText(/^refills/i), '0');
-  await user.type(
-    screen.getByLabelText(/patient instructions/i),
-    'Take one capsule by mouth daily'
-  );
-  await user.click(screen.getByRole('button', { name: /add prescription/i }));
-}

--- a/packages/elements/src/photon-multirx-form/prescribe-workflow-rtpb.test.tsx
+++ b/packages/elements/src/photon-multirx-form/prescribe-workflow-rtpb.test.tsx
@@ -1,0 +1,386 @@
+import { cleanup, render, screen, waitFor } from '@solidjs/testing-library';
+import userEvent from '@testing-library/user-event';
+import { GoogleServiceProvider, PhotonContext, SDKProvider } from '@photonhealth/components';
+import { afterAll, afterEach, beforeAll, expect, test, vi } from 'vitest';
+import { setupServer } from 'msw/node';
+import { HttpResponse } from 'msw';
+import { GraphQLError } from 'graphql';
+import { PatientStore } from '../stores/patient';
+import {
+  PhotonPrescribeWorkflowComponent,
+  type PrescribeWorkflowComponentProps
+} from './photon-prescribe-workflow-component';
+import { createTestClient, createTestClientStore } from '../test-utils/createTestClient';
+import {
+  clinicalGql,
+  defaultHandlers,
+  DISPENSE_UNIT,
+  lambdasGql,
+  TREATMENT
+} from '@photonhealth/sdk/test-utils';
+import { MockMedicationSearchElement } from '../test-utils/mock-medication-search.element';
+
+vi.mock('solid-element', () => ({
+  customElement: vi.fn()
+}));
+
+// Apollo's InMemoryCache writes every field present in a response into the
+// cache, regardless of the query's selection set. The shared `PATIENT` fixture
+// over-returns fields (e.g. `preferredPharmacies`, `address`) that the SDK's
+// `patient` query doesn't actually select — so cached values from that initial
+// call satisfy the downstream `GetPatientPreferredPharmaciesAndAddress` query
+// via cache-first, and per-test overrides of that query never reach the
+// network. To keep the cache honest, we override the default `patient` handler
+// here with a fixture that contains ONLY the fields PATIENT_FIELDS selects.
+const PATIENT_SDK_FIXTURE = {
+  __typename: 'Patient',
+  id: 'pat_123',
+  externalId: 'ext_pat_123',
+  name: { __typename: 'Name', full: 'Sally Patient' },
+  dateOfBirth: '1990-01-01',
+  sex: 'FEMALE',
+  gender: 'female',
+  email: 'sally@example.com',
+  phone: '+17185551234',
+  address: null
+};
+
+// Default response for GetPatientPreferredPharmaciesAndAddress — no preferred
+// pharmacies, no address. Per-test overrides replace this when they need a
+// preferred pharmacy or a local-pharmacy-with-address scenario.
+const EMPTY_PREFERRED_PHARMACIES_FIXTURE = {
+  __typename: 'Patient',
+  id: 'pat_123',
+  preferredPharmacies: [],
+  address: null
+};
+
+const server = setupServer(...defaultHandlers);
+
+beforeAll(() => {
+  server.listen({ onUnhandledRequest: 'warn' });
+
+  window.HTMLElement.prototype.scrollIntoView = vi.fn();
+
+  if (!customElements.get('photon-medication-search')) {
+    customElements.define('photon-medication-search', MockMedicationSearchElement);
+  }
+
+  // Default Geocoder stub. The local-pharmacy test overrides `geocode` to
+  // return real coordinates so fetchLocalPharmacies proceeds.
+  Object.defineProperty(window, 'google', {
+    configurable: true,
+    writable: true,
+    value: {
+      maps: {
+        Geocoder: class Geocoder {
+          geocode = vi.fn(async () => ({ results: [] }));
+        },
+        places: { AutocompleteService: class AutocompleteService {} }
+      }
+    }
+  });
+});
+
+beforeEach(() => {
+  // Re-register file-level overrides after server.resetHandlers() in afterEach.
+  server.use(
+    lambdasGql.query('patient', () =>
+      HttpResponse.json({ data: { patient: PATIENT_SDK_FIXTURE } })
+    ),
+    lambdasGql.query('GetPatientPreferredPharmaciesAndAddress', () =>
+      HttpResponse.json({ data: { patient: EMPTY_PREFERRED_PHARMACIES_FIXTURE } })
+    )
+  );
+});
+
+afterEach(async () => {
+  cleanup();
+  server.resetHandlers();
+  vi.clearAllMocks();
+  await PatientStore.actions.reset();
+});
+
+afterAll(() => server.close());
+
+test('does not fire GenerateCoverageOptions when enableCoverageCheck is false', async () => {
+  const generateCoverageSpy = vi.fn();
+  server.use(
+    clinicalGql.mutation('GenerateCoverageOptions', ({ variables }) => {
+      generateCoverageSpy(variables);
+      return HttpResponse.json({ data: { generateCoverageOptions: [] } });
+    })
+  );
+
+  const { user } = renderPrescribeWorkflow({ enableCoverageCheck: false });
+
+  await waitForPrescribeForm();
+  await addDraftPrescription(user);
+  await screen.findByText(TREATMENT.name, {}, { timeout: 3000 });
+
+  // Give any in-flight effects a chance to settle; assertion stays negative.
+  await new Promise((r) => setTimeout(r, 50));
+  expect(generateCoverageSpy).not.toHaveBeenCalled();
+});
+
+test("uses the patient's preferred pharmacy when one is set", async () => {
+  server.use(
+    lambdasGql.query('GetPatientPreferredPharmaciesAndAddress', () =>
+      HttpResponse.json({
+        data: {
+          patient: {
+            __typename: 'Patient',
+            id: 'pat_123',
+            preferredPharmacies: [
+              {
+                __typename: 'Pharmacy',
+                id: 'phr_preferred',
+                name: 'Preferred Pharmacy',
+                address: {
+                  __typename: 'Address',
+                  street1: '1 Main',
+                  city: 'NY',
+                  state: 'NY'
+                }
+              }
+            ],
+            address: null
+          }
+        }
+      })
+    )
+  );
+
+  const generateCoverageSpy = vi.fn();
+  server.use(
+    clinicalGql.mutation('GenerateCoverageOptions', ({ variables }) => {
+      generateCoverageSpy(variables);
+      return HttpResponse.json({ data: { generateCoverageOptions: [] } });
+    })
+  );
+
+  const { user } = renderPrescribeWorkflow({ enableCoverageCheck: true });
+
+  await waitForPrescribeForm();
+  await addDraftPrescription(user);
+
+  await waitFor(
+    () => {
+      expect(generateCoverageSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ pharmacyId: 'phr_preferred' })
+      );
+    },
+    { timeout: 3000 }
+  );
+});
+
+test('falls back to a nearby pharmacy when no preferred pharmacy', async () => {
+  // Make the geocoder return a real lat/lng so fetchLocalPharmacies proceeds.
+  Object.defineProperty(window, 'google', {
+    configurable: true,
+    writable: true,
+    value: {
+      maps: {
+        Geocoder: class Geocoder {
+          geocode = vi.fn(async () => ({
+            results: [
+              {
+                geometry: { location: { lat: () => 40.7128, lng: () => -74.006 } },
+                formatted_address: '1 Main, NY, NY 10001'
+              }
+            ]
+          }));
+        },
+        places: { AutocompleteService: class AutocompleteService {} }
+      }
+    }
+  });
+
+  server.use(
+    lambdasGql.query('GetPatientPreferredPharmaciesAndAddress', () =>
+      HttpResponse.json({
+        data: {
+          patient: {
+            __typename: 'Patient',
+            id: 'pat_123',
+            preferredPharmacies: [],
+            address: {
+              __typename: 'Address',
+              id: 'addr_1',
+              name: null,
+              street1: '1 Main',
+              street2: null,
+              city: 'NY',
+              state: 'NY',
+              postalCode: '10001',
+              country: 'US'
+            }
+          }
+        }
+      })
+    ),
+    lambdasGql.query('GetPharmacies', () =>
+      HttpResponse.json({
+        data: {
+          pharmacies: [
+            {
+              __typename: 'Pharmacy',
+              id: 'phr_walgreens',
+              name: 'Walgreens #123',
+              address: { street1: '99 Main', city: 'NY', state: 'NY' }
+            }
+          ]
+        }
+      })
+    )
+  );
+
+  const generateCoverageSpy = vi.fn();
+  server.use(
+    clinicalGql.mutation('GenerateCoverageOptions', ({ variables }) => {
+      generateCoverageSpy(variables);
+      return HttpResponse.json({ data: { generateCoverageOptions: [] } });
+    })
+  );
+
+  const { user } = renderPrescribeWorkflow({ enableCoverageCheck: true });
+
+  await waitForPrescribeForm();
+  await addDraftPrescription(user);
+
+  await waitFor(
+    () => {
+      expect(generateCoverageSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ pharmacyId: 'phr_walgreens' })
+      );
+    },
+    { timeout: 3000 }
+  );
+});
+
+test('silently ignores errors from GenerateCoverageOptions (current behavior)', async () => {
+  // TODO: This test backfills today's silent-failure behavior. The follow-up PR
+  // that adds the error Banner will flip the assertions here.
+  //
+  // PrescribeProvider awaits the mutation without a .catch, so a rejection
+  // surfaces as an unhandled Promise rejection. Capture it here so vitest
+  // doesn't fail the run on what is today's intended behavior.
+  const unhandledRejections: unknown[] = [];
+  const rejectionHandler = (reason: unknown) => unhandledRejections.push(reason);
+  process.on('unhandledRejection', rejectionHandler);
+
+  server.use(
+    lambdasGql.query('GetPatientPreferredPharmaciesAndAddress', () =>
+      HttpResponse.json({
+        data: {
+          patient: {
+            __typename: 'Patient',
+            id: 'pat_123',
+            preferredPharmacies: [
+              {
+                __typename: 'Pharmacy',
+                id: 'phr_preferred',
+                name: 'Preferred Pharmacy',
+                address: {
+                  __typename: 'Address',
+                  street1: '1 Main',
+                  city: 'NY',
+                  state: 'NY'
+                }
+              }
+            ],
+            address: null
+          }
+        }
+      })
+    )
+  );
+
+  const generateCoverageSpy = vi.fn();
+  server.use(
+    clinicalGql.mutation('GenerateCoverageOptions', () => {
+      generateCoverageSpy();
+      return HttpResponse.json({ errors: [new GraphQLError('Coverage service down')] });
+    })
+  );
+
+  const { user } = renderPrescribeWorkflow({ enableCoverageCheck: true });
+
+  await waitForPrescribeForm();
+  await addDraftPrescription(user);
+
+  // The mutation was invoked
+  await waitFor(() => expect(generateCoverageSpy).toHaveBeenCalled(), { timeout: 3000 });
+
+  // The draft still renders
+  await screen.findByText(TREATMENT.name);
+
+  // No user-facing error UI today
+  expect(screen.queryByText(/coverage/i)).toBeNull();
+  expect(screen.queryByRole('alert')).toBeNull();
+
+  // Confirm an unhandled rejection occurred (current bug we'll fix in a follow-up)
+  // and prevent it from failing the test run.
+  await waitFor(() => expect(unhandledRejections.length).toBeGreaterThan(0));
+  process.off('unhandledRejection', rejectionHandler);
+});
+
+function renderPrescribeWorkflow(props: Partial<PrescribeWorkflowComponentProps> = {}) {
+  const client = createTestClient();
+  const clientStore = createTestClientStore(client);
+  const eventListenerHost = document.createElement('div');
+  document.body.append(eventListenerHost);
+
+  const baseProps: PrescribeWorkflowComponentProps = {
+    patientId: 'pat_123',
+    hideSubmit: false,
+    hideTemplates: false,
+    hidePatientCard: false,
+    enableOrder: false,
+    enableMedHistory: false,
+    enableMedHistoryLinks: false,
+    enableMedHistoryRefillButton: false,
+    enableCombineAndDuplicate: false,
+    optionalPatientAddress: false,
+    triggerSubmit: false,
+    toastBuffer: 0,
+    enableCoverageCheck: false,
+    enableLocalPickup: false,
+    enableSendToPatient: false,
+    enableDeliveryPharmacies: false
+  };
+
+  const mergedProps = { ...baseProps, ...props };
+
+  const view = render(
+    () => (
+      <PhotonContext.Provider value={clientStore as never}>
+        <SDKProvider client={client as never}>
+          <GoogleServiceProvider>
+            <PhotonPrescribeWorkflowComponent {...mergedProps} />
+          </GoogleServiceProvider>
+        </SDKProvider>
+      </PhotonContext.Provider>
+    ),
+    { container: eventListenerHost }
+  );
+
+  return { ...view, user: userEvent.setup() };
+}
+
+async function waitForPrescribeForm() {
+  await screen.findByRole('button', { name: /add prescription/i }, { timeout: 3000 });
+}
+
+async function addDraftPrescription(user: ReturnType<typeof userEvent.setup>) {
+  await user.selectOptions(screen.getByLabelText(/search for treatment/i), TREATMENT.id);
+  await user.type(screen.getByLabelText(/quantity/i), '30');
+  await user.selectOptions(screen.getByLabelText(/dispense unit/i), DISPENSE_UNIT.name);
+  await user.type(screen.getByLabelText(/days supply/i), '10');
+  await user.type(screen.getByLabelText(/^refills/i), '0');
+  await user.type(
+    screen.getByLabelText(/patient instructions/i),
+    'Take one capsule by mouth daily'
+  );
+  await user.click(screen.getByRole('button', { name: /add prescription/i }));
+}

--- a/packages/elements/src/photon-multirx-form/prescribe-workflow-rtpb.test.tsx
+++ b/packages/elements/src/photon-multirx-form/prescribe-workflow-rtpb.test.tsx
@@ -25,8 +25,6 @@ beforeAll(() => {
     customElements.define('photon-medication-search', MockMedicationSearchElement);
   }
 
-  // Default Geocoder stub. The local-pharmacy test overrides with real
-  // coordinates so fetchLocalPharmacies proceeds.
   stubGoogleMaps();
 });
 
@@ -213,7 +211,7 @@ test('silently ignores errors from GenerateCoverageOptions (current behavior)', 
   expect(screen.queryByText(/coverage/i)).toBeNull();
   expect(screen.queryByRole('alert')).toBeNull();
 
-  // Confirm an unhandled rejection occurred (current bug we'll fix in a follow-up)
+  // Confirm an unhandled rejection occurred
   // and prevent it from failing the test run.
   await waitFor(() => expect(unhandledRejections.length).toBeGreaterThan(0));
   process.off('unhandledRejection', rejectionHandler);

--- a/packages/elements/src/photon-multirx-form/prescribe-workflow-template-prefill.test.tsx
+++ b/packages/elements/src/photon-multirx-form/prescribe-workflow-template-prefill.test.tsx
@@ -1,16 +1,11 @@
-import { cleanup, render, waitFor } from '@solidjs/testing-library';
-import { GoogleServiceProvider, PhotonContext, SDKProvider } from '@photonhealth/components';
+import { cleanup, waitFor } from '@solidjs/testing-library';
 import { afterAll, afterEach, beforeAll, expect, test, vi } from 'vitest';
 import { setupServer } from 'msw/node';
 import { HttpResponse } from 'msw';
 import { PatientStore } from '../stores/patient';
-import {
-  PhotonPrescribeWorkflowComponent,
-  type PrescribeWorkflowComponentProps
-} from './photon-prescribe-workflow-component';
-import { createTestClient, createTestClientStore } from '../test-utils/createTestClient';
 import { defaultHandlers, lambdasGql, TREATMENT } from '@photonhealth/sdk/test-utils';
 import { MockMedicationSearchElement } from '../test-utils/mock-medication-search.element';
+import { renderPrescribeWorkflow } from './test-utils/test-element-setup';
 
 vi.mock('solid-element', () => ({
   customElement: vi.fn()
@@ -102,42 +97,3 @@ test('additionalNotes are merged into prescriptions prefilled from templateIds',
   // template-prefilled rxs — only templateOverrides notes make it through.
   expect(sent.notes).toContain('Clinical additional note from host app');
 });
-
-function renderPrescribeWorkflow(props: Partial<PrescribeWorkflowComponentProps> = {}) {
-  const client = createTestClient();
-  const clientStore = createTestClientStore(client);
-  const host = document.createElement('div');
-  document.body.append(host);
-
-  const baseProps: PrescribeWorkflowComponentProps = {
-    patientId: 'pat_123',
-    hideSubmit: false,
-    hideTemplates: false,
-    hidePatientCard: false,
-    enableOrder: false,
-    enableMedHistory: false,
-    enableMedHistoryLinks: false,
-    enableMedHistoryRefillButton: false,
-    enableCombineAndDuplicate: false,
-    optionalPatientAddress: false,
-    triggerSubmit: false,
-    toastBuffer: 0,
-    enableCoverageCheck: false,
-    enableLocalPickup: false,
-    enableSendToPatient: false,
-    enableDeliveryPharmacies: false
-  };
-
-  return render(
-    () => (
-      <PhotonContext.Provider value={clientStore as never}>
-        <SDKProvider client={client as never}>
-          <GoogleServiceProvider>
-            <PhotonPrescribeWorkflowComponent {...{ ...baseProps, ...props }} />
-          </GoogleServiceProvider>
-        </SDKProvider>
-      </PhotonContext.Provider>
-    ),
-    { container: host }
-  );
-}

--- a/packages/elements/src/photon-multirx-form/prescribe-workflow-template-prefill.test.tsx
+++ b/packages/elements/src/photon-multirx-form/prescribe-workflow-template-prefill.test.tsx
@@ -6,6 +6,7 @@ import { PatientStore } from '../stores/patient';
 import { defaultHandlers, lambdasGql, TREATMENT } from '@photonhealth/sdk/test-utils';
 import { MockMedicationSearchElement } from '../test-utils/mock-medication-search.element';
 import { renderPrescribeWorkflow } from './test-utils/test-element-setup';
+import { stubGoogleMaps } from './test-utils/stub-google-maps';
 
 vi.mock('solid-element', () => ({
   customElement: vi.fn()
@@ -22,16 +23,7 @@ beforeAll(() => {
     customElements.define('photon-medication-search', MockMedicationSearchElement);
   }
 
-  Object.defineProperty(window, 'google', {
-    configurable: true,
-    writable: true,
-    value: {
-      maps: {
-        Geocoder: class Geocoder {},
-        places: { AutocompleteService: class AutocompleteService {} }
-      }
-    }
-  });
+  stubGoogleMaps();
 });
 
 afterEach(async () => {

--- a/packages/elements/src/photon-multirx-form/test-utils/generators.ts
+++ b/packages/elements/src/photon-multirx-form/test-utils/generators.ts
@@ -1,19 +1,24 @@
-import type { Address, Patient, Pharmacy } from '@photonhealth/sdk/dist/types';
+import { Address, Patient, Pharmacy, SexType } from '@photonhealth/sdk/dist/types';
 
 export function generatePatient(overrides: Partial<Patient> = {}): Patient {
   return {
     __typename: 'Patient',
     id: 'pat_123',
     externalId: 'ext_pat_123',
-    name: { __typename: 'Name', full: 'Sally Patient' },
+    name: {
+      __typename: 'Name',
+      full: 'Sally Patient',
+      first: 'Sally',
+      last: 'Patient'
+    },
     dateOfBirth: '1990-01-01',
-    sex: 'FEMALE',
+    sex: SexType.Female,
     gender: 'female',
     email: 'sally@example.com',
     phone: '+17185551234',
     address: null,
     ...overrides
-  } as Patient;
+  };
 }
 export function generateAddress(overrides: Partial<Address> = {}): Address {
   return {
@@ -27,7 +32,7 @@ export function generateAddress(overrides: Partial<Address> = {}): Address {
     postalCode: '10001',
     country: 'US',
     ...overrides
-  } as Address;
+  };
 }
 
 export function generatePharmacy(overrides: Partial<Pharmacy> = {}): Pharmacy {
@@ -44,5 +49,5 @@ export function generatePharmacy(overrides: Partial<Pharmacy> = {}): Pharmacy {
       country: 'US'
     },
     ...overrides
-  } as Pharmacy;
+  };
 }

--- a/packages/elements/src/photon-multirx-form/test-utils/generators.ts
+++ b/packages/elements/src/photon-multirx-form/test-utils/generators.ts
@@ -1,4 +1,4 @@
-import type { Patient, Pharmacy } from '@photonhealth/sdk/dist/types';
+import type { Address, Patient, Pharmacy } from '@photonhealth/sdk/dist/types';
 
 export function generatePatient(overrides: Partial<Patient> = {}): Patient {
   return {
@@ -27,7 +27,7 @@ export function generateAddress(overrides: Partial<Address> = {}): Address {
     postalCode: '10001',
     country: 'US',
     ...overrides
-  } as Patient;
+  } as Address;
 }
 
 export function generatePharmacy(overrides: Partial<Pharmacy> = {}): Pharmacy {

--- a/packages/elements/src/photon-multirx-form/test-utils/generators.ts
+++ b/packages/elements/src/photon-multirx-form/test-utils/generators.ts
@@ -1,0 +1,48 @@
+import type { Patient, Pharmacy } from '@photonhealth/sdk/dist/types';
+
+export function generatePatient(overrides: Partial<Patient> = {}): Patient {
+  return {
+    __typename: 'Patient',
+    id: 'pat_123',
+    externalId: 'ext_pat_123',
+    name: { __typename: 'Name', full: 'Sally Patient' },
+    dateOfBirth: '1990-01-01',
+    sex: 'FEMALE',
+    gender: 'female',
+    email: 'sally@example.com',
+    phone: '+17185551234',
+    address: null,
+    ...overrides
+  } as Patient;
+}
+export function generateAddress(overrides: Partial<Address> = {}): Address {
+  return {
+    __typename: 'Address',
+    id: 'addr_1',
+    name: null,
+    street1: '1 Main',
+    street2: null,
+    city: 'NY',
+    state: 'NY',
+    postalCode: '10001',
+    country: 'US',
+    ...overrides
+  } as Patient;
+}
+
+export function generatePharmacy(overrides: Partial<Pharmacy> = {}): Pharmacy {
+  return {
+    __typename: 'Pharmacy',
+    id: 'phr_123',
+    name: 'Test Pharmacy',
+    address: {
+      __typename: 'Address',
+      street1: '1 Main',
+      city: 'NY',
+      state: 'NY',
+      postalCode: '10001',
+      country: 'US'
+    },
+    ...overrides
+  } as Pharmacy;
+}

--- a/packages/elements/src/photon-multirx-form/test-utils/stub-google-maps.ts
+++ b/packages/elements/src/photon-multirx-form/test-utils/stub-google-maps.ts
@@ -1,0 +1,37 @@
+/// <reference types="google.maps" />
+import { vi } from 'vitest';
+
+/**
+ * Stubs `window.google.maps` so code paths that touch the Google Maps SDK
+ * (Geocoder, places.AutocompleteService) don't blow up in jsdom. Pass
+ * `geocodeResults` when the test exercises the local-pharmacy search feature and
+ * needs the Geocoder to return real coordinates.
+ */
+export function stubGoogleMaps(geocodeResults: google.maps.GeocoderResult[] = []) {
+  Object.defineProperty(window, 'google', {
+    configurable: true,
+    writable: true,
+    value: {
+      maps: {
+        Geocoder: class Geocoder {
+          geocode = vi.fn(async () => ({ results: geocodeResults }));
+        },
+        places: { AutocompleteService: class AutocompleteService {} }
+      }
+    }
+  });
+}
+
+/** Builds a minimal Geocoder result for `stubGoogleMaps`. */
+export function makeGeocodeResult(
+  lat: number,
+  lng: number,
+  formattedAddress: string
+): google.maps.GeocoderResult {
+  return {
+    geometry: {
+      location: { lat: () => lat, lng: () => lng } as google.maps.LatLng
+    } as google.maps.GeocoderGeometry,
+    formatted_address: formattedAddress
+  } as google.maps.GeocoderResult;
+}

--- a/packages/elements/src/photon-multirx-form/test-utils/stub-google-maps.ts
+++ b/packages/elements/src/photon-multirx-form/test-utils/stub-google-maps.ts
@@ -1,5 +1,6 @@
 /// <reference types="google.maps" />
 import { vi } from 'vitest';
+import LatLngBounds = google.maps.LatLngBounds;
 
 /**
  * Stubs `window.google.maps` so code paths that touch the Google Maps SDK
@@ -22,16 +23,26 @@ export function stubGoogleMaps(geocodeResults: google.maps.GeocoderResult[] = []
   });
 }
 
-/** Builds a minimal Geocoder result for `stubGoogleMaps`. */
 export function makeGeocodeResult(
   lat: number,
   lng: number,
   formattedAddress: string
 ): google.maps.GeocoderResult {
   return {
+    address_components: [],
+    place_id: 'stub-google-maps-place-id',
+    types: [],
     geometry: {
-      location: { lat: () => lat, lng: () => lng } as google.maps.LatLng
-    } as google.maps.GeocoderGeometry,
+      location: {
+        lat: () => lat,
+        lng: () => lng,
+        equals: vi.fn(),
+        toJSON: vi.fn(),
+        toUrlValue: vi.fn()
+      },
+      location_type: google.maps.GeocoderLocationType.APPROXIMATE,
+      viewport: new LatLngBounds()
+    },
     formatted_address: formattedAddress
-  } as google.maps.GeocoderResult;
+  };
 }

--- a/packages/elements/src/photon-multirx-form/test-utils/stub-google-maps.ts
+++ b/packages/elements/src/photon-multirx-form/test-utils/stub-google-maps.ts
@@ -1,12 +1,11 @@
 /// <reference types="google.maps" />
 import { vi } from 'vitest';
-import LatLngBounds = google.maps.LatLngBounds;
 
 /**
  * Stubs `window.google.maps` so code paths that touch the Google Maps SDK
  * (Geocoder, places.AutocompleteService) don't blow up in jsdom. Pass
- * `geocodeResults` when the test exercises the local-pharmacy search feature and
- * needs the Geocoder to return real coordinates.
+ * `geocodeResults` when the test exercises the local-pharmacy search feature
+ * and needs the Geocoder to return real coordinates.
  */
 export function stubGoogleMaps(geocodeResults: google.maps.GeocoderResult[] = []) {
   Object.defineProperty(window, 'google', {
@@ -23,6 +22,14 @@ export function stubGoogleMaps(geocodeResults: google.maps.GeocoderResult[] = []
   });
 }
 
+/**
+ * Builds a minimal Geocoder result. The production code that consumes this
+ * only reads `result.geometry.location.lat() / .lng()` and
+ * `result.formatted_address`; the other fields exist to satisfy the type but
+ * are stubbed with empty / cast values so we don't depend on Google Maps
+ * runtime classes (LatLngBounds, GeocoderLocationType) that aren't installed
+ * on the stubbed `window.google`.
+ */
 export function makeGeocodeResult(
   lat: number,
   lng: number,
@@ -40,8 +47,8 @@ export function makeGeocodeResult(
         toJSON: vi.fn(),
         toUrlValue: vi.fn()
       },
-      location_type: google.maps.GeocoderLocationType.APPROXIMATE,
-      viewport: new LatLngBounds()
+      location_type: 'APPROXIMATE' as google.maps.GeocoderLocationType,
+      viewport: {} as google.maps.LatLngBounds
     },
     formatted_address: formattedAddress
   };

--- a/packages/elements/src/photon-multirx-form/test-utils/test-element-setup.tsx
+++ b/packages/elements/src/photon-multirx-form/test-utils/test-element-setup.tsx
@@ -13,8 +13,8 @@ export function renderPrescribeWorkflow(props: Partial<PrescribeWorkflowComponen
   const clientStore = createTestClientStore(client);
   const eventListenerHost = document.createElement('div');
 
-  // Capture bubbled CustomEvents from inside the prescribe workflow. Listeners
-  // must be attached BEFORE render so events fired during mount aren't missed.
+  // Capture bubbled CustomEvents dispatched from inside the prescribe workflow.
+  // Listeners must be attached BEFORE render so events fired during mount aren't missed.
   const analyticsEvents: CustomEvent[] = [];
   const attestationResolvedEvents: Event[] = [];
   eventListenerHost.addEventListener('photon-analytics-track-event', (event: Event) => {

--- a/packages/elements/src/photon-multirx-form/test-utils/test-element-setup.tsx
+++ b/packages/elements/src/photon-multirx-form/test-utils/test-element-setup.tsx
@@ -12,6 +12,18 @@ export function renderPrescribeWorkflow(props: Partial<PrescribeWorkflowComponen
   const client = createTestClient();
   const clientStore = createTestClientStore(client);
   const eventListenerHost = document.createElement('div');
+
+  // Capture bubbled CustomEvents from inside the prescribe workflow. Listeners
+  // must be attached BEFORE render so events fired during mount aren't missed.
+  const analyticsEvents: CustomEvent[] = [];
+  const attestationResolvedEvents: Event[] = [];
+  eventListenerHost.addEventListener('photon-analytics-track-event', (event: Event) => {
+    analyticsEvents.push(event as CustomEvent);
+  });
+  eventListenerHost.addEventListener('photon-signature-attestation-resolved', (event: Event) => {
+    attestationResolvedEvents.push(event);
+  });
+
   document.body.append(eventListenerHost);
 
   const baseProps: PrescribeWorkflowComponentProps = {
@@ -53,6 +65,10 @@ export function renderPrescribeWorkflow(props: Partial<PrescribeWorkflowComponen
     await screen.findByRole('button', { name: /add prescription/i }, { timeout: 3000 });
   }
 
+  async function waitForSignatureAttestationModal() {
+    await screen.findByText('Prescriber Signature Attestation');
+  }
+
   async function addDraftPrescription() {
     await user.selectOptions(screen.getByLabelText(/search for treatment/i), TREATMENT.id);
     await user.type(screen.getByLabelText(/quantity/i), '30');
@@ -66,5 +82,14 @@ export function renderPrescribeWorkflow(props: Partial<PrescribeWorkflowComponen
     await user.click(screen.getByRole('button', { name: /add prescription/i }));
   }
 
-  return { ...view, user, waitForPrescribeForm, addDraftPrescription };
+  return {
+    ...view,
+    user,
+    eventListenerHost,
+    analyticsEvents,
+    attestationResolvedEvents,
+    waitForPrescribeForm,
+    waitForSignatureAttestationModal,
+    addDraftPrescription
+  };
 }

--- a/packages/elements/src/photon-multirx-form/test-utils/test-element-setup.tsx
+++ b/packages/elements/src/photon-multirx-form/test-utils/test-element-setup.tsx
@@ -1,0 +1,70 @@
+import {
+  PhotonPrescribeWorkflowComponent,
+  PrescribeWorkflowComponentProps
+} from '../photon-prescribe-workflow-component';
+import { createTestClient, createTestClientStore } from '../../test-utils/createTestClient';
+import { render, screen } from '@solidjs/testing-library';
+import { GoogleServiceProvider, PhotonContext, SDKProvider } from '@photonhealth/components';
+import userEvent from '@testing-library/user-event/dist/cjs/index.js';
+import { DISPENSE_UNIT, TREATMENT } from '@photonhealth/sdk/test-utils';
+
+export function renderPrescribeWorkflow(props: Partial<PrescribeWorkflowComponentProps> = {}) {
+  const client = createTestClient();
+  const clientStore = createTestClientStore(client);
+  const eventListenerHost = document.createElement('div');
+  document.body.append(eventListenerHost);
+
+  const baseProps: PrescribeWorkflowComponentProps = {
+    patientId: 'pat_123',
+    hideSubmit: false,
+    hideTemplates: false,
+    hidePatientCard: false,
+    enableOrder: false,
+    enableMedHistory: false,
+    enableMedHistoryLinks: false,
+    enableMedHistoryRefillButton: false,
+    enableCombineAndDuplicate: false,
+    optionalPatientAddress: false,
+    triggerSubmit: false,
+    toastBuffer: 0,
+    enableCoverageCheck: false,
+    enableLocalPickup: false,
+    enableSendToPatient: false,
+    enableDeliveryPharmacies: false
+  };
+
+  const mergedProps = { ...baseProps, ...props };
+  const user = userEvent.setup();
+
+  const view = render(
+    () => (
+      <PhotonContext.Provider value={clientStore as never}>
+        <SDKProvider client={client as never}>
+          <GoogleServiceProvider>
+            <PhotonPrescribeWorkflowComponent {...mergedProps} />
+          </GoogleServiceProvider>
+        </SDKProvider>
+      </PhotonContext.Provider>
+    ),
+    { container: eventListenerHost }
+  );
+
+  async function waitForPrescribeForm() {
+    await screen.findByRole('button', { name: /add prescription/i }, { timeout: 3000 });
+  }
+
+  async function addDraftPrescription() {
+    await user.selectOptions(screen.getByLabelText(/search for treatment/i), TREATMENT.id);
+    await user.type(screen.getByLabelText(/quantity/i), '30');
+    await user.selectOptions(screen.getByLabelText(/dispense unit/i), DISPENSE_UNIT.name);
+    await user.type(screen.getByLabelText(/days supply/i), '10');
+    await user.type(screen.getByLabelText(/^refills/i), '0');
+    await user.type(
+      screen.getByLabelText(/patient instructions/i),
+      'Take one capsule by mouth daily'
+    );
+    await user.click(screen.getByRole('button', { name: /add prescription/i }));
+  }
+
+  return { ...view, user, waitForPrescribeForm, addDraftPrescription };
+}

--- a/packages/sdk/src/graphql/clinical-api/query.ts
+++ b/packages/sdk/src/graphql/clinical-api/query.ts
@@ -22,6 +22,7 @@ export const SearchTreatmentOptionsQuery = graphql(`
 export const MeUserQuery = graphql(`
   query MeUserQuery {
     me {
+      id
       credentials
       address {
         state

--- a/packages/sdk/src/test-utils/fixtures.ts
+++ b/packages/sdk/src/test-utils/fixtures.ts
@@ -34,7 +34,7 @@ export const DISPENSE_UNIT = {
 };
 
 export const PROVIDER = {
-  id: 'prov_1',
+  id: 'usr_1',
   email: 'doc@test.com',
   credentials: 'MD',
   name: {

--- a/packages/sdk/src/test-utils/msw-handlers.ts
+++ b/packages/sdk/src/test-utils/msw-handlers.ts
@@ -22,6 +22,7 @@ const servicesHandlers = [
     HttpResponse.json({
       data: {
         me: {
+          __typename: 'User',
           id: PROVIDER.id,
           signatureAttestationStatus: {
             __typename: 'CompletedSignatureAttestation',
@@ -41,7 +42,14 @@ const servicesHandlers = [
 
   clinicalGql.query('MeUserQuery', () =>
     HttpResponse.json({
-      data: { me: { id: PROVIDER.id, credentials: 'MD', address: { state: 'NY' } } }
+      data: {
+        me: {
+          __typename: 'User',
+          id: PROVIDER.id,
+          credentials: 'MD',
+          address: { __typename: 'Address', state: 'NY' }
+        }
+      }
     })
   ),
 

--- a/packages/sdk/src/test-utils/msw-handlers.ts
+++ b/packages/sdk/src/test-utils/msw-handlers.ts
@@ -22,6 +22,7 @@ const servicesHandlers = [
     HttpResponse.json({
       data: {
         me: {
+          id: PROVIDER.id,
           signatureAttestationStatus: {
             __typename: 'CompletedSignatureAttestation',
             agreedAt: new Date().toISOString(),
@@ -40,7 +41,7 @@ const servicesHandlers = [
 
   clinicalGql.query('MeUserQuery', () =>
     HttpResponse.json({
-      data: { me: { credentials: 'MD', address: { state: 'NY' } } }
+      data: { me: { id: PROVIDER.id, credentials: 'MD', address: { state: 'NY' } } }
     })
   ),
 


### PR DESCRIPTION
Prep work for feature to show RTPB errors in KLU-275. No feature changes here!

* Backfill RTPB tests
* Setup some test-utils to make it easier to test the solidjs embed
* Updated a few query operations (unique names, add an id param for multiple `me` queries cache key). These resolved a few Apollo warnings that pollute test logs, but there are many more to cleanup.

Part of KLU-275