### PR TITLE
Add slightly more graceful error handling in catalog treatment search

### DIFF
--- a/apps/app/src/views/routes/Settings/components/treatments/TreatmentOptionSearch.tsx
+++ b/apps/app/src/views/routes/Settings/components/treatments/TreatmentOptionSearch.tsx
@@ -75,21 +75,27 @@ export const TreatmentOptionSearch = ({
       setError(undefined);
 
       try {
-        const { data } = await clinicalClient.query({
+        const { data, errors } = await clinicalClient.query({
           query: SearchTreatmentOptionsQuery,
           variables: { filter: { term: searchTermDebounce } }
         });
 
+        if (errors?.length) {
+          console.log('Treatment Search Error:', { errors });
+          throw new Error('An error occured in this search');
+        }
+
         setTreatments(
-          data.treatments?.map((treatmentOption: { id: string; name: string }) => ({
+          data?.treatments?.map((treatmentOption: { id: string; name: string }) => ({
             value: treatmentOption.id,
             label: treatmentOption.name,
             searchTerm: searchTermDebounce
           }))
         );
       } catch (err) {
+        const error = err as Error;
         setLoading(false);
-        setError(err as string);
+        setError(error.message);
       } finally {
         setLoading(false);
       }


### PR DESCRIPTION
From zpaper report and ticket [X-169](https://linear.app/photon-health/issue/X-169/prevent-white-screen-when-drug-catalog-search-fails)

Right now the backend is returning `null` for data and a list of items under `errors` when the user searches `ig` in neutron. Because the data is null, we get a NPE on the `setTreatments` line. Just adding some nullish coalescing to at least avoid the white screen, log the errors to the console, and present a human readable error message. 

This is the error message from the backend, and is a separate issue tracked in X-170 but we should probably do something about this package_ndc collision case when searching for something that already has an NDC in one of our tables from medispan. 

```
{"errors":[{"message":"Error creating device: insert into \"medical_equipment\" (\"description\", \"hcpcs_code\", \"hri\", \"id\", \"medispan_id\", \"name\", \"package_ndc\", \"upc\") values ($1, $2, $3, $4, $5, $6, $7, $8) on conflict (\"medispan_id\") do update set \"name\" = $9,\"medispan_id\" = $10,\"package_ndc\" = $11,\"upc\" = $12,\"hri\" = $13 returning \"id\", \"name\", \"hcpcs_code\", \"description\", \"medispan_id\", \"package_ndc\", \"upc\", \"hri\" - duplicate key value violates unique constraint \"medical_equipment_package_ndc_unique\"","path":["treatments"],"extensions":{"type":"DATA_ERROR","code":"READ_ID","header":"x-photon-data","status_code":500,"serviceName":"monolith"}}],"data":null}
```
