### PR TITLE
Provider side reroutes

### DIFF
--- a/apps/app/codegen.ts
+++ b/apps/app/codegen.ts
@@ -14,6 +14,7 @@ const config: CodegenConfig = {
   schema: schemaByEnv[env],
   documents: [
     'src/**/Settings/**/*.tsx',
+    'src/mutations/clinical-api/*.ts',
     'src/views/routes/PrescriptionForm.tsx',
     'src/views/routes/UpdatePatientForm.tsx',
     'src/views/routes/NewPatient/PatientForm.tsx',

--- a/apps/app/codegen.ts
+++ b/apps/app/codegen.ts
@@ -14,6 +14,7 @@ const config: CodegenConfig = {
   schema: schemaByEnv[env],
   documents: [
     'src/**/Settings/**/*.tsx',
+    'src/queries/clinical-api/*.ts',
     'src/mutations/clinical-api/*.ts',
     'src/views/routes/PrescriptionForm.tsx',
     'src/views/routes/UpdatePatientForm.tsx',

--- a/apps/app/codegen.ts
+++ b/apps/app/codegen.ts
@@ -14,6 +14,7 @@ const config: CodegenConfig = {
   schema: schemaByEnv[env],
   documents: [
     'src/**/Settings/**/*.tsx',
+    // should move all future queries/mutations to these two folders, for reusability and codegen
     'src/queries/clinical-api/*.ts',
     'src/mutations/clinical-api/*.ts',
     'src/views/routes/PrescriptionForm.tsx',

--- a/apps/app/src/App.tsx
+++ b/apps/app/src/App.tsx
@@ -14,7 +14,7 @@ import { Logout } from './views/routes/Logout';
 import { Main } from './views/routes/Main';
 import { NewOrder } from './views/routes/NewOrder';
 import { NotFound } from './views/routes/NotFound';
-import { Order } from './views/routes/Order';
+import { OrderDetailPage } from './views/routes/Order';
 import { Orders } from './views/routes/Orders';
 import { Patient } from './views/routes/PatientDetails';
 import { PatientForm } from './views/routes/NewPatient/PatientForm';
@@ -79,7 +79,7 @@ export const App = () => {
                 <Route path="/orders">
                   <Route path="/orders" element={<Orders />} />
                   <Route path="new" element={<NewOrder />} />
-                  <Route path=":orderId" element={<Order />} />
+                  <Route path=":orderId" element={<OrderDetailPage />} />
                 </Route>
               </Route>
               <Route path="/support" element={<Support />} />

--- a/apps/app/src/hooks/usePermissions.ts
+++ b/apps/app/src/hooks/usePermissions.ts
@@ -3,11 +3,18 @@ import jwtDecode from 'jwt-decode';
 import { Permission } from 'packages/sdk/dist/types';
 import { useEffect, useState } from 'react';
 
-function checkHasPermission(subset: Permission[], superset: Permission[]) {
+function hasEveryPermission(subset: Permission[], superset: Permission[]) {
   return subset.every((permission) => superset.includes(permission));
 }
 
-const usePermissions = (permissions: Permission[]) => {
+function hasAnyPermission(subset: Permission[], superset: Permission[]) {
+  return subset.some((permission) => superset.includes(permission));
+}
+
+const usePermissions = (
+  permissions: Permission[],
+  { hasAny = false }: { hasAny?: boolean } = {}
+) => {
   const [userPermissions, setUserPermissions] = useState<Permission[]>([]);
   const { getToken } = usePhoton();
 
@@ -26,7 +33,9 @@ const usePermissions = (permissions: Permission[]) => {
     getPermissions();
   }, []);
 
-  return checkHasPermission(permissions, userPermissions);
+  return hasAny
+    ? hasAnyPermission(permissions, userPermissions)
+    : hasEveryPermission(permissions, userPermissions);
 };
 
 export default usePermissions;

--- a/apps/app/src/hooks/useProviderAnalytics.tsx
+++ b/apps/app/src/hooks/useProviderAnalytics.tsx
@@ -29,6 +29,10 @@ const ANALYTICS_CONTEXT_QUERY = gql`
         middle
         title
       }
+      roles {
+        id
+        name
+      }
     }
     organization {
       customer {
@@ -50,6 +54,7 @@ export interface ProviderContextData {
   providerName?: string;
   providerNameFirst?: string;
   providerNameLast?: string;
+  providerRoles?: string[];
   // Organization info
   orgId?: string;
   orgName?: string;
@@ -119,6 +124,7 @@ export const ProviderAnalyticsProvider = ({ children }: ProviderAnalyticsProvide
       providerName: data?.me?.name?.full,
       providerNameFirst: data?.me?.name?.first,
       providerNameLast: data?.me?.name?.last,
+      providerRoles: data?.me?.roles?.map((role: { name: string }) => role.name),
       // Organization info
       orgId: data?.organization?.id,
       orgName: data?.organization?.name,

--- a/apps/app/src/mutations/clinical-api/index.ts
+++ b/apps/app/src/mutations/clinical-api/index.ts
@@ -1,0 +1,1 @@
+export * from './orders';

--- a/apps/app/src/mutations/clinical-api/orders.ts
+++ b/apps/app/src/mutations/clinical-api/orders.ts
@@ -1,0 +1,7 @@
+import { graphql } from 'apps/app/src/gql';
+
+export const rerouteOrderMutation = graphql(/* GraphQL */ `
+  mutation RerouteOrder($orderId: ID!, $pharmacyId: ID) {
+    rerouteOrder(orderId: $orderId, pharmacyId: $pharmacyId)
+  }
+`);

--- a/apps/app/src/mutations/index.ts
+++ b/apps/app/src/mutations/index.ts
@@ -10,7 +10,7 @@ export const CANCEL_ORDER = gql`
   }
 `;
 
-export const REROUTE_ORDER = gql`
+export const ROUTE_ORDER = gql`
   mutation RouteOrder($id: ID!, $pharmacyId: ID!) {
     routeOrder(id: $id, pharmacyId: $pharmacyId) {
       id

--- a/apps/app/src/queries/clinical-api/index.ts
+++ b/apps/app/src/queries/clinical-api/index.ts
@@ -1,0 +1,1 @@
+export * from './orders';

--- a/apps/app/src/queries/clinical-api/orders.ts
+++ b/apps/app/src/queries/clinical-api/orders.ts
@@ -1,0 +1,18 @@
+import { graphql } from 'apps/app/src/gql';
+
+export const getOrderRoutingHistory = graphql(/* GraphQL */ `
+  query GetOrder($id: ID!) {
+    order(id: $id) {
+      routingHistory {
+        pharmacy {
+          id
+          name
+          fulfillmentTypes
+        }
+        selector
+        reason
+        createdAt
+      }
+    }
+  }
+`);

--- a/apps/app/src/queries/clinical-api/orders.ts
+++ b/apps/app/src/queries/clinical-api/orders.ts
@@ -8,6 +8,17 @@ export const getOrderRoutingHistory = graphql(/* GraphQL */ `
           id
           name
           fulfillmentTypes
+          id
+          name
+          phone
+          address {
+            city
+            country
+            postalCode
+            state
+            street1
+            street2
+          }
         }
         selector
         reason

--- a/apps/app/src/queries/index.ts
+++ b/apps/app/src/queries/index.ts
@@ -1,0 +1,1 @@
+export * from './lambda-api';

--- a/apps/app/src/queries/index.ts
+++ b/apps/app/src/queries/index.ts
@@ -1,1 +1,2 @@
+export * from './clinical-api';
 export * from './lambda-api';

--- a/apps/app/src/queries/lambda-api/index.ts
+++ b/apps/app/src/queries/lambda-api/index.ts
@@ -1,0 +1,2 @@
+export * from './orders';
+export * from './pharmacies';

--- a/apps/app/src/queries/lambda-api/orders.ts
+++ b/apps/app/src/queries/lambda-api/orders.ts
@@ -32,6 +32,7 @@ export const GET_ORDER = gql`
           instructions
         }
         treatment {
+          id
           name
         }
         state

--- a/apps/app/src/queries/lambda-api/orders.ts
+++ b/apps/app/src/queries/lambda-api/orders.ts
@@ -1,0 +1,71 @@
+import { gql } from '@apollo/client';
+import { PHARMACY_FRAGMENT } from './pharmacies';
+
+export const GET_ORDER_QUERY_NAME = 'GetOrder';
+export const GET_ORDER = gql`
+  ${PHARMACY_FRAGMENT}
+
+  query ${GET_ORDER_QUERY_NAME}($id: ID!) {
+    order(id: $id) {
+      __typename
+      id
+      externalId
+      state
+      address {
+        name {
+          full
+        }
+        city
+        country
+        postalCode
+        state
+        street1
+        street2
+      }
+      fills {
+        id
+        prescription {
+          id
+          dispenseQuantity
+          dispenseUnit
+          fillsAllowed
+          instructions
+        }
+        treatment {
+          name
+        }
+        state
+        requestedAt
+        filledAt
+      }
+      patient {
+        id
+        externalId
+        name {
+          full
+        }
+        dateOfBirth
+        sex
+        gender
+        email
+        phone
+      }
+      pharmacy {
+        ...PharmacyFragment
+      }
+      fulfillment {
+        type
+        state
+        carrier
+        trackingNumber
+      }
+      exceptions {
+        type
+        message
+        createdAt
+        resolvedAt
+      }
+      createdAt
+    }
+  }
+`;

--- a/apps/app/src/queries/lambda-api/pharmacies.ts
+++ b/apps/app/src/queries/lambda-api/pharmacies.ts
@@ -1,0 +1,27 @@
+import { gql } from '@apollo/client';
+
+export const PHARMACY_FRAGMENT = gql`
+  fragment PharmacyFragment on Pharmacy {
+    id
+    name
+    phone
+    address {
+      city
+      country
+      postalCode
+      state
+      street1
+      street2
+    }
+  }
+`;
+
+export const PHARMACY_QUERY = gql`
+  ${PHARMACY_FRAGMENT}
+
+  query GetPharmacy($id: ID!) {
+    pharmacy(id: $id) {
+      ...PharmacyFragment
+    }
+  }
+`;

--- a/apps/app/src/setupTests.ts
+++ b/apps/app/src/setupTests.ts
@@ -1,6 +1,7 @@
 import '@testing-library/jest-dom';
-import { vi } from 'vitest';
 import { randomUUID } from 'node:crypto';
+import { PhotonClient } from '@photonhealth/sdk';
+import { vi } from 'vitest';
 
 // Auth0 fix to get tests passing. This gets around the 'auth0-spa-js must run on a secure origin' error
 // More info https://github.com/auth0/auth0-spa-js/blob/master/FAQ.md#why-do-you-get-auth0-spa-js-must-run-on-a-secure-origin
@@ -23,4 +24,66 @@ vi.mock('@client/settings', () => ({
 // Datadog instrumentation context setter — no-op in tests
 vi.mock('./instrumentation/setInstrumentationUserContext', () => ({
   setInstrumentationUserContext: vi.fn()
+}));
+
+// ---------------------------------------------------------------------------
+// Shared test-harness state
+// ---------------------------------------------------------------------------
+// Lives here (not in `./test-utils/harness`) so the global `vi.mock` factories
+// below can read it without triggering an import cycle. `harness.tsx`
+// statically imports `useProviderAnalytics`, which imports `@photonhealth/
+// react` — the very module being mocked. If the mock factory dynamically
+// imported `harness.tsx`, the mocked module would resolve to a partial
+// namespace and Apollo queries would hang. Keeping the state in this file
+// (which has no app imports) avoids that cycle.
+//
+// `harness.tsx` re-imports `harness` from here for its `setupHarness` /
+// `renderWithProviders` helpers, so tests still access everything through
+// the `test-utils` barrel.
+
+type MockUser = { org_id?: string } | null;
+
+const photonClient = new PhotonClient({ clientId: 'test', env: 'tau' });
+photonClient.authentication.getAccessToken = vi.fn(async () => 'test-token');
+
+export const DEFAULT_USER: MockUser = { org_id: 'org_1' };
+
+export const harness: {
+  photonClient: PhotonClient;
+  user: MockUser;
+  isAuthenticated: boolean;
+  isLoading: boolean;
+  trackSpy: ReturnType<typeof vi.fn>;
+  identifySpy: ReturnType<typeof vi.fn>;
+} = {
+  photonClient,
+  // Mocked usePhoton return — mutable so tests can adjust auth/user state.
+  user: DEFAULT_USER,
+  isAuthenticated: true,
+  isLoading: false,
+  // Spies are mutable references (not replaced) so captured references in
+  // the vi.mock factories stay valid across tests; `.mockClear()` rather
+  // than reassign.
+  trackSpy: vi.fn(),
+  identifySpy: vi.fn()
+};
+
+// Sync vi.mock factories that read directly from the module-scope `harness`.
+// No dynamic import → no cycle.
+vi.mock('@photonhealth/react', () => ({
+  usePhoton: () => ({
+    isAuthenticated: harness.isAuthenticated,
+    isLoading: harness.isLoading,
+    user: harness.user,
+    clinicalClient: harness.photonClient.apolloClinical,
+    getToken: async () => 'test-token'
+  })
+}));
+
+vi.mock('./configs/providerAnalytics', () => ({
+  getProviderAnalytics: () => ({
+    track: (...args: unknown[]) => harness.trackSpy(...args),
+    identify: (...args: unknown[]) => harness.identifySpy(...args),
+    isInitialized: true
+  })
 }));

--- a/apps/app/src/test-utils/fixtures.ts
+++ b/apps/app/src/test-utils/fixtures.ts
@@ -1,0 +1,101 @@
+// Pure data factories for the clinical-app test suite. No side effects, no
+// shared state — every call returns a fresh object built from defaults with
+// shallow overrides applied last. Use `as unknown as T` casts to keep the
+// fixtures from re-asserting every nullable field in the generated GraphQL
+// types; tests only need the fields they assert against.
+import type {
+  Address,
+  Fill,
+  Order,
+  Patient,
+  Pharmacy,
+  Treatment
+} from '@photonhealth/sdk/dist/types';
+import { OrderState } from '@photonhealth/sdk/dist/types';
+
+export function makeAddress(overrides: Partial<Address> = {}): Address {
+  return {
+    __typename: 'Address',
+    street1: '123 Main St',
+    street2: null,
+    city: 'Brooklyn',
+    state: 'NY',
+    postalCode: '11211',
+    country: 'US',
+    ...overrides
+  } as unknown as Address;
+}
+
+export function makePharmacy(overrides: Partial<Pharmacy> = {}): Pharmacy {
+  return {
+    __typename: 'Pharmacy',
+    id: 'phr_default',
+    name: 'Default Pharmacy',
+    phone: '+15550000000',
+    address: makeAddress(),
+    ...overrides
+  } as unknown as Pharmacy;
+}
+
+export function makeTreatment(overrides: Partial<Treatment> = {}): Treatment {
+  return {
+    __typename: 'Treatment',
+    id: 'trt_default',
+    name: 'Default Treatment',
+    ...overrides
+  } as unknown as Treatment;
+}
+
+export function makeFill(overrides: Partial<Fill> = {}): Fill {
+  return {
+    __typename: 'Fill',
+    id: 'fill_default',
+    state: 'NEW',
+    requestedAt: '2026-01-01T00:00:00Z',
+    filledAt: null,
+    treatment: makeTreatment(),
+    prescription: {
+      __typename: 'Prescription',
+      id: 'rx_default',
+      dispenseQuantity: 30,
+      dispenseUnit: 'tablet',
+      fillsAllowed: 1,
+      instructions: 'Take as directed'
+    },
+    ...overrides
+  } as unknown as Fill;
+}
+
+export function makePatient(overrides: Partial<Patient> = {}): Patient {
+  return {
+    __typename: 'Patient',
+    id: 'pat_default',
+    externalId: null,
+    name: { __typename: 'Name', full: 'Sally Patient' },
+    dateOfBirth: '1990-01-01',
+    sex: 'FEMALE',
+    gender: 'female',
+    email: 'sally@example.com',
+    phone: '+17185551234',
+    address: null,
+    preferredPharmacies: [],
+    ...overrides
+  } as unknown as Patient;
+}
+
+export function makeOrder(overrides: Partial<Order> = {}): Order {
+  return {
+    __typename: 'Order',
+    id: 'ord_default',
+    externalId: null,
+    state: OrderState.Routing,
+    address: null,
+    fills: [makeFill()],
+    patient: makePatient(),
+    pharmacy: makePharmacy(),
+    fulfillment: null,
+    exceptions: [],
+    createdAt: '2026-01-01T00:00:00Z',
+    ...overrides
+  } as unknown as Order;
+}

--- a/apps/app/src/test-utils/harness.tsx
+++ b/apps/app/src/test-utils/harness.tsx
@@ -1,0 +1,91 @@
+// Test harness for the clinical app. Exposes:
+//   - the singleton `harness` state (photon client, mock-auth state, spies)
+//   - `setupHarness(...)` — installs Vitest lifecycle hooks for state isolation
+//   - `renderWithProviders(ui)` — wraps in Router + Chakra + Apollo + Analytics
+//   - `dispatchCustomEvent` — composed/bubbles helper for web-component events
+//
+// The mutable `harness` object lives in `../setupTests.ts` to avoid circular deps
+import { ApolloProvider } from '@apollo/client';
+import { ChakraProvider } from '@chakra-ui/react';
+import { defaultHandlers } from '@photonhealth/sdk/test-utils';
+import { render } from '@testing-library/react';
+import type { RequestHandler } from 'msw';
+import { setupServer } from 'msw/node';
+import type { ReactNode } from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { afterAll, afterEach, beforeAll, beforeEach } from 'vitest';
+
+import { ProviderAnalyticsProvider } from '../hooks/useProviderAnalytics';
+import { DEFAULT_USER, harness } from '../setupTests';
+
+// Re-export so test files can import everything through the `test-utils` barrel.
+export { harness } from '../setupTests';
+
+/**
+ * Install the test harness for the current spec file. Call once at module
+ * scope. Returns the shared spies, photon client, MSW server, and renderer.
+ *
+ * Per-test isolation:
+ *   - Apollo caches (lambdas + clinical) cleared before each test
+ *   - `trackSpy`/`identifySpy` cleared before each test
+ *   - Mutable `harness.user`/`isAuthenticated`/`isLoading` reset to defaults
+ *   - MSW handlers reset after each test (use `server.use(...)` in a
+ *     `beforeEach` block to add per-test handlers)
+ *
+ * @param initialHandlers Optional handlers added to the server in addition
+ *   to the shared `defaultHandlers` from `@photonhealth/sdk/test-utils`.
+ */
+export function setupHarness(...initialHandlers: RequestHandler[]) {
+  const server = setupServer(...defaultHandlers, ...initialHandlers);
+
+  beforeAll(() => server.listen({ onUnhandledRequest: 'warn' }));
+  afterAll(() => server.close());
+
+  beforeEach(async () => {
+    await harness.photonClient.apollo.clearStore();
+    await harness.photonClient.apolloClinical.clearStore();
+    harness.trackSpy.mockClear();
+    harness.identifySpy.mockClear();
+    harness.user = DEFAULT_USER;
+    harness.isAuthenticated = true;
+    harness.isLoading = false;
+  });
+
+  afterEach(() => {
+    server.resetHandlers();
+  });
+
+  return {
+    server,
+    photonClient: harness.photonClient,
+    trackSpy: harness.trackSpy,
+    identifySpy: harness.identifySpy,
+    renderWithProviders
+  };
+}
+
+/**
+ * Render `ui` inside the standard clinical-app provider tree. Apollo's
+ * default client is the lambdas client; the clinical client is reached via
+ * the mocked `usePhoton().clinicalClient`.
+ */
+export function renderWithProviders(ui: ReactNode) {
+  return render(
+    <MemoryRouter>
+      <ChakraProvider>
+        <ApolloProvider client={harness.photonClient.apollo}>
+          <ProviderAnalyticsProvider>{ui}</ProviderAnalyticsProvider>
+        </ApolloProvider>
+      </ChakraProvider>
+    </MemoryRouter>
+  );
+}
+
+/**
+ * Convenience: dispatch a `composed: true, bubbles: true` CustomEvent on a
+ * web-component element. Mirrors the way real Solid web components emit
+ * events through Shadow DOM boundaries.
+ */
+export function dispatchCustomEvent<TDetail>(el: HTMLElement, type: string, detail: TDetail) {
+  el.dispatchEvent(new CustomEvent(type, { bubbles: true, composed: true, detail }));
+}

--- a/apps/app/src/test-utils/index.ts
+++ b/apps/app/src/test-utils/index.ts
@@ -1,0 +1,2 @@
+export * from './fixtures';
+export * from './harness';

--- a/apps/app/src/views/components/Dialog.tsx
+++ b/apps/app/src/views/components/Dialog.tsx
@@ -1,0 +1,136 @@
+// A minimal Chakra-styled dialog without the Chakra `Modal` machinery
+// (no Portal, no react-focus-lock, no react-remove-scroll). Use this when
+// the dialog contains a Solid web component (`<photon-*>`); the libraries
+// Modal pulls in interfere with shadow-DOM event/scroll handling.
+import { Box, BoxProps, Flex } from '@chakra-ui/react';
+import { createContext, ReactNode, useContext, useEffect, useId, useMemo, useRef } from 'react';
+
+type DialogSize = 'sm' | 'md' | 'lg' | 'xl' | '2xl' | '3xl';
+
+const SIZE_MAX_W: Record<DialogSize, string> = {
+  sm: '24rem',
+  md: '28rem',
+  lg: '32rem',
+  xl: '36rem',
+  '2xl': '42rem',
+  '3xl': '48rem'
+};
+
+interface DialogContextValue {
+  onClose: () => void;
+  labelId: string;
+}
+
+const DialogContext = createContext<DialogContextValue | null>(null);
+
+const useDialogContext = () => {
+  const ctx = useContext(DialogContext);
+  if (!ctx)
+    throw new Error('Dialog.Header / Dialog.Body / Dialog.Footer must be used inside <Dialog>');
+  return ctx;
+};
+
+interface DialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  size?: DialogSize;
+  closeOnOverlayClick?: boolean;
+  closeOnEsc?: boolean;
+  children: ReactNode;
+}
+
+const DialogRoot = ({
+  isOpen,
+  onClose,
+  size = 'md',
+  closeOnOverlayClick = true,
+  closeOnEsc = true,
+  children
+}: DialogProps) => {
+  const labelId = useId();
+  const value = useMemo(() => ({ onClose, labelId }), [onClose, labelId]);
+  const mouseDownTargetRef = useRef<EventTarget | null>(null);
+
+  useEffect(() => {
+    if (!isOpen || !closeOnEsc) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.stopPropagation();
+        onClose();
+      }
+    };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [isOpen, closeOnEsc, onClose]);
+
+  if (!isOpen) return null;
+
+  // Only close on overlay click if the gesture both started and ended on the
+  // overlay itself — otherwise dragging text from inside the dialog and
+  // releasing outside would close it.
+  const handleOverlayMouseDown = (e: React.MouseEvent) => {
+    mouseDownTargetRef.current = e.target;
+  };
+  const handleOverlayClick = (e: React.MouseEvent) => {
+    if (!closeOnOverlayClick) return;
+    if (mouseDownTargetRef.current === e.currentTarget) onClose();
+  };
+
+  return (
+    <DialogContext.Provider value={value}>
+      <Flex
+        position="fixed"
+        inset={0}
+        bg="blackAlpha.600"
+        align="center"
+        justify="center"
+        zIndex="modal"
+        onMouseDown={handleOverlayMouseDown}
+        onClick={handleOverlayClick}
+      >
+        <Box
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby={labelId}
+          bg="white"
+          borderRadius="md"
+          shadow="lg"
+          maxW={SIZE_MAX_W[size]}
+          w="90vw"
+          maxH="90vh"
+          display="flex"
+          flexDirection="column"
+        >
+          {children}
+        </Box>
+      </Flex>
+    </DialogContext.Provider>
+  );
+};
+
+const DialogHeader = ({ children }: { children: ReactNode }) => {
+  const { labelId } = useDialogContext();
+  return (
+    <Box id={labelId} px={6} py={4} borderBottomWidth="1px" fontSize="lg" fontWeight="semibold">
+      {children}
+    </Box>
+  );
+};
+
+const DialogBody = ({ children, ...boxProps }: { children: ReactNode } & BoxProps) => (
+  <Box flex="1" overflowY="scroll" px={6} py={4} {...boxProps}>
+    {children}
+  </Box>
+);
+
+const DialogFooter = ({ children }: { children: ReactNode }) => (
+  <Flex px={6} py={4} borderTopWidth="1px" justify="flex-end" gap={2}>
+    {children}
+  </Flex>
+);
+
+export const Dialog = Object.assign(DialogRoot, {
+  Header: DialogHeader,
+  Body: DialogBody,
+  Footer: DialogFooter
+});

--- a/apps/app/src/views/components/Dialog.tsx
+++ b/apps/app/src/views/components/Dialog.tsx
@@ -2,7 +2,7 @@
 // (no Portal, no react-focus-lock, no react-remove-scroll). Use this when
 // the dialog contains a Solid web component (`<photon-*>`); the libraries
 // Modal pulls in interfere with shadow-DOM event/scroll handling.
-import { Box, BoxProps, Flex } from '@chakra-ui/react';
+import { Box, BoxProps, Flex, FlexProps } from '@chakra-ui/react';
 import { createContext, ReactNode, useContext, useEffect, useId, useMemo, useRef } from 'react';
 
 type DialogSize = 'sm' | 'md' | 'lg' | 'xl' | '2xl' | '3xl';
@@ -98,6 +98,7 @@ const DialogRoot = ({
           maxW={SIZE_MAX_W[size]}
           w="90vw"
           maxH="90vh"
+          overflowY="scroll"
           display="flex"
           flexDirection="column"
         >
@@ -118,13 +119,13 @@ const DialogHeader = ({ children }: { children: ReactNode }) => {
 };
 
 const DialogBody = ({ children, ...boxProps }: { children: ReactNode } & BoxProps) => (
-  <Box flex="1" overflowY="scroll" px={6} py={4} {...boxProps}>
+  <Box flex="1" px={6} py={4} {...boxProps}>
     {children}
   </Box>
 );
 
-const DialogFooter = ({ children }: { children: ReactNode }) => (
-  <Flex px={6} py={4} borderTopWidth="1px" justify="flex-end" gap={2}>
+const DialogFooter = ({ children, ...flexProps }: { children: ReactNode } & FlexProps) => (
+  <Flex px={6} py={4} borderTopWidth="1px" justify="flex-end" gap={2} bg="white" {...flexProps}>
     {children}
   </Flex>
 );

--- a/apps/app/src/views/components/RerouteOrderButton.test.tsx
+++ b/apps/app/src/views/components/RerouteOrderButton.test.tsx
@@ -1,0 +1,370 @@
+import { ApolloProvider } from '@apollo/client';
+import { ChakraProvider } from '@chakra-ui/react';
+import { PhotonClient } from '@photonhealth/sdk';
+import type { Order, Pharmacy } from '@photonhealth/sdk/dist/types';
+import { FulfillmentType, OrderState } from '@photonhealth/sdk/dist/types';
+import { clinicalGql, defaultHandlers, lambdasGql } from '@photonhealth/sdk/test-utils';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import { MemoryRouter } from 'react-router-dom';
+import { afterAll, afterEach, beforeAll, beforeEach, expect, test, vi } from 'vitest';
+
+import { ProviderAnalyticsProvider } from '../../hooks/useProviderAnalytics';
+import { GET_ORDER } from '../../queries';
+import { RerouteOrderButton } from './RerouteOrderButton';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const ORDER_ID = 'ord_test123';
+const PATIENT_ID = 'pat_456';
+const ORIGINAL_PHARMACY_ID = 'phr_original';
+const NEW_PHARMACY_ID = 'phr_new';
+
+const ORIGINAL_PHARMACY = {
+  __typename: 'Pharmacy',
+  id: ORIGINAL_PHARMACY_ID,
+  name: 'Original Pharmacy',
+  phone: '+15551110000',
+  address: {
+    __typename: 'Address',
+    city: 'Brooklyn',
+    country: 'US',
+    postalCode: '11211',
+    state: 'NY',
+    street1: '123 Main St',
+    street2: null
+  }
+} as unknown as Pharmacy;
+
+const NEW_PHARMACY = {
+  __typename: 'Pharmacy',
+  id: NEW_PHARMACY_ID,
+  name: 'New Pharmacy',
+  phone: '+15552220000',
+  address: {
+    __typename: 'Address',
+    city: 'Queens',
+    country: 'US',
+    postalCode: '11375',
+    state: 'NY',
+    street1: '456 Side St',
+    street2: null
+  }
+} as unknown as Pharmacy;
+
+const FIXTURE_ORDER = {
+  __typename: 'Order',
+  id: ORDER_ID,
+  externalId: null,
+  state: OrderState.Routing,
+  address: null,
+  fills: [
+    {
+      __typename: 'Fill',
+      id: 'fill_1',
+      prescription: {
+        __typename: 'Prescription',
+        id: 'rx_1',
+        dispenseQuantity: 30,
+        dispenseUnit: 'tablet',
+        fillsAllowed: 1,
+        instructions: 'Take 1 daily'
+      },
+      treatment: { __typename: 'Treatment', id: 'trt_1', name: 'Amoxicillin' },
+      state: 'NEW',
+      requestedAt: '2026-05-01T00:00:00Z',
+      filledAt: null
+    }
+  ],
+  patient: {
+    __typename: 'Patient',
+    id: PATIENT_ID,
+    externalId: null,
+    name: { __typename: 'Name', full: 'Sally Patient' },
+    dateOfBirth: '1990-01-01',
+    sex: 'FEMALE',
+    gender: 'female',
+    email: 'sally@example.com',
+    phone: '+17185551234'
+  },
+  pharmacy: ORIGINAL_PHARMACY,
+  fulfillment: null,
+  exceptions: [],
+  createdAt: '2026-05-01T00:00:00Z'
+} as unknown as Order;
+
+// ---------------------------------------------------------------------------
+// MSW + Apollo client setup
+// ---------------------------------------------------------------------------
+
+// Spies for asserting the right operations fired with the right variables.
+const rerouteOrderSpy = vi.fn();
+const getPharmacySpy = vi.fn();
+
+const server = setupServer(
+  ...defaultHandlers,
+  // RerouteOrder lives on the clinical (services) API.
+  clinicalGql.mutation('RerouteOrder', async ({ variables }) => {
+    rerouteOrderSpy(variables);
+    return HttpResponse.json({ data: { rerouteOrder: true } });
+  }),
+  // The routing-history GetOrder lives on clinical too — empty history is fine.
+  clinicalGql.query('GetOrder', () =>
+    HttpResponse.json({
+      data: { order: { __typename: 'Order', id: ORDER_ID, routingHistory: [] } }
+    })
+  ),
+  // PHARMACY_QUERY runs against the lambdas client to fetch the new pharmacy
+  // for analytics + the cross-client cache update.
+  lambdasGql.query('GetPharmacy', ({ variables }) => {
+    getPharmacySpy(variables);
+    return HttpResponse.json({ data: { pharmacy: NEW_PHARMACY } });
+  })
+);
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'warn' }));
+afterEach(() => {
+  server.resetHandlers();
+  vi.clearAllMocks();
+});
+afterAll(() => server.close());
+
+// Use a real PhotonClient so we get a real Apollo Client per endpoint
+// (apollo = lambdas, apolloClinical = services). MSW intercepts the HTTP.
+const photonClient = new PhotonClient({ clientId: 'test', env: 'tau' });
+photonClient.authentication.getAccessToken = vi.fn(async () => 'test-token');
+
+vi.mock('@photonhealth/react', () => ({
+  usePhoton: () => ({
+    isAuthenticated: true,
+    isLoading: false,
+    user: { org_id: 'org_1' },
+    clinicalClient: photonClient.apolloClinical
+  })
+}));
+
+const rudderTrackSpy = vi.fn();
+const rudderIdentifySpy = vi.fn();
+vi.mock('../../configs/providerAnalytics', () => ({
+  getProviderAnalytics: () => ({
+    track: rudderTrackSpy,
+    isInitialized: true,
+    identify: rudderIdentifySpy
+  })
+}));
+
+beforeEach(async () => {
+  // Reset both Apollo caches so tests are isolated.
+  await photonClient.apollo.clearStore();
+  await photonClient.apolloClinical.clearStore();
+});
+
+// ---------------------------------------------------------------------------
+// Render helpers
+// ---------------------------------------------------------------------------
+
+function renderRerouteButton(order: Order = FIXTURE_ORDER) {
+  // Pre-populate the lambdas cache with GET_ORDER so the mutation's
+  // cross-client `update` callback has something to read + write.
+  photonClient.apollo.writeQuery({
+    query: GET_ORDER,
+    variables: { id: order.id },
+    data: { order }
+  });
+
+  return render(
+    <MemoryRouter>
+      <ChakraProvider>
+        <ApolloProvider client={photonClient.apollo}>
+          <ProviderAnalyticsProvider>
+            <RerouteOrderButton order={order} organizationId="org_1" />
+          </ProviderAnalyticsProvider>
+        </ApolloProvider>
+      </ChakraProvider>
+    </MemoryRouter>
+  );
+}
+
+function getCachedOrder(): Order | undefined {
+  return photonClient.apollo.readQuery<{ order: Order }>({
+    query: GET_ORDER,
+    variables: { id: ORDER_ID }
+  })?.order;
+}
+
+async function openReroute(order: Order = FIXTURE_ORDER) {
+  renderRerouteButton(order);
+  const user = userEvent.setup();
+  await user.click(screen.getByRole('button', { name: /reroute order/i }));
+  return user;
+}
+
+const getPharmacySelectElement = () => screen.findByTestId('pharmacy-select');
+
+function dispatchPharmacySelected(
+  el: HTMLElement,
+  detail: { pharmacyId?: string; fulfillmentType?: string }
+) {
+  el.dispatchEvent(
+    new CustomEvent('photon-pharmacy-selected', { bubbles: true, composed: true, detail })
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test('renders the Reroute Order trigger button', () => {
+  renderRerouteButton();
+  expect(screen.getByRole('button', { name: /reroute order/i })).toBeInTheDocument();
+});
+
+test('opens the dialog with photon-pharmacy-select and fires open analytics', async () => {
+  await openReroute();
+
+  expect(await screen.findByRole('dialog')).toBeInTheDocument();
+  const pharmacySelect = await getPharmacySelectElement();
+  expect(pharmacySelect).toHaveAttribute('patient-id', PATIENT_ID);
+  expect(pharmacySelect).toHaveAttribute('pharmacy-id', ORIGINAL_PHARMACY_ID);
+
+  expect(rudderTrackSpy).toHaveBeenCalledWith(
+    'Customer Clicked Reroute Order',
+    expect.objectContaining({
+      orderId: ORDER_ID,
+      patientId: PATIENT_ID,
+      medicationIds: ['trt_1'],
+      medicationNames: ['Amoxicillin']
+    })
+  );
+});
+
+test('Cancel closes the dialog and fires cancel analytics — no mutation', async () => {
+  const user = await openReroute();
+  await screen.findByRole('dialog');
+
+  await user.click(screen.getByRole('button', { name: /^cancel$/i }));
+
+  await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+  expect(rudderTrackSpy).toHaveBeenCalledWith(
+    'Cancel Reroute Order Clicked',
+    expect.objectContaining({ orderId: ORDER_ID })
+  );
+  expect(rerouteOrderSpy).not.toHaveBeenCalled();
+});
+
+test('Confirm button is disabled when a tab is selected but no pharmacy is chosen', async () => {
+  await openReroute();
+  const el = await getPharmacySelectElement();
+
+  // User picked the "Local Pickup" tab but hasn't chosen a pharmacy yet.
+  dispatchPharmacySelected(el, {
+    fulfillmentType: FulfillmentType.PickUp,
+    pharmacyId: undefined
+  });
+
+  await waitFor(() => {
+    expect(screen.getByRole('button', { name: /confirm reroute/i })).toBeDisabled();
+  });
+});
+
+test('Confirm fires mutation with selected pharmacy, updates lambdas cache, and fires analytics', async () => {
+  const user = await openReroute();
+  const el = await getPharmacySelectElement();
+
+  dispatchPharmacySelected(el, {
+    fulfillmentType: FulfillmentType.PickUp,
+    pharmacyId: NEW_PHARMACY_ID
+  });
+
+  await user.click(screen.getByRole('button', { name: /confirm reroute/i }));
+
+  // Mutation called against the clinical client with the chosen pharmacy.
+  await waitFor(() => {
+    expect(rerouteOrderSpy).toHaveBeenCalledWith({
+      orderId: ORDER_ID,
+      pharmacyId: NEW_PHARMACY_ID
+    });
+  });
+
+  // GetPharmacy was fetched on the lambdas client (for both analytics name + cache write).
+  expect(getPharmacySpy).toHaveBeenCalledWith({ id: NEW_PHARMACY_ID });
+
+  expect(rudderTrackSpy).toHaveBeenCalledWith(
+    'Confirm Reroute Order Clicked',
+    expect.objectContaining({
+      orderId: ORDER_ID,
+      pharmacyId: NEW_PHARMACY_ID,
+      pharmacyName: 'New Pharmacy',
+      routingType: 'Local Pick-up'
+    })
+  );
+
+  // Lambdas cache for GET_ORDER reflects the new pharmacy + Pending state.
+  await waitFor(() => {
+    const cached = getCachedOrder();
+    expect(cached?.state).toBe(OrderState.Pending);
+    expect(cached?.pharmacy?.id).toBe(NEW_PHARMACY_ID);
+  });
+
+  // Dialog closes on success.
+  await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+});
+
+test('Confirm with no pharmacy (Send to Patient) flips order back to Routing in cache', async () => {
+  const user = await openReroute();
+  const el = await getPharmacySelectElement();
+
+  // Send-to-Patient flow: no pharmacy chosen, fulfillmentType is undefined → confirm enabled.
+  dispatchPharmacySelected(el, { fulfillmentType: undefined, pharmacyId: undefined });
+
+  await user.click(screen.getByRole('button', { name: /confirm reroute/i }));
+
+  await waitFor(() => {
+    expect(rerouteOrderSpy).toHaveBeenCalledWith({ orderId: ORDER_ID, pharmacyId: '' });
+  });
+
+  // No PHARMACY_QUERY since there's no chosen pharmacy.
+  expect(getPharmacySpy).not.toHaveBeenCalled();
+
+  // Cache flips to Routing
+  await waitFor(() => {
+    expect(getCachedOrder()?.state).toBe(OrderState.Routing);
+  });
+});
+
+test('Confirm shows error toast and fires error analytics when mutation fails', async () => {
+  server.use(
+    clinicalGql.mutation('RerouteOrder', () =>
+      HttpResponse.json({
+        data: null,
+        errors: [{ message: 'pharmacy not accepting orders' }]
+      })
+    )
+  );
+
+  const user = await openReroute();
+  const el = await getPharmacySelectElement();
+  dispatchPharmacySelected(el, {
+    fulfillmentType: FulfillmentType.PickUp,
+    pharmacyId: NEW_PHARMACY_ID
+  });
+
+  await user.click(screen.getByRole('button', { name: /confirm reroute/i }));
+
+  expect(await screen.findByText(/error rerouting the order/i)).toBeInTheDocument();
+  expect(rudderTrackSpy).toHaveBeenCalledWith(
+    'Reroute Error Message Viewed',
+    expect.objectContaining({ orderId: ORDER_ID })
+  );
+
+  // Dialog remains open so the user can retry or cancel.
+  expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+  // Cache not advanced — still the original pharmacy.
+  expect(getCachedOrder()?.state).toBe(OrderState.Routing);
+  expect(getCachedOrder()?.pharmacy?.id).toBe(ORIGINAL_PHARMACY_ID);
+});

--- a/apps/app/src/views/components/RerouteOrderButton.test.tsx
+++ b/apps/app/src/views/components/RerouteOrderButton.test.tsx
@@ -1,225 +1,88 @@
-import { ApolloProvider } from '@apollo/client';
-import { ChakraProvider } from '@chakra-ui/react';
-import { PhotonClient } from '@photonhealth/sdk';
-import type { Order, Pharmacy } from '@photonhealth/sdk/dist/types';
 import { FulfillmentType, OrderState } from '@photonhealth/sdk/dist/types';
-import { clinicalGql, defaultHandlers, lambdasGql } from '@photonhealth/sdk/test-utils';
-import { render, screen, waitFor } from '@testing-library/react';
+import { clinicalGql, lambdasGql } from '@photonhealth/sdk/test-utils';
+import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { HttpResponse } from 'msw';
-import { setupServer } from 'msw/node';
-import { MemoryRouter } from 'react-router-dom';
-import { afterAll, afterEach, beforeAll, beforeEach, expect, test, vi } from 'vitest';
+import { beforeEach, expect, test, vi } from 'vitest';
 
-import { ProviderAnalyticsProvider } from '../../hooks/useProviderAnalytics';
+import {
+  dispatchCustomEvent,
+  makeOrder,
+  makePatient,
+  makePharmacy,
+  setupHarness
+} from '../../test-utils';
 import { GET_ORDER } from '../../queries';
 import { RerouteOrderButton } from './RerouteOrderButton';
 
-// ---------------------------------------------------------------------------
-// Fixtures
-// ---------------------------------------------------------------------------
-
-const ORDER_ID = 'ord_test123';
+const ORDER_ID = 'ord_test';
 const PATIENT_ID = 'pat_456';
 const ORIGINAL_PHARMACY_ID = 'phr_original';
 const NEW_PHARMACY_ID = 'phr_new';
 
-const ORIGINAL_PHARMACY = {
-  __typename: 'Pharmacy',
+const originalPharmacy = makePharmacy({
   id: ORIGINAL_PHARMACY_ID,
-  name: 'Original Pharmacy',
-  phone: '+15551110000',
-  address: {
-    __typename: 'Address',
-    city: 'Brooklyn',
-    country: 'US',
-    postalCode: '11211',
-    state: 'NY',
-    street1: '123 Main St',
-    street2: null
-  }
-} as unknown as Pharmacy;
-
-const NEW_PHARMACY = {
-  __typename: 'Pharmacy',
-  id: NEW_PHARMACY_ID,
-  name: 'New Pharmacy',
-  phone: '+15552220000',
-  address: {
-    __typename: 'Address',
-    city: 'Queens',
-    country: 'US',
-    postalCode: '11375',
-    state: 'NY',
-    street1: '456 Side St',
-    street2: null
-  }
-} as unknown as Pharmacy;
-
-const FIXTURE_ORDER = {
-  __typename: 'Order',
+  name: 'Original Pharmacy'
+});
+const newPharmacy = makePharmacy({ id: NEW_PHARMACY_ID, name: 'New Pharmacy' });
+const order = makeOrder({
   id: ORDER_ID,
-  externalId: null,
-  state: OrderState.Routing,
-  address: null,
-  fills: [
-    {
-      __typename: 'Fill',
-      id: 'fill_1',
-      prescription: {
-        __typename: 'Prescription',
-        id: 'rx_1',
-        dispenseQuantity: 30,
-        dispenseUnit: 'tablet',
-        fillsAllowed: 1,
-        instructions: 'Take 1 daily'
-      },
-      treatment: { __typename: 'Treatment', id: 'trt_1', name: 'Amoxicillin' },
-      state: 'NEW',
-      requestedAt: '2026-05-01T00:00:00Z',
-      filledAt: null
-    }
-  ],
-  patient: {
-    __typename: 'Patient',
-    id: PATIENT_ID,
-    externalId: null,
-    name: { __typename: 'Name', full: 'Sally Patient' },
-    dateOfBirth: '1990-01-01',
-    sex: 'FEMALE',
-    gender: 'female',
-    email: 'sally@example.com',
-    phone: '+17185551234'
-  },
-  pharmacy: ORIGINAL_PHARMACY,
-  fulfillment: null,
-  exceptions: [],
-  createdAt: '2026-05-01T00:00:00Z'
-} as unknown as Order;
+  patient: makePatient({ id: PATIENT_ID }),
+  pharmacy: originalPharmacy
+});
 
-// ---------------------------------------------------------------------------
-// MSW + Apollo client setup
-// ---------------------------------------------------------------------------
-
-// Spies for asserting the right operations fired with the right variables.
+// Per-test MSW spies.
 const rerouteOrderSpy = vi.fn();
 const getPharmacySpy = vi.fn();
 
-const server = setupServer(
-  ...defaultHandlers,
-  // RerouteOrder lives on the clinical (services) API.
-  clinicalGql.mutation('RerouteOrder', async ({ variables }) => {
-    rerouteOrderSpy(variables);
-    return HttpResponse.json({ data: { rerouteOrder: true } });
-  }),
-  // The routing-history GetOrder lives on clinical too — empty history is fine.
-  clinicalGql.query('GetOrder', () =>
-    HttpResponse.json({
-      data: { order: { __typename: 'Order', id: ORDER_ID, routingHistory: [] } }
-    })
-  ),
-  // PHARMACY_QUERY runs against the lambdas client to fetch the new pharmacy
-  // for analytics + the cross-client cache update.
-  lambdasGql.query('GetPharmacy', ({ variables }) => {
-    getPharmacySpy(variables);
-    return HttpResponse.json({ data: { pharmacy: NEW_PHARMACY } });
-  })
-);
+const { server, photonClient, trackSpy, renderWithProviders } = setupHarness();
 
-beforeAll(() => server.listen({ onUnhandledRequest: 'warn' }));
-afterEach(() => {
-  server.resetHandlers();
-  vi.clearAllMocks();
-});
-afterAll(() => server.close());
+beforeEach(() => {
+  rerouteOrderSpy.mockClear();
+  getPharmacySpy.mockClear();
 
-// Use a real PhotonClient so we get a real Apollo Client per endpoint
-// (apollo = lambdas, apolloClinical = services). MSW intercepts the HTTP.
-const photonClient = new PhotonClient({ clientId: 'test', env: 'tau' });
-photonClient.authentication.getAccessToken = vi.fn(async () => 'test-token');
-
-vi.mock('@photonhealth/react', () => ({
-  usePhoton: () => ({
-    isAuthenticated: true,
-    isLoading: false,
-    user: { org_id: 'org_1' },
-    clinicalClient: photonClient.apolloClinical
-  })
-}));
-
-const rudderTrackSpy = vi.fn();
-const rudderIdentifySpy = vi.fn();
-vi.mock('../../configs/providerAnalytics', () => ({
-  getProviderAnalytics: () => ({
-    track: rudderTrackSpy,
-    isInitialized: true,
-    identify: rudderIdentifySpy
-  })
-}));
-
-beforeEach(async () => {
-  // Reset both Apollo caches so tests are isolated.
-  await photonClient.apollo.clearStore();
-  await photonClient.apolloClinical.clearStore();
-});
-
-// ---------------------------------------------------------------------------
-// Render helpers
-// ---------------------------------------------------------------------------
-
-function renderRerouteButton(order: Order = FIXTURE_ORDER) {
-  // Pre-populate the lambdas cache with GET_ORDER so the mutation's
-  // cross-client `update` callback has something to read + write.
+  // Pre-populate the lambdas cache so the mutation's cross-client `update`
+  // callback has data to read + write.
   photonClient.apollo.writeQuery({
     query: GET_ORDER,
-    variables: { id: order.id },
+    variables: { id: ORDER_ID },
     data: { order }
   });
 
-  return render(
-    <MemoryRouter>
-      <ChakraProvider>
-        <ApolloProvider client={photonClient.apollo}>
-          <ProviderAnalyticsProvider>
-            <RerouteOrderButton order={order} organizationId="org_1" />
-          </ProviderAnalyticsProvider>
-        </ApolloProvider>
-      </ChakraProvider>
-    </MemoryRouter>
+  server.use(
+    clinicalGql.mutation('RerouteOrder', ({ variables }) => {
+      rerouteOrderSpy(variables);
+      return HttpResponse.json({ data: { rerouteOrder: true } });
+    }),
+    clinicalGql.query('GetOrder', () =>
+      HttpResponse.json({
+        data: { order: { __typename: 'Order', id: ORDER_ID, routingHistory: [] } }
+      })
+    ),
+    lambdasGql.query('GetPharmacy', ({ variables }) => {
+      getPharmacySpy(variables);
+      return HttpResponse.json({ data: { pharmacy: newPharmacy } });
+    })
   );
-}
+});
 
-function getCachedOrder(): Order | undefined {
-  return photonClient.apollo.readQuery<{ order: Order }>({
-    query: GET_ORDER,
-    variables: { id: ORDER_ID }
-  })?.order;
-}
-
-async function openReroute(order: Order = FIXTURE_ORDER) {
-  renderRerouteButton(order);
+async function openReroute() {
+  renderWithProviders(<RerouteOrderButton order={order} organizationId="org_1" />);
   const user = userEvent.setup();
   await user.click(screen.getByRole('button', { name: /reroute order/i }));
   return user;
 }
 
-const getPharmacySelectElement = () => screen.findByTestId('pharmacy-select');
+const getPharmacySelect = () => screen.findByTestId('pharmacy-select');
 
-function dispatchPharmacySelected(
-  el: HTMLElement,
-  detail: { pharmacyId?: string; fulfillmentType?: string }
-) {
-  el.dispatchEvent(
-    new CustomEvent('photon-pharmacy-selected', { bubbles: true, composed: true, detail })
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
+const getCachedOrder = () =>
+  photonClient.apollo.readQuery<{ order: typeof order }>({
+    query: GET_ORDER,
+    variables: { id: ORDER_ID }
+  })?.order;
 
 test('renders the Reroute Order trigger button', () => {
-  renderRerouteButton();
+  renderWithProviders(<RerouteOrderButton order={order} organizationId="org_1" />);
   expect(screen.getByRole('button', { name: /reroute order/i })).toBeInTheDocument();
 });
 
@@ -227,29 +90,27 @@ test('opens the dialog with photon-pharmacy-select and fires open analytics', as
   await openReroute();
 
   expect(await screen.findByRole('dialog')).toBeInTheDocument();
-  const pharmacySelect = await getPharmacySelectElement();
+  const pharmacySelect = await getPharmacySelect();
   expect(pharmacySelect).toHaveAttribute('patient-id', PATIENT_ID);
   expect(pharmacySelect).toHaveAttribute('pharmacy-id', ORIGINAL_PHARMACY_ID);
 
-  expect(rudderTrackSpy).toHaveBeenCalledWith(
+  expect(trackSpy).toHaveBeenCalledWith(
     'Customer Clicked Reroute Order',
     expect.objectContaining({
       orderId: ORDER_ID,
-      patientId: PATIENT_ID,
-      medicationIds: ['trt_1'],
-      medicationNames: ['Amoxicillin']
+      patientId: PATIENT_ID
     })
   );
 });
 
-test('Cancel closes the dialog and fires cancel analytics — no mutation', async () => {
+test('Cancel closes the dialog, fires cancel analytics, and does not call the mutation', async () => {
   const user = await openReroute();
   await screen.findByRole('dialog');
 
   await user.click(screen.getByRole('button', { name: /^cancel$/i }));
 
   await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
-  expect(rudderTrackSpy).toHaveBeenCalledWith(
+  expect(trackSpy).toHaveBeenCalledWith(
     'Cancel Reroute Order Clicked',
     expect.objectContaining({ orderId: ORDER_ID })
   );
@@ -258,10 +119,9 @@ test('Cancel closes the dialog and fires cancel analytics — no mutation', asyn
 
 test('Confirm button is disabled when a tab is selected but no pharmacy is chosen', async () => {
   await openReroute();
-  const el = await getPharmacySelectElement();
+  const el = await getPharmacySelect();
 
-  // User picked the "Local Pickup" tab but hasn't chosen a pharmacy yet.
-  dispatchPharmacySelected(el, {
+  dispatchCustomEvent(el, 'photon-pharmacy-selected', {
     fulfillmentType: FulfillmentType.PickUp,
     pharmacyId: undefined
   });
@@ -271,18 +131,17 @@ test('Confirm button is disabled when a tab is selected but no pharmacy is chose
   });
 });
 
-test('Confirm fires mutation with selected pharmacy, updates lambdas cache, and fires analytics', async () => {
+test('Confirm fires mutation, updates lambdas cache, and fires analytics on success', async () => {
   const user = await openReroute();
-  const el = await getPharmacySelectElement();
+  const el = await getPharmacySelect();
 
-  dispatchPharmacySelected(el, {
+  dispatchCustomEvent(el, 'photon-pharmacy-selected', {
     fulfillmentType: FulfillmentType.PickUp,
     pharmacyId: NEW_PHARMACY_ID
   });
 
   await user.click(screen.getByRole('button', { name: /confirm reroute/i }));
 
-  // Mutation called against the clinical client with the chosen pharmacy.
   await waitFor(() => {
     expect(rerouteOrderSpy).toHaveBeenCalledWith({
       orderId: ORDER_ID,
@@ -290,10 +149,8 @@ test('Confirm fires mutation with selected pharmacy, updates lambdas cache, and 
     });
   });
 
-  // GetPharmacy was fetched on the lambdas client (for both analytics name + cache write).
   expect(getPharmacySpy).toHaveBeenCalledWith({ id: NEW_PHARMACY_ID });
-
-  expect(rudderTrackSpy).toHaveBeenCalledWith(
+  expect(trackSpy).toHaveBeenCalledWith(
     'Confirm Reroute Order Clicked',
     expect.objectContaining({
       orderId: ORDER_ID,
@@ -303,23 +160,23 @@ test('Confirm fires mutation with selected pharmacy, updates lambdas cache, and 
     })
   );
 
-  // Lambdas cache for GET_ORDER reflects the new pharmacy + Pending state.
   await waitFor(() => {
     const cached = getCachedOrder();
     expect(cached?.state).toBe(OrderState.Pending);
     expect(cached?.pharmacy?.id).toBe(NEW_PHARMACY_ID);
   });
 
-  // Dialog closes on success.
   await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
 });
 
-test('Confirm with no pharmacy (Send to Patient) flips order back to Routing in cache', async () => {
+test('Confirm with no pharmacy (Send to Patient) flips cache state back to Routing', async () => {
   const user = await openReroute();
-  const el = await getPharmacySelectElement();
+  const el = await getPharmacySelect();
 
-  // Send-to-Patient flow: no pharmacy chosen, fulfillmentType is undefined → confirm enabled.
-  dispatchPharmacySelected(el, { fulfillmentType: undefined, pharmacyId: undefined });
+  dispatchCustomEvent(el, 'photon-pharmacy-selected', {
+    fulfillmentType: undefined,
+    pharmacyId: undefined
+  });
 
   await user.click(screen.getByRole('button', { name: /confirm reroute/i }));
 
@@ -327,16 +184,15 @@ test('Confirm with no pharmacy (Send to Patient) flips order back to Routing in 
     expect(rerouteOrderSpy).toHaveBeenCalledWith({ orderId: ORDER_ID, pharmacyId: '' });
   });
 
-  // No PHARMACY_QUERY since there's no chosen pharmacy.
   expect(getPharmacySpy).not.toHaveBeenCalled();
 
-  // Cache flips to Routing
-  await waitFor(() => {
-    expect(getCachedOrder()?.state).toBe(OrderState.Routing);
-  });
+  // NB: the production cache update writes `pharmacy: newPharmacy || undefined`,
+  // and Apollo leaves the existing pharmacy reference in place when given
+  // `undefined`, so we assert on the state transition rather than pharmacy clear.
+  await waitFor(() => expect(getCachedOrder()?.state).toBe(OrderState.Routing));
 });
 
-test('Confirm shows error toast and fires error analytics when mutation fails', async () => {
+test('Confirm shows error toast and fires error analytics on mutation failure', async () => {
   server.use(
     clinicalGql.mutation('RerouteOrder', () =>
       HttpResponse.json({
@@ -347,8 +203,8 @@ test('Confirm shows error toast and fires error analytics when mutation fails', 
   );
 
   const user = await openReroute();
-  const el = await getPharmacySelectElement();
-  dispatchPharmacySelected(el, {
+  const el = await getPharmacySelect();
+  dispatchCustomEvent(el, 'photon-pharmacy-selected', {
     fulfillmentType: FulfillmentType.PickUp,
     pharmacyId: NEW_PHARMACY_ID
   });
@@ -356,7 +212,7 @@ test('Confirm shows error toast and fires error analytics when mutation fails', 
   await user.click(screen.getByRole('button', { name: /confirm reroute/i }));
 
   expect(await screen.findByText(/error rerouting the order/i)).toBeInTheDocument();
-  expect(rudderTrackSpy).toHaveBeenCalledWith(
+  expect(trackSpy).toHaveBeenCalledWith(
     'Reroute Error Message Viewed',
     expect.objectContaining({ orderId: ORDER_ID })
   );
@@ -364,7 +220,7 @@ test('Confirm shows error toast and fires error analytics when mutation fails', 
   // Dialog remains open so the user can retry or cancel.
   expect(screen.getByRole('dialog')).toBeInTheDocument();
 
-  // Cache not advanced — still the original pharmacy.
+  // Cache not advanced.
   expect(getCachedOrder()?.state).toBe(OrderState.Routing);
   expect(getCachedOrder()?.pharmacy?.id).toBe(ORIGINAL_PHARMACY_ID);
 });

--- a/apps/app/src/views/components/RerouteOrderButton.tsx
+++ b/apps/app/src/views/components/RerouteOrderButton.tsx
@@ -176,9 +176,10 @@ export function RerouteOrderButton({ order, organizationId }: RerouteOrderButton
             enable-send-to-patient={true}
             enable-delivery-pharmacies={true}
             infer-send-to-patient-pharmacy={false}
+            sticky-tab-header={true}
           />
         </Dialog.Body>
-        <Dialog.Footer>
+        <Dialog.Footer position="sticky" bottom="0">
           <Button variant="outline" size="sm" onClick={handleRerouteCancel} disabled={updating}>
             Cancel
           </Button>

--- a/apps/app/src/views/components/RerouteOrderButton.tsx
+++ b/apps/app/src/views/components/RerouteOrderButton.tsx
@@ -28,8 +28,6 @@ declare global {
 export function RerouteOrderButton({ order, organizationId }: RerouteOrderButtonProps) {
   const { track } = useProviderAnalytics();
   const toast = useToast();
-  const apollo = useApolloClient();
-  const { clinicalClient } = usePhoton();
 
   const [updating, setUpdating] = useState(false);
   const [rerouteModalOpen, setRerouteModalOpen] = useState(false);
@@ -43,6 +41,8 @@ export function RerouteOrderButton({ order, organizationId }: RerouteOrderButton
     () => getOrgMailOrderPharms(organizationId)?.provider?.join(',') ?? '',
     [organizationId]
   );
+
+  const [rerouteOrder] = useRerouteOrderMutation({ order, rerouteTo: pharmacyId });
 
   useEffect(() => {
     // effect to set up event listener that detects pharmacy selection from the web component
@@ -109,57 +109,6 @@ export function RerouteOrderButton({ order, organizationId }: RerouteOrderButton
     }
   };
 
-  const [rerouteOrder] = useMutation(rerouteOrderMutation, {
-    client: clinicalClient,
-    update: async () => {
-      try {
-        const cachedResponse: { order: Order } | null = apollo.readQuery({
-          query: GET_ORDER,
-          variables: { id: order.id }
-        });
-        if (!cachedResponse?.order) return;
-
-        let newPharmacy: Order['pharmacy'];
-        if (pharmacyId) {
-          // provider chose a pharmacy, get its data to update the cache
-          const { data: pharmacyData } = await apollo.query<{ pharmacy: Order['pharmacy'] }>({
-            query: PHARMACY_QUERY,
-            variables: { id: pharmacyId }
-          });
-          newPharmacy = pharmacyData.pharmacy;
-        }
-
-        apollo.writeQuery({
-          query: GET_ORDER,
-          variables: { id: order.id },
-          data: {
-            order: {
-              ...cachedResponse.order,
-              state: newPharmacy ? OrderState.Pending : OrderState.Routing,
-              pharmacy: newPharmacy || undefined
-            }
-          }
-        });
-      } catch (error) {
-        const message = error instanceof Error ? error.message : `${error}`;
-        console.error('Failure in optimistically updating the cache with pharmacy data', message);
-        toast({
-          position: 'top-right',
-          duration: 5000,
-          render: ({ onClose: onToastClose }) => (
-            <StyledToast
-              onClose={onToastClose}
-              type="error"
-              title="Error loading pharmacy data"
-              description="The order has been rerouted, but there was an error in loading the new pharmacy data. Refresh or come back later to see the updated order"
-            />
-          )
-        });
-      }
-      return;
-    }
-  });
-
   return (
     <>
       <Button
@@ -207,4 +156,61 @@ export function RerouteOrderButton({ order, organizationId }: RerouteOrderButton
       </Dialog>
     </>
   );
+}
+
+function useRerouteOrderMutation({ order, rerouteTo }: { order: Order; rerouteTo?: string }) {
+  const toast = useToast();
+  const apollo = useApolloClient();
+  const { clinicalClient } = usePhoton();
+
+  return useMutation(rerouteOrderMutation, {
+    client: clinicalClient,
+    update: async () => {
+      try {
+        const cachedResponse: { order: Order } | null = apollo.readQuery({
+          query: GET_ORDER,
+          variables: { id: order.id }
+        });
+        if (!cachedResponse?.order) return;
+
+        let newPharmacy: Order['pharmacy'];
+        if (rerouteTo) {
+          // provider chose a pharmacy, get its data to update the cache
+          const { data: pharmacyData } = await apollo.query<{ pharmacy: Order['pharmacy'] }>({
+            query: PHARMACY_QUERY,
+            variables: { id: rerouteTo }
+          });
+          newPharmacy = pharmacyData.pharmacy;
+        }
+
+        apollo.writeQuery({
+          query: GET_ORDER,
+          variables: { id: order.id },
+          data: {
+            order: {
+              ...cachedResponse.order,
+              state: newPharmacy ? OrderState.Pending : OrderState.Routing,
+              pharmacy: newPharmacy || undefined
+            }
+          }
+        });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : `${error}`;
+        console.error('Failure in optimistically updating the cache with pharmacy data', message);
+        toast({
+          position: 'top-right',
+          duration: 5000,
+          render: ({ onClose: onToastClose }) => (
+            <StyledToast
+              onClose={onToastClose}
+              type="error"
+              title="Error loading pharmacy data"
+              description="The order has been rerouted, but there was an error in loading the new pharmacy data. Refresh or come back later to see the updated order"
+            />
+          )
+        });
+      }
+      return;
+    }
+  });
 }

--- a/apps/app/src/views/components/RerouteOrderButton.tsx
+++ b/apps/app/src/views/components/RerouteOrderButton.tsx
@@ -167,6 +167,7 @@ export function RerouteOrderButton({ order, organizationId }: RerouteOrderButton
         <Dialog.Body pt="0.5" pb="4" px="4">
           <photon-pharmacy-select
             ref={pharmacySelectRef}
+            data-testid="pharmacy-select"
             patient-id={order.patient.id}
             address={order.address ? formatAddress(order.address) : ''}
             pharmacy-id={order.pharmacy?.id}

--- a/apps/app/src/views/components/RerouteOrderButton.tsx
+++ b/apps/app/src/views/components/RerouteOrderButton.tsx
@@ -1,0 +1,209 @@
+import { Button, useToast } from '@chakra-ui/react';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { getOrgMailOrderPharms } from '@client/settings';
+import { Dialog } from './Dialog';
+import { useApolloClient, useMutation } from '@apollo/client';
+import { rerouteOrderMutation } from '../../mutations/clinical-api/orders';
+import { Order } from '@photonhealth/sdk/dist/types';
+import { formatAddress } from '../../utils';
+import { useProviderAnalytics } from '../../hooks/useProviderAnalytics';
+import { StyledToast } from './StyledToast';
+import { GET_ORDER, PHARMACY_QUERY } from '../../queries';
+import { OrderState } from 'packages/sdk/src/types';
+import { usePhoton } from '@photonhealth/react';
+
+interface RerouteOrderButtonProps {
+  order: Order;
+  organizationId: string;
+}
+
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      'photon-pharmacy-select': unknown;
+    }
+  }
+}
+
+export function RerouteOrderButton({ order, organizationId }: RerouteOrderButtonProps) {
+  const { track } = useProviderAnalytics();
+  const toast = useToast();
+  const apollo = useApolloClient();
+  const { clinicalClient } = usePhoton();
+
+  const [updating, setUpdating] = useState(false);
+  const [rerouteModalOpen, setRerouteModalOpen] = useState(false);
+  const [pharmacyId, setPharmacyId] = useState('');
+  const [fulfillmentType, setFulfillmentType] = useState<string | undefined>(undefined);
+
+  const confirmButtonDisabled = !!fulfillmentType && !pharmacyId;
+
+  const pharmacySelectRef = useRef<HTMLElement>(null);
+  const mailOrderIds = useMemo(
+    () => getOrgMailOrderPharms(organizationId)?.provider?.join(',') ?? '',
+    [organizationId]
+  );
+
+  useEffect(() => {
+    // effect to set up event listener that detects pharmacy selection from the web component
+    if (!rerouteModalOpen) return;
+
+    const el = pharmacySelectRef.current;
+    if (!el) return;
+
+    const pharmacySelectedHandler = (e: Event) => {
+      const ce = e as CustomEvent<{ pharmacyId?: string; fulfillmentType?: string }>;
+      const detail = ce.detail;
+      setPharmacyId(detail?.pharmacyId ?? '');
+      setFulfillmentType(detail?.fulfillmentType);
+    };
+
+    el.addEventListener('photon-pharmacy-selected', pharmacySelectedHandler);
+    return () => el.removeEventListener('photon-pharmacy-selected', pharmacySelectedHandler);
+  }, [rerouteModalOpen]);
+
+  const handleRerouteButtonClick = () => {
+    setPharmacyId('');
+    setFulfillmentType(undefined);
+    setRerouteModalOpen(true);
+    // TODO: Tracking event
+  };
+
+  const handleRerouteCancel = () => {
+    setPharmacyId('');
+    setFulfillmentType(undefined);
+    setRerouteModalOpen(false);
+    // TODO: Tracking event
+  };
+
+  const handleRerouteConfirmation = async () => {
+    setUpdating(true);
+    try {
+      track('Confirm Reroute Order Clicked', {
+        // TODO: add more attributes
+        orderId: order.id,
+        pharmacyId
+      });
+
+      await rerouteOrder({ variables: { orderId: order.id, pharmacyId } });
+
+      setPharmacyId('');
+      setFulfillmentType(undefined);
+      setRerouteModalOpen(false);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : `${error}`;
+      toast({
+        position: 'top-right',
+        duration: 5000,
+        render: ({ onClose: onToastClose }) => (
+          <StyledToast
+            onClose={onToastClose}
+            type="error"
+            title="Error Rerouting Order"
+            description={`There was an error rerouting the order: ${message}`}
+          />
+        )
+      });
+    } finally {
+      setUpdating(false);
+    }
+  };
+
+  const [rerouteOrder] = useMutation(rerouteOrderMutation, {
+    client: clinicalClient,
+    update: async () => {
+      try {
+        const cachedResponse: { order: Order } | null = apollo.readQuery({
+          query: GET_ORDER,
+          variables: { id: order.id }
+        });
+        if (!cachedResponse?.order) return;
+
+        let newPharmacy: Order['pharmacy'];
+        if (pharmacyId) {
+          // provider chose a pharmacy, get its data to update the cache
+          const { data: pharmacyData } = await apollo.query<{ pharmacy: Order['pharmacy'] }>({
+            query: PHARMACY_QUERY,
+            variables: { id: pharmacyId }
+          });
+          newPharmacy = pharmacyData.pharmacy;
+        }
+
+        apollo.writeQuery({
+          query: GET_ORDER,
+          variables: { id: order.id },
+          data: {
+            order: {
+              ...cachedResponse.order,
+              state: newPharmacy ? OrderState.Pending : OrderState.Routing,
+              pharmacy: newPharmacy || undefined
+            }
+          }
+        });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : `${error}`;
+        console.error('Failure in optimistically updating the cache with pharmacy data', message);
+        toast({
+          position: 'top-right',
+          duration: 5000,
+          render: ({ onClose: onToastClose }) => (
+            <StyledToast
+              onClose={onToastClose}
+              type="error"
+              title="Error loading pharmacy data"
+              description="The order has been rerouted, but there was an error in loading the new pharmacy data. Refresh or come back later to see the updated order"
+            />
+          )
+        });
+      }
+      return;
+    }
+  });
+
+  return (
+    <>
+      <Button
+        onClick={handleRerouteButtonClick}
+        variant="outline"
+        colorScheme="gray"
+        borderColor="gray.300"
+        borderRadius="lg"
+        paddingY="1"
+        paddingX="3"
+      >
+        Reroute Order
+      </Button>
+
+      <Dialog isOpen={rerouteModalOpen} onClose={handleRerouteCancel} size="xl">
+        <Dialog.Body pt="0.5" pb="4" px="4">
+          <photon-pharmacy-select
+            ref={pharmacySelectRef}
+            patient-id={order.patient.id}
+            address={order.address ? formatAddress(order.address) : ''}
+            pharmacy-id={order.pharmacy?.id}
+            mail-order-ids={mailOrderIds}
+            enable-local-pickup={true}
+            enable-send-to-patient={true}
+            enable-delivery-pharmacies={true}
+          />
+        </Dialog.Body>
+        <Dialog.Footer>
+          <Button variant="outline" size="sm" onClick={handleRerouteCancel} disabled={updating}>
+            Cancel
+          </Button>
+          <Button
+            variant="solid"
+            colorScheme="blue"
+            size="sm"
+            isLoading={updating}
+            loadingText="Rerouting..."
+            isDisabled={confirmButtonDisabled}
+            onClick={handleRerouteConfirmation}
+          >
+            Confirm Reroute
+          </Button>
+        </Dialog.Footer>
+      </Dialog>
+    </>
+  );
+}

--- a/apps/app/src/views/components/RerouteOrderButton.tsx
+++ b/apps/app/src/views/components/RerouteOrderButton.tsx
@@ -2,14 +2,14 @@ import { Button, useToast } from '@chakra-ui/react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { getOrgMailOrderPharms } from '@client/settings';
 import { Dialog } from './Dialog';
-import { useApolloClient, useMutation } from '@apollo/client';
+import { useApolloClient, useMutation, useQuery } from '@apollo/client';
 import { rerouteOrderMutation } from '../../mutations/clinical-api/orders';
-import { Order } from '@photonhealth/sdk/dist/types';
+import { Order, Treatment } from '@photonhealth/sdk/dist/types';
 import { formatAddress } from '../../utils';
 import { useProviderAnalytics } from '../../hooks/useProviderAnalytics';
 import { StyledToast } from './StyledToast';
-import { GET_ORDER, PHARMACY_QUERY } from '../../queries';
-import { OrderState } from 'packages/sdk/src/types';
+import { GET_ORDER, getOrderRoutingHistory, PHARMACY_QUERY } from '../../queries';
+import { FulfillmentType, OrderState } from 'packages/sdk/src/types';
 import { usePhoton } from '@photonhealth/react';
 
 interface RerouteOrderButtonProps {
@@ -25,23 +25,27 @@ declare global {
   }
 }
 
+const CONFIRMATION_TEXT = 'Confirm Reroute';
+
 export function RerouteOrderButton({ order, organizationId }: RerouteOrderButtonProps) {
-  const { track } = useProviderAnalytics();
   const toast = useToast();
-
-  const [updating, setUpdating] = useState(false);
-  const [rerouteModalOpen, setRerouteModalOpen] = useState(false);
-  const [pharmacyId, setPharmacyId] = useState('');
-  const [fulfillmentType, setFulfillmentType] = useState<string | undefined>(undefined);
-
-  const confirmButtonDisabled = !!fulfillmentType && !pharmacyId;
-
+  const { track } = useProviderAnalytics();
   const pharmacySelectRef = useRef<HTMLElement>(null);
   const mailOrderIds = useMemo(
     () => getOrgMailOrderPharms(organizationId)?.provider?.join(',') ?? '',
     [organizationId]
   );
 
+  const [updating, setUpdating] = useState(false);
+  const [rerouteModalOpen, setRerouteModalOpen] = useState(false);
+  const [pharmacyId, setPharmacyId] = useState('');
+  const [fulfillmentType, setFulfillmentType] = useState<string | undefined>(undefined);
+  const confirmButtonDisabled = !!fulfillmentType && !pharmacyId;
+
+  const uniqueTreatments = useUniqueMeds(order);
+  const selector = useRerouteSelector();
+
+  const routingHistory = useRoutingHistory(order.id);
   const [rerouteOrder] = useRerouteOrderMutation({ order, rerouteTo: pharmacyId });
 
   useEffect(() => {
@@ -66,23 +70,43 @@ export function RerouteOrderButton({ order, organizationId }: RerouteOrderButton
     setPharmacyId('');
     setFulfillmentType(undefined);
     setRerouteModalOpen(true);
-    // TODO: Tracking event
+
+    track('Customer Clicked Reroute Order', {
+      selector,
+      numberOfReroutes: routingHistory.slice(1).length,
+      orderId: order.id,
+      patientId: order.patient.id,
+      medicationIds: uniqueTreatments.map(({ id }) => id),
+      medicationNames: uniqueTreatments.map(({ name }) => name)
+    });
   };
 
   const handleRerouteCancel = () => {
     setPharmacyId('');
     setFulfillmentType(undefined);
     setRerouteModalOpen(false);
-    // TODO: Tracking event
+
+    track('Cancel Reroute Order Clicked', {
+      selector,
+      orderId: order.id,
+      patientId: order.patient.id,
+      medicationIds: uniqueTreatments.map(({ id }) => id),
+      medicationNames: uniqueTreatments.map(({ name }) => name)
+    });
   };
 
   const handleRerouteConfirmation = async () => {
     setUpdating(true);
     try {
       track('Confirm Reroute Order Clicked', {
-        // TODO: add more attributes
+        buttonText: CONFIRMATION_TEXT,
+        pharmacyId,
+        pharmacyName: '', // TODO
+        routingType: routingTypeLabel(fulfillmentType),
         orderId: order.id,
-        pharmacyId
+        patientId: order.patient.id,
+        medicationIds: uniqueTreatments.map(({ id }) => id),
+        medicationNames: uniqueTreatments.map(({ name }) => name)
       });
 
       await rerouteOrder({ variables: { orderId: order.id, pharmacyId } });
@@ -92,6 +116,16 @@ export function RerouteOrderButton({ order, organizationId }: RerouteOrderButton
       setRerouteModalOpen(false);
     } catch (error) {
       const message = error instanceof Error ? error.message : `${error}`;
+      track('Reroute Error Message Viewed', {
+        orderId: order.id,
+        patientId: order.patient.id,
+        medicationIds: uniqueTreatments.map(({ id }) => id),
+        medicationNames: uniqueTreatments.map(({ name }) => name),
+        pharmacyId,
+        pharmacyName: '', // TODO
+        routingType: routingTypeLabel(fulfillmentType),
+        message
+      });
       toast({
         position: 'top-right',
         duration: 5000,
@@ -150,7 +184,7 @@ export function RerouteOrderButton({ order, organizationId }: RerouteOrderButton
             isDisabled={confirmButtonDisabled}
             onClick={handleRerouteConfirmation}
           >
-            Confirm Reroute
+            {CONFIRMATION_TEXT}
           </Button>
         </Dialog.Footer>
       </Dialog>
@@ -213,4 +247,65 @@ function useRerouteOrderMutation({ order, rerouteTo }: { order: Order; rerouteTo
       return;
     }
   });
+}
+
+function useRoutingHistory(id: string) {
+  const { clinicalClient } = usePhoton();
+
+  const routingHistoryRes = useQuery(getOrderRoutingHistory, {
+    client: clinicalClient,
+    variables: { id }
+  });
+  const routingHistory = routingHistoryRes.data?.order?.routingHistory ?? [];
+  return routingHistory;
+}
+
+function useUniqueMeds(order: Order) {
+  return useMemo(() => {
+    const medicationLookup = order.fills.reduce<Record<string, Treatment>>((acc, cur) => {
+      if (!acc[cur.treatment.id]) {
+        acc[cur.treatment.id] = cur.treatment;
+      }
+
+      return acc;
+    }, {});
+
+    return Object.values(medicationLookup);
+  }, [order]);
+}
+
+function useRerouteSelector() {
+  const { contextData } = useProviderAnalytics();
+
+  return useMemo(() => {
+    if (!contextData.providerRoles) return;
+
+    switch (true) {
+      case 'Administrator' in contextData.providerRoles:
+        return 'ADMIN';
+      case 'Prescriber' in contextData.providerRoles:
+        return 'PROVIDER';
+      case 'Medical Operations' in contextData.providerRoles:
+        return 'MED_OPS';
+      case 'Staff' in contextData.providerRoles:
+        return 'STAFF';
+      case 'Support' in contextData.providerRoles:
+        return 'SUPPORT';
+      case 'Developer' in contextData.providerRoles:
+        return 'DEVELOPER';
+      default:
+        return 'READ_ONLY';
+    }
+  }, [contextData.providerRoles]);
+}
+
+function routingTypeLabel(type?: string) {
+  switch (type) {
+    case FulfillmentType.PickUp:
+      return 'Local Pick-up';
+    case FulfillmentType.MailOrder:
+      return 'Mail Order';
+    default:
+      return 'Send to Patient';
+  }
 }

--- a/apps/app/src/views/components/RerouteOrderButton.tsx
+++ b/apps/app/src/views/components/RerouteOrderButton.tsx
@@ -287,17 +287,17 @@ function useRerouteSelector() {
     if (!contextData.providerRoles) return;
 
     switch (true) {
-      case 'Administrator' in contextData.providerRoles:
+      case contextData.providerRoles.includes('Administrator'):
         return 'ADMIN';
-      case 'Prescriber' in contextData.providerRoles:
+      case contextData.providerRoles.includes('Prescriber'):
         return 'PROVIDER';
-      case 'Medical Operations' in contextData.providerRoles:
+      case contextData.providerRoles.includes('Medical Operations'):
         return 'MED_OPS';
-      case 'Staff' in contextData.providerRoles:
+      case contextData.providerRoles.includes('Staff'):
         return 'STAFF';
-      case 'Support' in contextData.providerRoles:
+      case contextData.providerRoles.includes('Support'):
         return 'SUPPORT';
-      case 'Developer' in contextData.providerRoles:
+      case contextData.providerRoles.includes('Developer'):
         return 'DEVELOPER';
       default:
         return 'READ_ONLY';

--- a/apps/app/src/views/components/RerouteOrderButton.tsx
+++ b/apps/app/src/views/components/RerouteOrderButton.tsx
@@ -300,7 +300,7 @@ function useRerouteSelector() {
       case contextData.providerRoles.includes('Developer'):
         return 'DEVELOPER';
       default:
-        return 'READ_ONLY';
+        return 'UNKNOWN';
     }
   }, [contextData.providerRoles]);
 }

--- a/apps/app/src/views/components/RerouteOrderButton.tsx
+++ b/apps/app/src/views/components/RerouteOrderButton.tsx
@@ -1,16 +1,17 @@
-import { Button, useToast } from '@chakra-ui/react';
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { getOrgMailOrderPharms } from '@client/settings';
-import { Dialog } from './Dialog';
 import { useApolloClient, useMutation, useQuery } from '@apollo/client';
-import { rerouteOrderMutation } from '../../mutations/clinical-api/orders';
+import { Button, useToast } from '@chakra-ui/react';
+import { getOrgMailOrderPharms } from '@client/settings';
+import { usePhoton } from '@photonhealth/react';
 import { Order, Treatment } from '@photonhealth/sdk/dist/types';
+import { FulfillmentType, OrderState } from 'packages/sdk/src/types';
+
+import { Dialog } from './Dialog';
+import { StyledToast } from './StyledToast';
+import { rerouteOrderMutation } from '../../mutations/clinical-api/orders';
 import { formatAddress } from '../../utils';
 import { useProviderAnalytics } from '../../hooks/useProviderAnalytics';
-import { StyledToast } from './StyledToast';
 import { GET_ORDER, getOrderRoutingHistory, PHARMACY_QUERY } from '../../queries';
-import { FulfillmentType, OrderState } from 'packages/sdk/src/types';
-import { usePhoton } from '@photonhealth/react';
 
 interface RerouteOrderButtonProps {
   order: Order;
@@ -29,6 +30,7 @@ const CONFIRMATION_TEXT = 'Confirm Reroute';
 
 export function RerouteOrderButton({ order, organizationId }: RerouteOrderButtonProps) {
   const toast = useToast();
+  const apollo = useApolloClient();
   const { track } = useProviderAnalytics();
   const pharmacySelectRef = useRef<HTMLElement>(null);
   const mailOrderIds = useMemo(
@@ -47,24 +49,6 @@ export function RerouteOrderButton({ order, organizationId }: RerouteOrderButton
 
   const routingHistory = useRoutingHistory(order.id);
   const [rerouteOrder] = useRerouteOrderMutation({ order, rerouteTo: pharmacyId });
-
-  useEffect(() => {
-    // effect to set up event listener that detects pharmacy selection from the web component
-    if (!rerouteModalOpen) return;
-
-    const el = pharmacySelectRef.current;
-    if (!el) return;
-
-    const pharmacySelectedHandler = (e: Event) => {
-      const ce = e as CustomEvent<{ pharmacyId?: string; fulfillmentType?: string }>;
-      const detail = ce.detail;
-      setPharmacyId(detail?.pharmacyId ?? '');
-      setFulfillmentType(detail?.fulfillmentType);
-    };
-
-    el.addEventListener('photon-pharmacy-selected', pharmacySelectedHandler);
-    return () => el.removeEventListener('photon-pharmacy-selected', pharmacySelectedHandler);
-  }, [rerouteModalOpen]);
 
   const handleRerouteButtonClick = () => {
     setPharmacyId('');
@@ -98,10 +82,19 @@ export function RerouteOrderButton({ order, organizationId }: RerouteOrderButton
   const handleRerouteConfirmation = async () => {
     setUpdating(true);
     try {
+      let pharmacyName: string | undefined = undefined;
+      if (pharmacyId) {
+        const { data: pharmacyData } = await apollo.query<{ pharmacy: Order['pharmacy'] }>({
+          query: PHARMACY_QUERY,
+          variables: { id: pharmacyId }
+        });
+        pharmacyName = pharmacyData?.pharmacy?.name;
+      }
+
       track('Confirm Reroute Order Clicked', {
         buttonText: CONFIRMATION_TEXT,
         pharmacyId,
-        pharmacyName: '', // TODO
+        pharmacyName,
         routingType: routingTypeLabel(fulfillmentType),
         orderId: order.id,
         patientId: order.patient.id,
@@ -119,11 +112,6 @@ export function RerouteOrderButton({ order, organizationId }: RerouteOrderButton
       track('Reroute Error Message Viewed', {
         orderId: order.id,
         patientId: order.patient.id,
-        medicationIds: uniqueTreatments.map(({ id }) => id),
-        medicationNames: uniqueTreatments.map(({ name }) => name),
-        pharmacyId,
-        pharmacyName: '', // TODO
-        routingType: routingTypeLabel(fulfillmentType),
         message
       });
       toast({
@@ -142,6 +130,24 @@ export function RerouteOrderButton({ order, organizationId }: RerouteOrderButton
       setUpdating(false);
     }
   };
+
+  useEffect(() => {
+    // effect to set up event listener that detects pharmacy selection from the web component
+    if (!rerouteModalOpen) return;
+
+    const el = pharmacySelectRef.current;
+    if (!el) return;
+
+    const pharmacySelectedHandler = (e: Event) => {
+      const ce = e as CustomEvent<{ pharmacyId?: string; fulfillmentType?: string }>;
+      const detail = ce.detail;
+      setPharmacyId(detail?.pharmacyId ?? '');
+      setFulfillmentType(detail?.fulfillmentType);
+    };
+
+    el.addEventListener('photon-pharmacy-selected', pharmacySelectedHandler);
+    return () => el.removeEventListener('photon-pharmacy-selected', pharmacySelectedHandler);
+  }, [rerouteModalOpen]);
 
   return (
     <>

--- a/apps/app/src/views/components/RerouteOrderButton.tsx
+++ b/apps/app/src/views/components/RerouteOrderButton.tsx
@@ -185,6 +185,7 @@ export function RerouteOrderButton({ order, organizationId }: RerouteOrderButton
             enable-local-pickup={true}
             enable-send-to-patient={true}
             enable-delivery-pharmacies={true}
+            infer-send-to-patient-pharmacy={false}
           />
         </Dialog.Body>
         <Dialog.Footer>

--- a/apps/app/src/views/routes/Order.tsx
+++ b/apps/app/src/views/routes/Order.tsx
@@ -55,7 +55,14 @@ import { datadogRum } from '@datadog/browser-rum';
 import { useProviderAnalytics } from '../../hooks/useProviderAnalytics';
 import { StyledToast } from '../components/StyledToast';
 import { RerouteOrderButton } from '../components/RerouteOrderButton';
-import { GET_ORDER, GET_ORDER_QUERY_NAME, PHARMACY_QUERY } from '../../queries';
+import {
+  GET_ORDER,
+  GET_ORDER_QUERY_NAME,
+  getOrderRoutingHistory,
+  PHARMACY_QUERY
+} from '../../queries';
+import { OrderRoutingHistory } from '../../gql/graphql';
+import { OrderState } from 'packages/sdk/src/types';
 
 export const ORDER_FULFILLMENT_TYPE_MAP = {
   [types.FulfillmentType.PickUp]: 'Pick up',
@@ -137,22 +144,29 @@ Description:
 
 export const OrderDetailPage = () => {
   const params = useParams();
-  const id = params.orderId;
-  const { user, getToken } = usePhoton();
+  const id = params.orderId!;
+  const { user, getToken, clinicalClient } = usePhoton();
   const { track } = useProviderAnalytics();
   const [isTicketModalOpen, setIsTicketModalOpen] = useState(false);
   const [accessToken, setAccessToken] = useState('');
   const [updating, setUpdating] = useState(false);
   const { isOpen, onOpen, onClose } = useDisclosure();
   const [pharmacyId, setPharmacyId] = useState('');
-  const { data, loading, error } = useQuery(GET_ORDER, {
-    variables: { id: id! }
-  });
   const [cancelReason, setCancelReason] = useState('');
   const cancelReasonRef = useRef(cancelReason);
   const client = useApolloClient();
   const theme = useTheme();
   const toast = useToast();
+
+  const { data, loading, error } = useQuery(GET_ORDER, {
+    variables: { id }
+  });
+
+  const routingHistoryRes = useQuery(getOrderRoutingHistory, {
+    client: clinicalClient,
+    variables: { id }
+  });
+  const routingHistory = routingHistoryRes.data?.order?.routingHistory ?? [];
 
   useEffect(() => {
     cancelReasonRef.current = cancelReason;
@@ -543,13 +557,13 @@ export const OrderDetailPage = () => {
                       <VStack spacing={1} align="start">
                         <VStack spacing={0} align="start">
                           <Text fontSize="md" fontWeight="medium">
-                            {getRoutingOrderStatusText(order)}
+                            {getRoutingOrderStatusText(order, routingHistory)}
                           </Text>
                           <Text fontSize="md" color="gray.500">
-                            {getRoutingOrderSubText(order)}
+                            {getRoutingOrderSubText(order, routingHistory)}
                           </Text>
                         </VStack>
-                        {shouldShowSelectPharmacyButton(order) ? (
+                        {shouldShowSelectPharmacyButton(order, routingHistory) ? (
                           <Button
                             onClick={() => {
                               datadogRum.addAction('select_pharmacy_btn_click', {
@@ -659,55 +673,59 @@ export const OrderDetailPage = () => {
                 </>
               ) : null}
 
-              <InfoGrid name="Name">
-                {loading ? (
-                  <SkeletonText skeletonHeight={5} noOfLines={1} width="100px" />
-                ) : order?.pharmacy?.name ? (
-                  <Text fontSize="md">{order.pharmacy.name}</Text>
-                ) : (
-                  <Text fontSize="md" as="i" color="gray.500">
-                    None
-                  </Text>
-                )}
-              </InfoGrid>
+              {order?.state !== 'ROUTING' && (
+                <>
+                  <InfoGrid name="Name">
+                    {loading ? (
+                      <SkeletonText skeletonHeight={5} noOfLines={1} width="100px" />
+                    ) : order?.pharmacy?.name ? (
+                      <Text fontSize="md">{order.pharmacy.name}</Text>
+                    ) : (
+                      <Text fontSize="md" as="i" color="gray.500">
+                        None
+                      </Text>
+                    )}
+                  </InfoGrid>
 
-              <InfoGrid name="Phone">
-                {loading ? (
-                  <SkeletonText skeletonHeight={5} noOfLines={1} width="100px" />
-                ) : order?.pharmacy?.phone ? (
-                  <Link fontSize="md" href={`tel:${order.pharmacy.phone}`} isExternal>
-                    {formatPhone(order.pharmacy.phone)}
-                  </Link>
-                ) : (
-                  <Text fontSize="md" as="i" color="gray.500">
-                    None
-                  </Text>
-                )}
-              </InfoGrid>
+                  <InfoGrid name="Phone">
+                    {loading ? (
+                      <SkeletonText skeletonHeight={5} noOfLines={1} width="100px" />
+                    ) : order?.pharmacy?.phone ? (
+                      <Link fontSize="md" href={`tel:${order.pharmacy.phone}`} isExternal>
+                        {formatPhone(order.pharmacy.phone)}
+                      </Link>
+                    ) : (
+                      <Text fontSize="md" as="i" color="gray.500">
+                        None
+                      </Text>
+                    )}
+                  </InfoGrid>
 
-              <InfoGrid name="Address">
-                {loading ? (
-                  <SkeletonText skeletonHeight={5} noOfLines={1} width="100px" />
-                ) : order?.pharmacy?.address ? (
-                  <Text fontSize="md">{formatAddress(order.pharmacy.address)}</Text>
-                ) : (
-                  <Text fontSize="md" as="i" color="gray.500">
-                    None
-                  </Text>
-                )}
-              </InfoGrid>
+                  <InfoGrid name="Address">
+                    {loading ? (
+                      <SkeletonText skeletonHeight={5} noOfLines={1} width="100px" />
+                    ) : order?.pharmacy?.address ? (
+                      <Text fontSize="md">{formatAddress(order.pharmacy.address)}</Text>
+                    ) : (
+                      <Text fontSize="md" as="i" color="gray.500">
+                        None
+                      </Text>
+                    )}
+                  </InfoGrid>
 
-              <InfoGrid name="Id">
-                {loading ? (
-                  <SkeletonText skeletonHeight={5} noOfLines={1} width="100px" />
-                ) : order?.pharmacy?.id ? (
-                  <CopyText text={order.pharmacy.id} />
-                ) : (
-                  <Text fontSize="md" as="i" color="gray.500">
-                    None
-                  </Text>
-                )}
-              </InfoGrid>
+                  <InfoGrid name="Id">
+                    {loading ? (
+                      <SkeletonText skeletonHeight={5} noOfLines={1} width="100px" />
+                    ) : order?.pharmacy?.id ? (
+                      <CopyText text={order.pharmacy.id} />
+                    ) : (
+                      <Text fontSize="md" as="i" color="gray.500">
+                        None
+                      </Text>
+                    )}
+                  </InfoGrid>
+                </>
+              )}
 
               {!loading && order?.fulfillment?.type === 'MAIL_ORDER' ? (
                 <>
@@ -786,23 +804,48 @@ export const OrderDetailPage = () => {
   );
 };
 
-function getRoutingOrderStatusText(order: OrderType) {
-  return isOrderMissingPharmacy(order)
-    ? 'This order is pending pharmacy selection by the patient.'
-    : 'This order is pending pharmacy confirmation by the patient.';
+function getRoutingOrderStatusText(order: OrderType, routingHistory: OrderRoutingHistory[]) {
+  switch (true) {
+    case inPreferredPharmacyRoutingWindow(order, routingHistory):
+      return 'This order is pending pharmacy confirmation by the patient.';
+    case isRequestingRerouteFromPatient(order, routingHistory):
+      return 'This order is pending a pharmacy reroute selection from the patient.';
+    default: // initial STP flow, never had an initial pharmacy selection
+      return 'This order is pending pharmacy selection by the patient.';
+  }
 }
 
-function getRoutingOrderSubText(order: OrderType) {
-  return isOrderMissingPharmacy(order)
-    ? 'Select a pharmacy for the patient if needed.'
-    : 'The order will be routed to the below pharmacy if the patient does not confirm within 15 minutes.';
+function getRoutingOrderSubText(order: OrderType, routingHistory: OrderRoutingHistory[]) {
+  switch (true) {
+    case inPreferredPharmacyRoutingWindow(order, routingHistory):
+      return 'The order will be routed to the below pharmacy if the patient does not confirm within 15 minutes.';
+    default:
+      return 'Select a pharmacy for the patient if needed.';
+  }
 }
 
-function shouldShowSelectPharmacyButton(order: OrderType): boolean {
-  const shouldShowButton = isOrderMissingPharmacy(order);
-  return shouldShowButton;
+function shouldShowSelectPharmacyButton(
+  order: OrderType,
+  routingHistory: OrderRoutingHistory[]
+): boolean {
+  return (
+    inPreferredPharmacyRoutingWindow(order, routingHistory) ||
+    isRequestingRerouteFromPatient(order, routingHistory)
+  );
 }
 
-function isOrderMissingPharmacy(order: OrderType): boolean {
-  return order.pharmacy === null || order.pharmacy === undefined;
+function inPreferredPharmacyRoutingWindow(order: OrderType, routingHistory: OrderRoutingHistory[]) {
+  const isRouting = order.state === OrderState.Routing;
+  const hasPharmacy = !!order.pharmacy;
+  const isInitialRoute = !routingHistory.length;
+
+  return isRouting && hasPharmacy && isInitialRoute;
+}
+
+function isRequestingRerouteFromPatient(order: OrderType, routingHistory: OrderRoutingHistory[]) {
+  const isRouting = order.state === OrderState.Routing;
+  const hasPharmacy = !!order.pharmacy;
+  const isInitialRoute = !routingHistory.length;
+
+  return isRouting && hasPharmacy && !isInitialRoute;
 }

--- a/apps/app/src/views/routes/Order.tsx
+++ b/apps/app/src/views/routes/Order.tsx
@@ -54,7 +54,7 @@ import { Fill, Order as OrderType } from '@photonhealth/sdk/dist/types';
 import { datadogRum } from '@datadog/browser-rum';
 import { useProviderAnalytics } from '../../hooks/useProviderAnalytics';
 import { StyledToast } from '../components/StyledToast';
-
+import { RerouteOrderButton } from '../components/RerouteOrderButton';
 import { GET_ORDER, GET_ORDER_QUERY_NAME, PHARMACY_QUERY } from '../../queries';
 
 export const ORDER_FULFILLMENT_TYPE_MAP = {
@@ -138,14 +138,16 @@ Description:
 export const OrderDetailPage = () => {
   const params = useParams();
   const id = params.orderId;
-  const { getToken } = usePhoton();
+  const { user, getToken } = usePhoton();
   const { track } = useProviderAnalytics();
   const [isTicketModalOpen, setIsTicketModalOpen] = useState(false);
   const [accessToken, setAccessToken] = useState('');
   const [updating, setUpdating] = useState(false);
   const { isOpen, onOpen, onClose } = useDisclosure();
   const [pharmacyId, setPharmacyId] = useState('');
-  const { data, loading, error } = useQuery(GET_ORDER, { variables: { id: id! } });
+  const { data, loading, error } = useQuery(GET_ORDER, {
+    variables: { id: id! }
+  });
   const [cancelReason, setCancelReason] = useState('');
   const cancelReasonRef = useRef(cancelReason);
   const client = useApolloClient();
@@ -362,8 +364,8 @@ export const OrderDetailPage = () => {
               loadingText="Canceling..."
               isDisabled={
                 loading ||
-                order.state === types.OrderState.Canceled ||
-                order.state === types.OrderState.Completed ||
+                order?.state === types.OrderState.Canceled ||
+                order?.state === types.OrderState.Completed ||
                 order?.fulfillment?.state === 'SHIPPED'
               }
               onClick={async () => {
@@ -463,8 +465,8 @@ export const OrderDetailPage = () => {
                 <Skeleton width="70px" height="24px" borderRadius="xl" />
               ) : (
                 <OrderStatusBadge
-                  fulfillmentState={order.fulfillment?.state}
-                  orderState={order.state}
+                  fulfillmentState={order?.fulfillment?.state}
+                  orderState={order?.state}
                 />
               )}
             </Stack>
@@ -481,7 +483,7 @@ export const OrderDetailPage = () => {
                     <SkeletonText skeletonHeight={5} noOfLines={2} flexGrow={1} />
                   </HStack>
                 ) : (
-                  <PatientView patient={order.patient} />
+                  <PatientView patient={order?.patient} />
                 )}
               </VStack>
 
@@ -497,7 +499,7 @@ export const OrderDetailPage = () => {
                 {loading ? (
                   <SkeletonText skeletonHeight={5} noOfLines={1} width="125px" />
                 ) : (
-                  <Text fontSize="md">{formatDate(order.createdAt)}</Text>
+                  <Text fontSize="md">{formatDate(order?.createdAt)}</Text>
                 )}
               </VStack>
               {order?.externalId ? (
@@ -525,7 +527,14 @@ export const OrderDetailPage = () => {
               w="100%"
               mt={0}
             >
-              <SectionTitleRow headerText="Pharmacy Information" />
+              <SectionTitleRow
+                headerText="Pharmacy Information"
+                rightElement={
+                  order && order?.state !== 'ROUTING' ? (
+                    <RerouteOrderButton organizationId={user.organizationId} order={order} />
+                  ) : undefined
+                }
+              />
 
               {order?.state === types.OrderState.Routing ? (
                 <>
@@ -700,7 +709,7 @@ export const OrderDetailPage = () => {
                 )}
               </InfoGrid>
 
-              {!loading && order.fulfillment?.type === 'MAIL_ORDER' ? (
+              {!loading && order?.fulfillment?.type === 'MAIL_ORDER' ? (
                 <>
                   <InfoGrid name="Delivery Address">
                     {order?.address ? (

--- a/apps/app/src/views/routes/Order.tsx
+++ b/apps/app/src/views/routes/Order.tsx
@@ -63,6 +63,7 @@ import {
 } from '../../queries';
 import { OrderRoutingHistory } from '../../gql/graphql';
 import { OrderState } from 'packages/sdk/src/types';
+import usePermissions from '../../hooks/usePermissions';
 
 export const ORDER_FULFILLMENT_TYPE_MAP = {
   [types.FulfillmentType.PickUp]: 'Pick up',
@@ -157,6 +158,10 @@ export const OrderDetailPage = () => {
   const client = useApolloClient();
   const theme = useTheme();
   const toast = useToast();
+
+  const canRerouteOrder = usePermissions(['write:order', 'update:order', 'reroute:order'], {
+    hasAny: true
+  });
 
   const { data, loading, error } = useQuery(GET_ORDER, {
     variables: { id }
@@ -544,7 +549,7 @@ export const OrderDetailPage = () => {
               <SectionTitleRow
                 headerText="Pharmacy Information"
                 rightElement={
-                  order && order?.state !== 'ROUTING' ? (
+                  canRerouteOrder && order && order?.state !== 'ROUTING' ? (
                     <RerouteOrderButton organizationId={user.organizationId} order={order} />
                   ) : undefined
                 }

--- a/apps/app/src/views/routes/Order.tsx
+++ b/apps/app/src/views/routes/Order.tsx
@@ -48,7 +48,7 @@ import { LocalPickup } from './NewOrder/components/SelectPharmacyCard/components
 import { LocationResults, LocationSearch } from '../components/LocationSearch';
 import SectionTitleRow from '../components/SectionTitleRow';
 import { gql, useApolloClient, useMutation, useQuery } from '@apollo/client';
-import { CANCEL_ORDER, REROUTE_ORDER } from '../../mutations';
+import { CANCEL_ORDER, ROUTE_ORDER } from '../../mutations';
 import { TicketModal } from '../components/TicketModal';
 import { Fill, Order as OrderType } from '@photonhealth/sdk/dist/types';
 import { datadogRum } from '@datadog/browser-rum';
@@ -256,7 +256,7 @@ export const Order = () => {
       }
     }
   });
-  const [rerouteOrder] = useMutation(REROUTE_ORDER, {
+  const [routeOrder] = useMutation(ROUTE_ORDER, {
     update: async (cache) => {
       // after routing an order, we need to update the cache with the new pharmacy data optimistically
       const existingOrder: { order: types.Order } | null = cache.readQuery({
@@ -713,7 +713,7 @@ export const Order = () => {
                                 orderId: id,
                                 pharmacyId
                               });
-                              await rerouteOrder({ variables: { id, pharmacyId } });
+                              await routeOrder({ variables: { id, pharmacyId } });
                               setPharmacyId('');
                               onClose();
                             } catch (error) {

--- a/apps/app/src/views/routes/Order.tsx
+++ b/apps/app/src/views/routes/Order.tsx
@@ -135,7 +135,7 @@ Description:
   `;
 }
 
-export const Order = () => {
+export const OrderDetailPage = () => {
   const params = useParams();
   const id = params.orderId;
   const { getToken } = usePhoton();

--- a/apps/app/src/views/routes/Order.tsx
+++ b/apps/app/src/views/routes/Order.tsx
@@ -47,7 +47,7 @@ import CopyText from '../components/CopyText';
 import { LocalPickup } from './NewOrder/components/SelectPharmacyCard/components/LocalPickup';
 import { LocationResults, LocationSearch } from '../components/LocationSearch';
 import SectionTitleRow from '../components/SectionTitleRow';
-import { gql, useApolloClient, useMutation, useQuery } from '@apollo/client';
+import { useApolloClient, useMutation, useQuery } from '@apollo/client';
 import { CANCEL_ORDER, ROUTE_ORDER } from '../../mutations';
 import { TicketModal } from '../components/TicketModal';
 import { Fill, Order as OrderType } from '@photonhealth/sdk/dist/types';
@@ -55,100 +55,7 @@ import { datadogRum } from '@datadog/browser-rum';
 import { useProviderAnalytics } from '../../hooks/useProviderAnalytics';
 import { StyledToast } from '../components/StyledToast';
 
-const PHARMACY_FRAGMENT = gql`
-  fragment PharmacyFragment on Pharmacy {
-    id
-    name
-    phone
-    address {
-      city
-      country
-      postalCode
-      state
-      street1
-      street2
-    }
-  }
-`;
-
-const PHARMACY_QUERY = gql`
-  ${PHARMACY_FRAGMENT}
-
-  query GetPharmacy($id: ID!) {
-    pharmacy(id: $id) {
-      ...PharmacyFragment
-    }
-  }
-`;
-
-const GET_ORDER_QUERY_NAME = 'GetOrder';
-const GET_ORDER = gql`
-  ${PHARMACY_FRAGMENT}
-
-  query ${GET_ORDER_QUERY_NAME}($id: ID!) {
-    order(id: $id) {
-      __typename
-      id
-      externalId
-      state
-      address {
-        name {
-          full
-        }
-        city
-        country
-        postalCode
-        state
-        street1
-        street2
-      }
-      fills {
-        id
-        prescription {
-          id
-          dispenseQuantity
-          dispenseUnit
-          fillsAllowed
-          instructions
-        }
-        treatment {
-          name
-        }
-        state
-        requestedAt
-        filledAt
-      }
-      patient {
-        id
-        externalId
-        name {
-          full
-        }
-        dateOfBirth
-        sex
-        gender
-        email
-        phone
-      }
-      pharmacy {
-        ...PharmacyFragment
-      }
-      fulfillment {
-        type
-        state
-        carrier
-        trackingNumber
-      }
-      exceptions {
-        type
-        message
-        createdAt
-        resolvedAt
-      }
-      createdAt
-    }
-  }
-`;
+import { GET_ORDER, GET_ORDER_QUERY_NAME, PHARMACY_QUERY } from '../../queries';
 
 export const ORDER_FULFILLMENT_TYPE_MAP = {
   [types.FulfillmentType.PickUp]: 'Pick up',

--- a/apps/app/src/views/routes/Order.tsx
+++ b/apps/app/src/views/routes/Order.tsx
@@ -550,7 +550,7 @@ export const OrderDetailPage = () => {
                 headerText="Pharmacy Information"
                 rightElement={
                   canRerouteOrder && order && order?.state !== 'ROUTING' ? (
-                    <RerouteOrderButton organizationId={user.organizationId} order={order} />
+                    <RerouteOrderButton organizationId={user.org_id} order={order} />
                   ) : undefined
                 }
               />

--- a/apps/patient/src/views/Status.tsx
+++ b/apps/patient/src/views/Status.tsx
@@ -23,6 +23,7 @@ import { computeNumRefillsForPrescription } from '../utils/presenters';
 import { CouponCardList } from '../components/coupons';
 import { Pharmacy } from '../utils/models';
 import { usePatientAnalytics } from '../hooks/usePatientAnalytics';
+import { OrderState } from 'packages/sdk/src/types';
 
 export const Status = () => {
   const navigate = useNavigate();
@@ -161,6 +162,17 @@ export const Status = () => {
   };
 
   const handleReroute = () => {
+    const isRouting = order.state === OrderState.Routing;
+    const isInitialRoute = !order.metadata?.routingHistory?.length;
+    const providerRequestedReroute = isRouting && !isInitialRoute;
+
+    if (providerRequestedReroute) {
+      const reason = 'Provider enabled rerouting';
+      setReason(reason);
+      navigateToReroute(reason);
+      return;
+    }
+
     const hasUnresolvedOrderError = order.exceptions.some(
       (e) => e.exceptionType === 'ORDER_ERROR' && !e.resolvedAt
     );

--- a/packages/components/src/particles/ComboBox/index.tsx
+++ b/packages/components/src/particles/ComboBox/index.tsx
@@ -1,9 +1,9 @@
 import {
   createContext,
   createEffect,
-  createMemo,
   createSignal,
   JSX,
+  onCleanup,
   onMount,
   Show,
   splitProps,
@@ -15,7 +15,8 @@ import Input, { InputProps } from '../Input';
 import { createStore } from 'solid-js/store';
 import clsx from 'clsx';
 import { useInputGroup } from '../InputGroup';
-import { Dynamic } from 'solid-js/web';
+import { Dynamic, Portal } from 'solid-js/web';
+import { getScrollAncestors } from '../../utils/getScrollAncestors';
 
 export type ComboBoxValueBase = { id: string };
 
@@ -108,39 +109,80 @@ export function ComboBox<T extends ComboBoxValueBase>(props: ComboBoxProps<T>) {
   );
 }
 
+type DropdownPos = { top?: number; bottom?: number; left: number; width: number };
+
 function ComboOptions(props: { children?: JSX.Element }) {
   const [state] = useContext(ComboBoxContext);
   let ref: HTMLDivElement | undefined;
+  const [pos, setPos] = createSignal<DropdownPos | null>(null);
 
-  const calculateDropdownPosition = createMemo(() => {
-    // this defaults to the dropdown being below the input, but if it's near
-    // the bottom of the viewport it will go above
-    if (state.open && ref?.getBoundingClientRect) {
-      const rect = ref.getBoundingClientRect();
-      const spaceBelow = window.innerHeight - rect.bottom;
-      const spaceAbove = rect.top;
-      return spaceBelow > spaceAbove ? 'bottom' : 'top';
+  // Anchor the dropdown via `position: fixed` instead of `position: absolute`
+  // so it escapes any scrolling/overflow ancestor
+  const updatePosition = () => {
+    if (!ref?.getBoundingClientRect) return;
+    const rect = ref.getBoundingClientRect();
+    const inputBottom = rect.top;
+    const inputTop = ref.parentElement?.getBoundingClientRect().top ?? rect.top;
+    const spaceBelow = window.innerHeight - inputBottom;
+    const spaceAbove = inputTop;
+    if (spaceBelow > spaceAbove) {
+      setPos({ top: inputBottom + 4, left: rect.left, width: rect.width });
+    } else {
+      setPos({
+        bottom: window.innerHeight - inputTop + 4,
+        left: rect.left,
+        width: rect.width
+      });
     }
-    return 'bottom';
+  };
+
+  // Set event listeners while open to update position on scroll and resize and flip
+  createEffect(() => {
+    if (!state.open || !ref) {
+      setPos(null);
+      return;
+    }
+    updatePosition();
+    const onScroll = () => updatePosition();
+    const onResize = () => updatePosition();
+    const scrollTargets = getScrollAncestors(ref);
+    scrollTargets.forEach((t) => t.addEventListener('scroll', onScroll, { passive: true }));
+    window.addEventListener('resize', onResize, { passive: true });
+    onCleanup(() => {
+      scrollTargets.forEach((t) => t.removeEventListener('scroll', onScroll));
+      window.removeEventListener('resize', onResize);
+    });
   });
 
-  const classes = createMemo(() => {
-    return clsx(
-      'absolute z-10 w-full bg-white shadow-lg max-h-60 rounded-md py-1 text-base ring-1 ring-black ring-opacity-5 overflow-auto focus:outline-none sm:text-sm',
-      {
-        'bottom-full mb-1': calculateDropdownPosition() === 'top',
-        'top-full mt-1': calculateDropdownPosition() === 'bottom'
-      }
-    );
-  });
+  // Portal the dropdown out of the in-flow position so it isn't clipped by
+  // scrolling/overflow ancestors
+  const getMountTarget = (): Node | undefined => {
+    if (!ref) return undefined;
+    const root = ref.getRootNode();
+    if (root instanceof ShadowRoot) return root;
+    return undefined; // Portal defaults to document.body
+  };
 
   // ref! => https://github.com/solidjs/solid/issues/116#issuecomment-1487981714
   return (
     <div ref={ref!}>
-      <Show when={state.open}>
-        <ul class={classes()} role="listbox" tabindex="-1">
-          {props.children}
-        </ul>
+      <Show when={state.open && pos()}>
+        <Portal mount={getMountTarget()}>
+          <ul
+            class="z-10 bg-white shadow-lg max-h-60 rounded-md py-1 text-base ring-1 ring-black ring-opacity-5 overflow-auto focus:outline-none sm:text-sm"
+            role="listbox"
+            tabindex="-1"
+            style={{
+              position: 'fixed',
+              top: pos()!.top != null ? `${pos()!.top}px` : undefined,
+              bottom: pos()!.bottom != null ? `${pos()!.bottom}px` : undefined,
+              left: `${pos()!.left}px`,
+              width: `${pos()!.width}px`
+            }}
+          >
+            {props.children}
+          </ul>
+        </Portal>
       </Show>
     </div>
   );

--- a/packages/components/src/particles/ComboBox/index.tsx
+++ b/packages/components/src/particles/ComboBox/index.tsx
@@ -169,7 +169,7 @@ function ComboOptions(props: { children?: JSX.Element }) {
       <Show when={state.open && pos()}>
         <Portal mount={getMountTarget()}>
           <ul
-            class="z-10 bg-white shadow-lg max-h-60 rounded-md py-1 text-base ring-1 ring-black ring-opacity-5 overflow-auto focus:outline-none sm:text-sm"
+            class="z-2000 bg-white shadow-lg max-h-60 rounded-md py-1 text-base ring-1 ring-black ring-opacity-5 overflow-auto focus:outline-none sm:text-sm"
             role="listbox"
             tabindex="-1"
             style={{

--- a/packages/components/src/systems/PharmacySearch/MailOrderPharmacySearch.tsx
+++ b/packages/components/src/systems/PharmacySearch/MailOrderPharmacySearch.tsx
@@ -78,7 +78,7 @@ export function MailOrderPharmacySearch(props: MailOrderPharmacySearchProps) {
         <PharmacySearchInput
           label={
             <div class="mb-2">
-              <label>Search home delivery options</label>
+              <label class="text-sm font-medium">Search home delivery options</label>
             </div>
           }
           options={pharmacyOptions()}

--- a/packages/components/src/systems/PharmacySearch/index.tsx
+++ b/packages/components/src/systems/PharmacySearch/index.tsx
@@ -248,7 +248,7 @@ export default function PickupPharmacySearch(props: PharmacySearchProps) {
         loading={fetchingPharmacies()}
         label={
           <div class="w-full flex flex-col sm:flex-row sm:items-center mb-2">
-            <label class="whitespace-nowrap mr-1">Showing near:</label>
+            <label class="text-sm font-medium whitespace-nowrap mr-1">Showing near:</label>
             <Show when={!fetchingPreferred()} fallback={<Spinner size="sm" />}>
               <button
                 type="button"

--- a/packages/components/src/systems/PharmacySelect/PharmacySelect.tsx
+++ b/packages/components/src/systems/PharmacySelect/PharmacySelect.tsx
@@ -36,6 +36,7 @@ interface PharmacySelectProps {
   patientIds?: string[];
   address?: string;
   hasPreferredPharmacy?: boolean;
+  inferSendToPatientPharmacy?: boolean;
 }
 
 const fulfillmentOptions: FulfillmentOptions = [
@@ -157,7 +158,10 @@ export function PharmacySelect(props: PharmacySelectProps) {
               when={(props?.patientIds?.length || 0) > 0}
               fallback={<div>Please select a patient.</div>}
             >
-              <SendToPatient patientId={props.patientIds![0]} />
+              <SendToPatient
+                patientId={props.patientIds![0]}
+                inferSendToPatientPharmacy={props.inferSendToPatientPharmacy}
+              />
             </Show>
           </div>
         </Show>

--- a/packages/components/src/systems/PharmacySelect/PharmacySelect.tsx
+++ b/packages/components/src/systems/PharmacySelect/PharmacySelect.tsx
@@ -39,6 +39,7 @@ interface PharmacySelectProps {
   hasPreferredPharmacy?: boolean;
   inferSendToPatientPharmacy?: boolean;
   stickyTabHeader?: boolean;
+  enableSavingPreferredPharmacy?: boolean;
 }
 
 const fulfillmentOptions: FulfillmentOptions = [
@@ -191,6 +192,7 @@ export function PharmacySelect(props: PharmacySelectProps) {
                     pharmacySelectionContext.setPharmacyId(pharmacy.id);
                   }
                 }}
+                hidePreferred={!(props.enableSavingPreferredPharmacy ?? true)}
                 setPreferred={(shouldSetPreferred) => {
                   pharmacySelectionContext.setUpdatePreferredPharmacy(shouldSetPreferred);
                   dispatchAnalyticsTrackEvent('fieldInteraction', {

--- a/packages/components/src/systems/PharmacySelect/PharmacySelect.tsx
+++ b/packages/components/src/systems/PharmacySelect/PharmacySelect.tsx
@@ -12,6 +12,7 @@ import { PharmacyRoutingAlert } from '../RoutingConstraints';
 import { Alert } from '../../particles/Alert';
 import { MailOrderPharmacySearch } from '../PharmacySearch/MailOrderPharmacySearch';
 import { PharmacyOption } from '../PharmacySearch/PharmacySearch';
+import clsx from 'clsx';
 
 enum SendToPatientEnum {
   sendToPatient = 'SEND_TO_PATIENT'
@@ -37,6 +38,7 @@ interface PharmacySelectProps {
   address?: string;
   hasPreferredPharmacy?: boolean;
   inferSendToPatientPharmacy?: boolean;
+  stickyTabHeader?: boolean;
 }
 
 const fulfillmentOptions: FulfillmentOptions = [
@@ -150,7 +152,9 @@ export function PharmacySelect(props: PharmacySelectProps) {
 
   return (
     <div>
-      <Tabs<TabNamesEnum> tabs={tabs()} activeTab={activeTab()} setActiveTab={handleTabChange} />
+      <div class={clsx({ 'sticky top-0 bg-white z-10': props.stickyTabHeader ?? false })}>
+        <Tabs<TabNamesEnum> tabs={tabs()} activeTab={activeTab()} setActiveTab={handleTabChange} />
+      </div>
       <div class="pt-4">
         <Show when={tabs().includes(TabNamesEnum.sendToPatient)}>
           <div class={activeTab() !== TabNamesEnum.sendToPatient ? 'hidden' : ''}>

--- a/packages/components/src/systems/PharmacySelect/PharmacySelect.tsx
+++ b/packages/components/src/systems/PharmacySelect/PharmacySelect.tsx
@@ -223,7 +223,7 @@ export function PharmacySelect(props: PharmacySelectProps) {
                 />
                 {(pharmacySelectionContext.mailOrderPharmacyIds()?.length ?? 0) > 0 && (
                   <div class="space-y-2">
-                    <label>Choose a partner pharmacy</label>
+                    <label class="text-sm font-medium">Choose a partner pharmacy</label>
                     <RadioGroupCards
                       label="Pharmacies"
                       value={mailOrderId()}

--- a/packages/components/src/systems/PharmacySelect/SendToPatient.tsx
+++ b/packages/components/src/systems/PharmacySelect/SendToPatient.tsx
@@ -47,7 +47,15 @@ const stpStates: {
   }
 };
 
-export function SendToPatient(props: { patientId: string; inferSendToPatientPharmacy?: boolean }) {
+type SendToPatientProps = {
+  patientId: string;
+  // this is to control whether or not we infer which pharmacy is chosen in the
+  // send to patient flow. Inferences such as recent order pharmacy, preferred
+  // pharmacy, or coverage pharmacy on the STP tab.
+  inferSendToPatientPharmacy?: boolean;
+};
+
+export function SendToPatient(props: SendToPatientProps) {
   const client = usePhotonClient();
   const { selectedCoverageOption } = usePrescribe();
   const { pharmacyId } = usePharmacySelectionContext();

--- a/packages/components/src/systems/PharmacySelect/SendToPatient.tsx
+++ b/packages/components/src/systems/PharmacySelect/SendToPatient.tsx
@@ -47,7 +47,7 @@ const stpStates: {
   }
 };
 
-export function SendToPatient(props: { patientId: string }) {
+export function SendToPatient(props: { patientId: string; inferSendToPatientPharmacy?: boolean }) {
   const client = usePhotonClient();
   const { selectedCoverageOption } = usePrescribe();
   const { pharmacyId } = usePharmacySelectionContext();
@@ -55,9 +55,12 @@ export function SendToPatient(props: { patientId: string }) {
   const [stpState, setStpState] = createSignal<STPState>(stpStates.patientWillSelect);
   const [pharmacy, setPharmacy] = createSignal<Pharmacy | undefined>(undefined);
 
+  const inferSendToPatientPharmacy = createMemo(() => props.inferSendToPatientPharmacy ?? true);
+
   const queryOptions = createMemo(() => ({
     variables: { id: props.patientId },
-    client: client.apollo
+    client: client.apollo,
+    skip: !inferSendToPatientPharmacy()
   }));
 
   const preferredPharmaciesData = createQuery<GetPreferredPharmaciesResponse, { id: string }>(
@@ -84,7 +87,7 @@ export function SendToPatient(props: { patientId: string }) {
   });
 
   createEffect(() => {
-    if (notLoading()) {
+    if (notLoading() && inferSendToPatientPharmacy()) {
       const preferredPharmacies = preferredPharmaciesData()?.patient?.preferredPharmacies;
       const lastPharmacy = recentOrder()?.pharmacy;
       if ((preferredPharmacies?.length ?? 0) > 0) {
@@ -113,6 +116,8 @@ export function SendToPatient(props: { patientId: string }) {
   });
 
   createEffect(() => {
+    if (!inferSendToPatientPharmacy()) return;
+
     const coverageOption = selectedCoverageOption();
     const currentPharmacyId = pharmacyId();
     if (coverageOption && currentPharmacyId && coverageOption.pharmacy.id === currentPharmacyId) {

--- a/packages/components/src/utils/getScrollAncestors.ts
+++ b/packages/components/src/utils/getScrollAncestors.ts
@@ -1,0 +1,21 @@
+// Walk up the DOM finding every overflow ancestor of `el`, traversing across
+// shadow-DOM boundaries when we hit a shadow root.
+export const getScrollAncestors = (el: Element): EventTarget[] => {
+  const result: EventTarget[] = [];
+  let node: Node | null = el.parentNode;
+  while (node) {
+    if (node instanceof Element) {
+      const { overflowX, overflowY } = getComputedStyle(node);
+      if (/(auto|scroll|overlay)/.test(`${overflowX}${overflowY}`)) {
+        result.push(node);
+      }
+      node = node.parentNode;
+    } else if (node instanceof ShadowRoot) {
+      node = node.host;
+    } else {
+      break; // Document — stop; window catches viewport scroll
+    }
+  }
+  result.push(window);
+  return result;
+};

--- a/packages/elements/src/index.ts
+++ b/packages/elements/src/index.ts
@@ -11,3 +11,4 @@ import './photon-medication-search';
 import './photon-add-medication-history-dialog';
 import './photon-med-history';
 import './photon-multirx-form-wrapper';
+import './photon-pharmacy-select';

--- a/packages/elements/src/photon-pharmacy-select/index.ts
+++ b/packages/elements/src/photon-pharmacy-select/index.ts
@@ -1,0 +1,1 @@
+export * from './photon-pharmacy-select';

--- a/packages/elements/src/photon-pharmacy-select/photon-pharmacy-select.tsx
+++ b/packages/elements/src/photon-pharmacy-select/photon-pharmacy-select.tsx
@@ -20,6 +20,7 @@ interface PhotonPharmacySelectProps {
   enableLocalPickup: boolean;
   enableSendToPatient: boolean;
   enableDeliveryPharmacies: boolean;
+  enableSavingPreferredPharmacy?: boolean;
   inferSendToPatientPharmacy?: boolean;
   stickyTabHeader?: boolean;
 }
@@ -30,13 +31,18 @@ type PharmacySelectedDetail = {
   updatePreferredPharmacy: boolean;
 };
 
-const PharmacySelectWithEvents = (props: {
-  patientId?: string;
-  address?: string;
-  inferSendToPatientPharmacy?: boolean;
-  stickyTabHeader?: boolean;
-  onChange: (detail: PharmacySelectedDetail) => void;
-}) => {
+const PharmacySelectWithEvents = (
+  props: Pick<
+    PhotonPharmacySelectProps,
+    | 'patientId'
+    | 'address'
+    | 'inferSendToPatientPharmacy'
+    | 'stickyTabHeader'
+    | 'enableSavingPreferredPharmacy'
+  > & {
+    onChange: (detail: PharmacySelectedDetail) => void;
+  }
+) => {
   const ctx = usePharmacySelectionContext();
 
   let isFirst = true;
@@ -59,6 +65,7 @@ const PharmacySelectWithEvents = (props: {
       address={props.address}
       inferSendToPatientPharmacy={props.inferSendToPatientPharmacy}
       stickyTabHeader={props.stickyTabHeader}
+      enableSavingPreferredPharmacy={props.enableSavingPreferredPharmacy}
     />
   );
 };
@@ -101,6 +108,7 @@ const PhotonPharmacySelectComponent = (props: PhotonPharmacySelectProps) => {
                   onChange={dispatchPharmacySelected}
                   inferSendToPatientPharmacy={props.inferSendToPatientPharmacy}
                   stickyTabHeader={props.stickyTabHeader}
+                  enableSavingPreferredPharmacy={props.enableSavingPreferredPharmacy}
                 />
               </PrescribeProvider>
             </PharmacySelectionProvider>
@@ -121,6 +129,7 @@ customElement(
     enableLocalPickup: false,
     enableSendToPatient: false,
     enableDeliveryPharmacies: false,
+    enableSavingPreferredPharmacy: false,
     inferSendToPatientPharmacy: true,
     stickyTabHeader: false
   },

--- a/packages/elements/src/photon-pharmacy-select/photon-pharmacy-select.tsx
+++ b/packages/elements/src/photon-pharmacy-select/photon-pharmacy-select.tsx
@@ -20,6 +20,7 @@ interface PhotonPharmacySelectProps {
   enableLocalPickup: boolean;
   enableSendToPatient: boolean;
   enableDeliveryPharmacies: boolean;
+  inferSendToPatientPharmacy?: boolean;
 }
 
 type PharmacySelectedDetail = {
@@ -31,6 +32,7 @@ type PharmacySelectedDetail = {
 const PharmacySelectWithEvents = (props: {
   patientId?: string;
   address?: string;
+  inferSendToPatientPharmacy?: boolean;
   onChange: (detail: PharmacySelectedDetail) => void;
 }) => {
   const ctx = usePharmacySelectionContext();
@@ -53,6 +55,7 @@ const PharmacySelectWithEvents = (props: {
     <PharmacySelect
       patientIds={props.patientId ? [props.patientId] : undefined}
       address={props.address}
+      inferSendToPatientPharmacy={props.inferSendToPatientPharmacy}
     />
   );
 };
@@ -93,6 +96,7 @@ const PhotonPharmacySelectComponent = (props: PhotonPharmacySelectProps) => {
                   patientId={props.patientId}
                   address={props.address}
                   onChange={dispatchPharmacySelected}
+                  inferSendToPatientPharmacy={props.inferSendToPatientPharmacy}
                 />
               </PrescribeProvider>
             </PharmacySelectionProvider>
@@ -112,7 +116,8 @@ customElement(
     mailOrderIds: undefined,
     enableLocalPickup: false,
     enableSendToPatient: false,
-    enableDeliveryPharmacies: false
+    enableDeliveryPharmacies: false,
+    inferSendToPatientPharmacy: true
   },
   PhotonPharmacySelectComponent
 );

--- a/packages/elements/src/photon-pharmacy-select/photon-pharmacy-select.tsx
+++ b/packages/elements/src/photon-pharmacy-select/photon-pharmacy-select.tsx
@@ -21,6 +21,7 @@ interface PhotonPharmacySelectProps {
   enableSendToPatient: boolean;
   enableDeliveryPharmacies: boolean;
   inferSendToPatientPharmacy?: boolean;
+  stickyTabHeader?: boolean;
 }
 
 type PharmacySelectedDetail = {
@@ -33,6 +34,7 @@ const PharmacySelectWithEvents = (props: {
   patientId?: string;
   address?: string;
   inferSendToPatientPharmacy?: boolean;
+  stickyTabHeader?: boolean;
   onChange: (detail: PharmacySelectedDetail) => void;
 }) => {
   const ctx = usePharmacySelectionContext();
@@ -56,6 +58,7 @@ const PharmacySelectWithEvents = (props: {
       patientIds={props.patientId ? [props.patientId] : undefined}
       address={props.address}
       inferSendToPatientPharmacy={props.inferSendToPatientPharmacy}
+      stickyTabHeader={props.stickyTabHeader}
     />
   );
 };
@@ -97,6 +100,7 @@ const PhotonPharmacySelectComponent = (props: PhotonPharmacySelectProps) => {
                   address={props.address}
                   onChange={dispatchPharmacySelected}
                   inferSendToPatientPharmacy={props.inferSendToPatientPharmacy}
+                  stickyTabHeader={props.stickyTabHeader}
                 />
               </PrescribeProvider>
             </PharmacySelectionProvider>
@@ -117,7 +121,8 @@ customElement(
     enableLocalPickup: false,
     enableSendToPatient: false,
     enableDeliveryPharmacies: false,
-    inferSendToPatientPharmacy: true
+    inferSendToPatientPharmacy: true,
+    stickyTabHeader: false
   },
   PhotonPharmacySelectComponent
 );

--- a/packages/elements/src/photon-pharmacy-select/photon-pharmacy-select.tsx
+++ b/packages/elements/src/photon-pharmacy-select/photon-pharmacy-select.tsx
@@ -1,0 +1,118 @@
+import {
+  DraftPrescriptionsProvider,
+  PharmacySelect,
+  PharmacySelectionProvider,
+  PrescribeEventDispatchProvider,
+  PrescribeProvider,
+  RecentOrders,
+  usePharmacySelectionContext
+} from '@photonhealth/components';
+import { customElement } from 'solid-element';
+import { createEffect } from 'solid-js';
+import { types } from '@photonhealth/sdk';
+import tailwind from '../tailwind.css?inline';
+
+interface PhotonPharmacySelectProps {
+  patientId?: string;
+  address?: string;
+  pharmacyId?: string;
+  mailOrderIds?: string;
+  enableLocalPickup: boolean;
+  enableSendToPatient: boolean;
+  enableDeliveryPharmacies: boolean;
+}
+
+type PharmacySelectedDetail = {
+  pharmacyId: string | undefined;
+  fulfillmentType: types.FulfillmentType | undefined;
+  updatePreferredPharmacy: boolean;
+};
+
+const PharmacySelectWithEvents = (props: {
+  patientId?: string;
+  address?: string;
+  onChange: (detail: PharmacySelectedDetail) => void;
+}) => {
+  const ctx = usePharmacySelectionContext();
+
+  let isFirst = true;
+  createEffect(() => {
+    const pharmacyId = ctx.pharmacyId();
+    const fulfillmentType = ctx.fulfillmentType();
+    const updatePreferredPharmacy = ctx.updatePreferredPharmacy();
+
+    if (isFirst) {
+      isFirst = false;
+      return;
+    }
+
+    props.onChange({ pharmacyId, fulfillmentType, updatePreferredPharmacy });
+  });
+
+  return (
+    <PharmacySelect
+      patientIds={props.patientId ? [props.patientId] : undefined}
+      address={props.address}
+    />
+  );
+};
+
+const PhotonPharmacySelectComponent = (props: PhotonPharmacySelectProps) => {
+  let ref!: HTMLDivElement;
+
+  const dispatchPharmacySelected = (detail: PharmacySelectedDetail) => {
+    const event = new CustomEvent('photon-pharmacy-selected', {
+      composed: true,
+      bubbles: true,
+      detail
+    });
+    ref?.dispatchEvent(event);
+  };
+
+  return (
+    <div ref={ref}>
+      <style>{tailwind}</style>
+      <PrescribeEventDispatchProvider>
+        <RecentOrders patientId={props.patientId ?? ''}>
+          <DraftPrescriptionsProvider
+            patientId={props.patientId || ''}
+            templateIdsPrefill={[]}
+            templateOverrides={{}}
+            prescriptionIdsPrefill={[]}
+            enableCombineAndDuplicate={false}
+          >
+            <PharmacySelectionProvider
+              pharmacyIdProp={props.pharmacyId}
+              enableLocalPickup={props.enableLocalPickup}
+              enableSendToPatient={props.enableSendToPatient}
+              enableDeliveryPharmacies={props.enableDeliveryPharmacies}
+              mailOrderIds={props.mailOrderIds}
+            >
+              <PrescribeProvider patientId={props.patientId || ''} enableCoverageCheck={false}>
+                <PharmacySelectWithEvents
+                  patientId={props.patientId}
+                  address={props.address}
+                  onChange={dispatchPharmacySelected}
+                />
+              </PrescribeProvider>
+            </PharmacySelectionProvider>
+          </DraftPrescriptionsProvider>
+        </RecentOrders>
+      </PrescribeEventDispatchProvider>
+    </div>
+  );
+};
+
+customElement(
+  'photon-pharmacy-select',
+  {
+    patientId: undefined,
+    address: undefined,
+    pharmacyId: undefined,
+    mailOrderIds: undefined,
+    enableLocalPickup: false,
+    enableSendToPatient: false,
+    enableDeliveryPharmacies: false
+  },
+  PhotonPharmacySelectComponent
+);

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -949,6 +949,7 @@ export type Permission =
   | 'edit:profile_self'
   | 'manage:organization'
   | 'manage:user_roles'
+  | 'reroute:order'
   | 'read:client'
   | 'read:invite'
   | 'read:order'


### PR DESCRIPTION
Fulfilling all the needs of this ticket: https://linear.app/photon-health/issue/X-109/build-ui-for-provider-rerouting
# Technical Notes:
- had to expose a web component wrapper specifically for the order pharmacy select portion
- Had to create a Dialog component because Chakra's modal component portals out and prevents the pharmacy select web component events from bubbling up and being caught in the reroute order modal 
- Had to use a Portal and fixed position for `Combobox` options so that they didn't get clipped by any modal UI and still respected position flipping when the screen changes. 
- A lot of the lift for this is already done on the backend. 
- Tested edge cases for patient with preferred pharmacies, recent orders, rerouting to mail order, rerouting to pick up, rerouting as STP and selecting via patient UI
  - In order to do a full component test for the reroute button, i needed to add a test harness for the clinical-app component tests. 
    - added `app/src/test-utils` and had claude follow similar test harness patterns established elsewhere in the project. 
    - fixtures should grow and be less painful with time
    - harness is mutable for per-test flexibility
    - each component test runs in a separate node process via vite, so each test has its own msw server and should prevent brittle tests
- Was getting frustrated with all the inline graphql queries. Moved them to specific folders `src/(queries|mutations)/(lambda-api|clinical-api)`
  - Can move more there in a follow-up refactor pr


# Functionality: 

## Ordinary provider reroutes

### Reroutes to another pharmacy

https://github.com/user-attachments/assets/bd13cae3-c808-4e23-be2f-405b62c8e34c

### Displays an error message when max reroutes is hit
https://github.com/user-attachments/assets/a325b05f-4851-4059-aa14-cd2acff3c8a9

## "Send To Patient" Reroutes

### Shows the order as back in pending selection

https://github.com/user-attachments/assets/21ffafcc-1751-442c-abd4-7658cdb2dcef


### Texts the patient to select a new pharmacy
<img width="1179" height="652" alt="IMG_6486" src="https://github.com/user-attachments/assets/d9a5d1e6-49be-4ec8-bb47-0211a23990d3" />

### Patient changes pharmacy without needing a reason

https://github.com/user-attachments/assets/af9659f4-2240-4d31-9172-200a4e8789ba

### Routing History Shows Provider for initial route, Patient for the STP Reroute
<img width="1310" height="102" alt="Screenshot 2026-05-18 at 2 21 29 PM" src="https://github.com/user-attachments/assets/aaf2ada1-0687-4c0b-a004-26a0c27b0552" />

