### PR TITLE
move identify call to after order is loaded and we have patient id

### DIFF
--- a/apps/patient/src/views/Main.tsx
+++ b/apps/patient/src/views/Main.tsx
@@ -106,27 +106,6 @@ export const Main = () => {
   const settings = order?.organization.settings;
 
   useEffect(() => {
-    if (order) {
-      patientAnalytics.identify({
-        userId: order.patient.id,
-        address: order.address
-          ? {
-              city: order.address.city,
-              country: order.address.country,
-              postalCode: order.address.postalCode,
-              state: order.address.state,
-              street: order.address.street2
-                ? `${order.address.street1}, ${order.address.street2}`
-                : order.address.street1
-            }
-          : undefined,
-        orgId: order.organization.id,
-        orgName: order.organization.name
-      });
-    }
-  }, [order?.patient.id, order?.organization.id, order?.organization.name, order?.address]);
-
-  useEffect(() => {
     // need to parse the token and see if this is a controlled substance link
     let tokenData: TokenPayload | undefined;
     try {
@@ -167,7 +146,22 @@ export const Main = () => {
 
       const newFlattenedFills = countFillsAndRemoveDuplicates(newOrder.fills);
       setFlattenedFills(newFlattenedFills);
-
+      patientAnalytics.identify({
+        userId: newOrder.patient.id,
+        address: newOrder.address
+          ? {
+              city: newOrder.address.city,
+              country: newOrder.address.country,
+              postalCode: newOrder.address.postalCode,
+              state: newOrder.address.state,
+              street: newOrder.address.street2
+                ? `${newOrder.address.street1}, ${newOrder.address.street2}`
+                : newOrder.address.street1
+            }
+          : undefined,
+        orgId: newOrder.organization.id,
+        orgName: newOrder.organization.name
+      });
       patientAnalytics.track('Patient App Opened', newOrder, {});
     },
     [orderId, order]


### PR DESCRIPTION
<img width="541" height="215" alt="Screenshot 2026-05-19 at 4 15 42 PM" src="https://github.com/user-attachments/assets/20e35ff8-b8e6-4119-bf46-f2c2c57e29af" />
<img width="532" height="179" alt="Screenshot 2026-05-19 at 4 15 59 PM" src="https://github.com/user-attachments/assets/a4d6a240-64b8-49b9-a4cb-74950d3172a0" />

we were grabbing the feature flag BEFORE identifying the user, which meant mixpanel was using a default distinct_id to associate the ff (default is to use device id). This resulted in us having two FF fetches - one with the device id and one with the patient id. We wait until after the order is loaded to identify the user so we can pass along relevant context. I just moved this call to happen BEFORE we attempt to grab the flag. 