### PR TITLE
Bump graphql for services api compat

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "formik": "^2.2.9",
         "framer-motion": "^11.0.20",
         "graphiql": "^2.4.1",
-        "graphql": "^16.9.0",
+        "graphql": "^16.14.0",
         "graphql-request": "^6.1.0",
         "graphql-scalars": "^1.23.0",
         "graphql-tag": "^2.12.6",
@@ -17642,9 +17642,9 @@
       }
     },
     "node_modules/graphql": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.13.1.tgz",
-      "integrity": "sha512-gGgrVCoDKlIZ8fIqXBBb0pPKqDgki0Z/FSKNiQzSGj2uEYHr1tq5wmBegGwJx6QB5S5cM0khSBpi/JFHMCvsmQ==",
+      "version": "16.14.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.14.0.tgz",
+      "integrity": "sha512-BBvQ/406p+4CZbTpCbVPSxfzrZrbnuWSP1ELYgyS6B+hNeKzgrdB4JczCa5VZUBQrDa9hUngm0KnexY6pJRN5Q==",
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "formik": "^2.2.9",
     "framer-motion": "^11.0.20",
     "graphiql": "^2.4.1",
-    "graphql": "^16.9.0",
+    "graphql": "^16.14.0",
     "graphql-request": "^6.1.0",
     "graphql-scalars": "^1.23.0",
     "graphql-tag": "^2.12.6",


### PR DESCRIPTION
fixes codegen against patient API via `nx run patient:codegen`