### PR TITLE
Fix missing `Select a pharmacy` link cta when order is in initial routing state (waiting for preferred pharmacy auto route) 

### DIFF
--- a/apps/app/src/queries/lambda-api/orders.ts
+++ b/apps/app/src/queries/lambda-api/orders.ts
@@ -1,9 +1,13 @@
 import { gql } from '@apollo/client';
 import { PHARMACY_FRAGMENT } from './pharmacies';
+import { PatientFieldsFragmentMap } from '../../model/fragments';
+
+const PatientFieldsAppFragment = PatientFieldsFragmentMap.PatientFieldsAppFragment;
 
 export const GET_ORDER_QUERY_NAME = 'GetOrder';
 export const GET_ORDER = gql`
   ${PHARMACY_FRAGMENT}
+  ${PatientFieldsAppFragment}
 
   query ${GET_ORDER_QUERY_NAME}($id: ID!) {
     order(id: $id) {
@@ -50,6 +54,7 @@ export const GET_ORDER = gql`
         gender
         email
         phone
+        ...PatientFieldsAppFragment
       }
       pharmacy {
         ...PharmacyFragment

--- a/apps/app/src/setupTests.ts
+++ b/apps/app/src/setupTests.ts
@@ -70,15 +70,19 @@ export const harness: {
 
 // Sync vi.mock factories that read directly from the module-scope `harness`.
 // No dynamic import → no cycle.
-vi.mock('@photonhealth/react', () => ({
-  usePhoton: () => ({
-    isAuthenticated: harness.isAuthenticated,
-    isLoading: harness.isLoading,
-    user: harness.user,
-    clinicalClient: harness.photonClient.apolloClinical,
-    getToken: async () => 'test-token'
-  })
-}));
+vi.mock('@photonhealth/react', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@photonhealth/react')>();
+  return {
+    ...actual,
+    usePhoton: () => ({
+      isAuthenticated: harness.isAuthenticated,
+      isLoading: harness.isLoading,
+      user: harness.user,
+      clinicalClient: harness.photonClient.apolloClinical,
+      getToken: async () => 'test-token'
+    })
+  };
+});
 
 vi.mock('./configs/providerAnalytics', () => ({
   getProviderAnalytics: () => ({

--- a/apps/app/src/setupTests.ts
+++ b/apps/app/src/setupTests.ts
@@ -26,6 +26,45 @@ vi.mock('./instrumentation/setInstrumentationUserContext', () => ({
   setInstrumentationUserContext: vi.fn()
 }));
 
+// Chakra's `useBreakpointValue` (and other Chakra responsive helpers) calls
+// `window.matchMedia`, which jsdom does not implement.
+if (!window.matchMedia) {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: (query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: () => undefined,
+      removeListener: () => undefined,
+      addEventListener: () => undefined,
+      removeEventListener: () => undefined,
+      dispatchEvent: () => false
+    })
+  });
+}
+
+// `google.maps` is loaded at runtime by Google Maps' JS API. In jsdom we stub
+// the surface area touched at component construction time (Geocoder,
+// AutocompleteService) so pages like Order / NewOrder / LocationSearch don't
+// crash on mount.
+(globalThis as unknown as { google: unknown }).google ??= {
+  maps: {
+    Geocoder: class {
+      geocode() {
+        return Promise.resolve({ results: [] });
+      }
+    },
+    places: {
+      AutocompleteService: class {
+        getPlacePredictions() {
+          return Promise.resolve({ predictions: [] });
+        }
+      }
+    }
+  }
+};
+
 // ---------------------------------------------------------------------------
 // Shared test-harness state
 // ---------------------------------------------------------------------------

--- a/apps/app/src/test-utils/harness.tsx
+++ b/apps/app/src/test-utils/harness.tsx
@@ -15,6 +15,7 @@ import type { ReactNode } from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { afterAll, afterEach, beforeAll, beforeEach } from 'vitest';
 
+import customTheme from '../configs/theme';
 import { ProviderAnalyticsProvider } from '../hooks/useProviderAnalytics';
 import { DEFAULT_USER, harness } from '../setupTests';
 
@@ -67,12 +68,17 @@ export function setupHarness(...initialHandlers: RequestHandler[]) {
 /**
  * Render `ui` inside the standard clinical-app provider tree. Apollo's
  * default client is the lambdas client; the clinical client is reached via
- * the mocked `usePhoton().clinicalClient`.
+ * the mocked `usePhoton().clinicalClient`. Pass `initialEntries` to seed the
+ * `MemoryRouter` history when the rendered tree includes route-aware
+ * components (e.g. a `<Routes>` block with `:param`s).
  */
-export function renderWithProviders(ui: ReactNode) {
+export function renderWithProviders(
+  ui: ReactNode,
+  { initialEntries }: { initialEntries?: string[] } = {}
+) {
   return render(
-    <MemoryRouter>
-      <ChakraProvider>
+    <MemoryRouter initialEntries={initialEntries}>
+      <ChakraProvider theme={customTheme}>
         <ApolloProvider client={harness.photonClient.apollo}>
           <ProviderAnalyticsProvider>{ui}</ProviderAnalyticsProvider>
         </ApolloProvider>

--- a/apps/app/src/views/routes/Order.test.tsx
+++ b/apps/app/src/views/routes/Order.test.tsx
@@ -1,0 +1,312 @@
+import { OrderState } from '@photonhealth/sdk/dist/types';
+import { clinicalGql, lambdasGql } from '@photonhealth/sdk/test-utils';
+import { render, screen, within } from '@testing-library/react';
+import { HttpResponse } from 'msw';
+import { ReactNode } from 'react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { ApolloProvider } from '@apollo/client';
+import { ChakraProvider } from '@chakra-ui/react';
+import { beforeAll, expect, test } from 'vitest';
+
+import customTheme from '../../configs/theme';
+import { ProviderAnalyticsProvider } from '../../hooks/useProviderAnalytics';
+import {
+  harness,
+  makeAddress,
+  makeOrder,
+  makePatient,
+  makePharmacy,
+  setupHarness
+} from '../../test-utils';
+import { OrderDetailPage } from './Order';
+
+const ORDER_ID = 'ord_test';
+const ORDER_PHARMACY_ID = 'phr_order';
+const PREFERRED_PHARMACY_ID = 'phr_preferred';
+
+const orderPharmacy = makePharmacy({
+  id: ORDER_PHARMACY_ID,
+  name: 'Order Pharmacy',
+  phone: '+15550001111',
+  address: makeAddress({
+    street1: '1 Order St',
+    city: 'Brooklyn',
+    state: 'NY',
+    postalCode: '11211'
+  })
+});
+
+const preferredPharmacy = makePharmacy({
+  id: PREFERRED_PHARMACY_ID,
+  name: 'Preferred Pharmacy',
+  phone: '+15550002222',
+  address: makeAddress({
+    street1: '2 Preferred Ave',
+    city: 'Queens',
+    state: 'NY',
+    postalCode: '11385'
+  })
+});
+
+const { server } = setupHarness();
+
+beforeAll(() => {
+  // OrderDetailPage instantiates `new google.maps.Geocoder()` on every render.
+  // jsdom has no `google` global, so stub the bits the component touches.
+  (globalThis as unknown as { google: unknown }).google = {
+    maps: {
+      Geocoder: class {
+        geocode() {
+          return Promise.resolve({ results: [] });
+        }
+      },
+      // LocationSearch (rendered alongside the routing-state status card)
+      // constructs an AutocompleteService in a useEffect.
+      places: {
+        AutocompleteService: class {
+          getPlacePredictions() {
+            return Promise.resolve({ predictions: [] });
+          }
+        }
+      }
+    }
+  };
+
+  // Chakra's `useBreakpointValue` calls `matchMedia`, which jsdom lacks.
+  if (!window.matchMedia) {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: (query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: () => undefined,
+        removeListener: () => undefined,
+        addEventListener: () => undefined,
+        removeEventListener: () => undefined,
+        dispatchEvent: () => false
+      })
+    });
+  }
+});
+
+type OrderOverrides = Parameters<typeof makeOrder>[0];
+
+function mockOrderQueries(orderOverrides: OrderOverrides = {}, routingHistory: unknown[] = []) {
+  const order = makeOrder({ id: ORDER_ID, ...orderOverrides });
+  server.use(
+    lambdasGql.query('GetOrder', () => HttpResponse.json({ data: { order } })),
+    clinicalGql.query('GetOrder', () =>
+      HttpResponse.json({
+        data: { order: { __typename: 'Order', id: ORDER_ID, routingHistory } }
+      })
+    )
+  );
+  return order;
+}
+
+function renderOrderPage() {
+  return render(
+    <Providers initialEntries={[`/orders/${ORDER_ID}`]}>
+      <Routes>
+        <Route path="/orders/:orderId" element={<OrderDetailPage />} />
+      </Routes>
+    </Providers>
+  );
+}
+
+function Providers({
+  initialEntries,
+  children
+}: {
+  initialEntries: string[];
+  children: ReactNode;
+}) {
+  return (
+    <MemoryRouter initialEntries={initialEntries}>
+      <ChakraProvider theme={customTheme}>
+        <ApolloProvider client={harness.photonClient.apollo}>
+          <ProviderAnalyticsProvider>{children}</ProviderAnalyticsProvider>
+        </ApolloProvider>
+      </ChakraProvider>
+    </MemoryRouter>
+  );
+}
+
+test('ROUTING + no pharmacy + no preferred shows STP prompt and Select Pharmacy button, no pharmacy info', async () => {
+  mockOrderQueries({
+    state: OrderState.Routing,
+    pharmacy: null,
+    patient: makePatient({ preferredPharmacies: [] })
+  });
+
+  renderOrderPage();
+
+  expect(await screen.findByText(/pending pharmacy selection by the patient/i)).toBeInTheDocument();
+  expect(screen.getByText(/select a pharmacy for the patient if needed/i)).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: /^select pharmacy$/i })).toBeInTheDocument();
+
+  // No pharmacy info grid rendered when there's no display pharmacy.
+  expect(screen.queryByText('Name')).not.toBeInTheDocument();
+  expect(screen.queryByText('Phone')).not.toBeInTheDocument();
+  expect(screen.queryByText('Address')).not.toBeInTheDocument();
+});
+
+test('ROUTING + preferred pharmacy + no routing history shows 15-min window text and the preferred pharmacy info', async () => {
+  mockOrderQueries({
+    state: OrderState.Routing,
+    pharmacy: null,
+    patient: makePatient({ preferredPharmacies: [preferredPharmacy] })
+  });
+
+  renderOrderPage();
+
+  expect(
+    await screen.findByText(/pending pharmacy confirmation by the patient/i)
+  ).toBeInTheDocument();
+  expect(
+    screen.getByText(/will be routed to the below pharmacy if the patient does not confirm/i)
+  ).toBeInTheDocument();
+  // In-window initial route → patient can still pick a different pharmacy.
+  expect(screen.getByRole('button', { name: /^select pharmacy$/i })).toBeInTheDocument();
+
+  // Regression: pharmacy info must fall back to the patient's preferred pharmacy
+  // when the order itself doesn't have one set yet.
+  expect(await screen.findByText('Preferred Pharmacy')).toBeInTheDocument();
+  expect(screen.getByText('(555) 000-2222')).toBeInTheDocument();
+  expect(screen.getByText(/2 Preferred Ave/)).toBeInTheDocument();
+});
+
+test('ROUTING + order pharmacy + routing history (reroute requested from patient) hides Select Pharmacy and shows pharmacy info', async () => {
+  mockOrderQueries(
+    {
+      state: OrderState.Routing,
+      pharmacy: orderPharmacy,
+      patient: makePatient({ preferredPharmacies: [] })
+    },
+    [
+      {
+        __typename: 'OrderRoutingHistory',
+        pharmacy: orderPharmacy,
+        selector: 'PROVIDER',
+        reason: null,
+        createdAt: '2026-01-01T00:00:00Z'
+      }
+    ]
+  );
+
+  renderOrderPage();
+
+  expect(
+    await screen.findByText(/pending a pharmacy reroute selection from the patient/i)
+  ).toBeInTheDocument();
+  expect(screen.queryByRole('button', { name: /^select pharmacy$/i })).not.toBeInTheDocument();
+
+  // Pharmacy info section is still rendered with the order's pharmacy.
+  expect(await screen.findByText('Order Pharmacy')).toBeInTheDocument();
+  expect(screen.getByText('(555) 000-1111')).toBeInTheDocument();
+});
+
+test('PLACED + order pharmacy shows pharmacy info and no routing status card', async () => {
+  mockOrderQueries({
+    state: OrderState.Placed,
+    pharmacy: orderPharmacy,
+    patient: makePatient({ preferredPharmacies: [] })
+  });
+
+  renderOrderPage();
+
+  expect(await screen.findByText('Order Pharmacy')).toBeInTheDocument();
+  expect(screen.getByText('(555) 000-1111')).toBeInTheDocument();
+  expect(screen.getByText(/1 Order St/)).toBeInTheDocument();
+
+  // No routing status card on a placed order.
+  expect(
+    screen.queryByText(/pending pharmacy (selection|confirmation|reroute)/i)
+  ).not.toBeInTheDocument();
+  expect(screen.queryByRole('button', { name: /^select pharmacy$/i })).not.toBeInTheDocument();
+});
+
+test('PLACED + no order pharmacy + preferred pharmacy falls back to preferred pharmacy display (regression)', async () => {
+  // This is the bug the branch fixes: previously, once we got off the lambdas
+  // GET_ORDER `pharmacy` field, the pharmacy info section either hid the rows
+  // or showed "None" for every value. With the fix we fall through to the
+  // patient's first preferred pharmacy.
+  mockOrderQueries({
+    state: OrderState.Placed,
+    pharmacy: null,
+    patient: makePatient({ preferredPharmacies: [preferredPharmacy] })
+  });
+
+  renderOrderPage();
+
+  expect(await screen.findByText('Preferred Pharmacy')).toBeInTheDocument();
+  expect(screen.getByText('(555) 000-2222')).toBeInTheDocument();
+  expect(screen.getByText(/2 Preferred Ave/)).toBeInTheDocument();
+
+  // No "None" placeholders should appear for the pharmacy rows.
+  expect(screen.queryAllByText('None')).toHaveLength(0);
+});
+
+test('PLACED + no pharmacy + no preferred hides the pharmacy info rows entirely', async () => {
+  mockOrderQueries({
+    state: OrderState.Placed,
+    pharmacy: null,
+    patient: makePatient({ preferredPharmacies: [] })
+  });
+
+  renderOrderPage();
+
+  // The section header doubles as a sentinel that the page mounted.
+  expect(await screen.findByText('Pharmacy Information')).toBeInTheDocument();
+
+  // displayPharmacy is undefined → the InfoGrid rows are not rendered at all.
+  expect(screen.queryByText('Name')).not.toBeInTheDocument();
+  expect(screen.queryByText('Phone')).not.toBeInTheDocument();
+  expect(screen.queryByText('Address')).not.toBeInTheDocument();
+});
+
+test('CANCELED order still renders pharmacy info from order.pharmacy', async () => {
+  mockOrderQueries({
+    state: OrderState.Canceled,
+    pharmacy: orderPharmacy,
+    patient: makePatient({ preferredPharmacies: [] })
+  });
+
+  renderOrderPage();
+
+  expect(await screen.findByText('Order Pharmacy')).toBeInTheDocument();
+  expect(screen.getByText(/1 Order St/)).toBeInTheDocument();
+  expect(
+    screen.queryByText(/pending pharmacy (selection|confirmation|reroute)/i)
+  ).not.toBeInTheDocument();
+});
+
+test('order.pharmacy takes precedence over patient.preferredPharmacies for display', async () => {
+  mockOrderQueries({
+    state: OrderState.Placed,
+    pharmacy: orderPharmacy,
+    patient: makePatient({ preferredPharmacies: [preferredPharmacy] })
+  });
+
+  renderOrderPage();
+
+  expect(await screen.findByText('Order Pharmacy')).toBeInTheDocument();
+  expect(screen.queryByText('Preferred Pharmacy')).not.toBeInTheDocument();
+});
+
+test('unknown order id surfaces the "Unknown Order" alert', async () => {
+  server.use(
+    lambdasGql.query('GetOrder', () => HttpResponse.json({ data: { order: null } })),
+    clinicalGql.query('GetOrder', () =>
+      HttpResponse.json({
+        data: { order: { __typename: 'Order', id: ORDER_ID, routingHistory: [] } }
+      })
+    )
+  );
+
+  renderOrderPage();
+
+  const alert = await screen.findByRole('alert');
+  expect(within(alert).getByText(/unknown order/i)).toBeInTheDocument();
+});

--- a/apps/app/src/views/routes/Order.test.tsx
+++ b/apps/app/src/views/routes/Order.test.tsx
@@ -1,23 +1,11 @@
 import { OrderState } from '@photonhealth/sdk/dist/types';
 import { clinicalGql, lambdasGql } from '@photonhealth/sdk/test-utils';
-import { render, screen, within } from '@testing-library/react';
+import { screen, within } from '@testing-library/react';
 import { HttpResponse } from 'msw';
-import { ReactNode } from 'react';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
-import { ApolloProvider } from '@apollo/client';
-import { ChakraProvider } from '@chakra-ui/react';
-import { beforeAll, expect, test } from 'vitest';
+import { Route, Routes } from 'react-router-dom';
+import { expect, test } from 'vitest';
 
-import customTheme from '../../configs/theme';
-import { ProviderAnalyticsProvider } from '../../hooks/useProviderAnalytics';
-import {
-  harness,
-  makeAddress,
-  makeOrder,
-  makePatient,
-  makePharmacy,
-  setupHarness
-} from '../../test-utils';
+import { makeAddress, makeOrder, makePatient, makePharmacy, setupHarness } from '../../test-utils';
 import { OrderDetailPage } from './Order';
 
 const ORDER_ID = 'ord_test';
@@ -48,47 +36,7 @@ const preferredPharmacy = makePharmacy({
   })
 });
 
-const { server } = setupHarness();
-
-beforeAll(() => {
-  // OrderDetailPage instantiates `new google.maps.Geocoder()` on every render.
-  // jsdom has no `google` global, so stub the bits the component touches.
-  (globalThis as unknown as { google: unknown }).google = {
-    maps: {
-      Geocoder: class {
-        geocode() {
-          return Promise.resolve({ results: [] });
-        }
-      },
-      // LocationSearch (rendered alongside the routing-state status card)
-      // constructs an AutocompleteService in a useEffect.
-      places: {
-        AutocompleteService: class {
-          getPlacePredictions() {
-            return Promise.resolve({ predictions: [] });
-          }
-        }
-      }
-    }
-  };
-
-  // Chakra's `useBreakpointValue` calls `matchMedia`, which jsdom lacks.
-  if (!window.matchMedia) {
-    Object.defineProperty(window, 'matchMedia', {
-      writable: true,
-      value: (query: string) => ({
-        matches: false,
-        media: query,
-        onchange: null,
-        addListener: () => undefined,
-        removeListener: () => undefined,
-        addEventListener: () => undefined,
-        removeEventListener: () => undefined,
-        dispatchEvent: () => false
-      })
-    });
-  }
-});
+const { server, renderWithProviders } = setupHarness();
 
 type OrderOverrides = Parameters<typeof makeOrder>[0];
 
@@ -106,30 +54,11 @@ function mockOrderQueries(orderOverrides: OrderOverrides = {}, routingHistory: u
 }
 
 function renderOrderPage() {
-  return render(
-    <Providers initialEntries={[`/orders/${ORDER_ID}`]}>
-      <Routes>
-        <Route path="/orders/:orderId" element={<OrderDetailPage />} />
-      </Routes>
-    </Providers>
-  );
-}
-
-function Providers({
-  initialEntries,
-  children
-}: {
-  initialEntries: string[];
-  children: ReactNode;
-}) {
-  return (
-    <MemoryRouter initialEntries={initialEntries}>
-      <ChakraProvider theme={customTheme}>
-        <ApolloProvider client={harness.photonClient.apollo}>
-          <ProviderAnalyticsProvider>{children}</ProviderAnalyticsProvider>
-        </ApolloProvider>
-      </ChakraProvider>
-    </MemoryRouter>
+  return renderWithProviders(
+    <Routes>
+      <Route path="/orders/:orderId" element={<OrderDetailPage />} />
+    </Routes>,
+    { initialEntries: [`/orders/${ORDER_ID}`] }
   );
 }
 
@@ -228,10 +157,6 @@ test('PLACED + order pharmacy shows pharmacy info and no routing status card', a
 });
 
 test('PLACED + no order pharmacy + preferred pharmacy falls back to preferred pharmacy display (regression)', async () => {
-  // This is the bug the branch fixes: previously, once we got off the lambdas
-  // GET_ORDER `pharmacy` field, the pharmacy info section either hid the rows
-  // or showed "None" for every value. With the fix we fall through to the
-  // patient's first preferred pharmacy.
   mockOrderQueries({
     state: OrderState.Placed,
     pharmacy: null,

--- a/apps/app/src/views/routes/Order.test.tsx
+++ b/apps/app/src/views/routes/Order.test.tsx
@@ -106,7 +106,7 @@ test('ROUTING + preferred pharmacy + no routing history shows 15-min window text
   expect(screen.getByText(/2 Preferred Ave/)).toBeInTheDocument();
 });
 
-test('ROUTING + order pharmacy + routing history (reroute requested from patient) hides Select Pharmacy and shows pharmacy info', async () => {
+test('ROUTING + order pharmacy + routing history (reroute requested from patient) shows Select Pharmacy and hides pharmacy info', async () => {
   mockOrderQueries(
     {
       state: OrderState.Routing,
@@ -129,11 +129,16 @@ test('ROUTING + order pharmacy + routing history (reroute requested from patient
   expect(
     await screen.findByText(/pending a pharmacy reroute selection from the patient/i)
   ).toBeInTheDocument();
-  expect(screen.queryByRole('button', { name: /^select pharmacy$/i })).not.toBeInTheDocument();
+  // Provider can intervene and pick a pharmacy themselves while the patient is
+  // being asked to reroute.
+  expect(screen.getByRole('button', { name: /^select pharmacy$/i })).toBeInTheDocument();
 
-  // Pharmacy info section is still rendered with the order's pharmacy.
-  expect(await screen.findByText('Order Pharmacy')).toBeInTheDocument();
-  expect(screen.getByText('(555) 000-1111')).toBeInTheDocument();
+  // Pharmacy info is suppressed in the reroute-requested state — the
+  // previously-routed pharmacy is no longer the "active" choice.
+  expect(screen.queryByText('Order Pharmacy')).not.toBeInTheDocument();
+  expect(screen.queryByText('Name')).not.toBeInTheDocument();
+  expect(screen.queryByText('Phone')).not.toBeInTheDocument();
+  expect(screen.queryByText('Address')).not.toBeInTheDocument();
 });
 
 test('PLACED + order pharmacy shows pharmacy info and no routing status card', async () => {

--- a/apps/app/src/views/routes/Order.tsx
+++ b/apps/app/src/views/routes/Order.tsx
@@ -304,6 +304,7 @@ export const OrderDetailPage = () => {
 
   const fills = order ? uniqueFills(order) : [];
   const medicationNames = getMedicationNames(fills);
+  const displayPharmacy = order?.pharmacy || order?.patient.preferredPharmacies[0];
 
   return (
     <>
@@ -678,13 +679,13 @@ export const OrderDetailPage = () => {
                 </>
               ) : null}
 
-              {order?.state !== 'ROUTING' && (
+              {displayPharmacy && (
                 <>
                   <InfoGrid name="Name">
                     {loading ? (
                       <SkeletonText skeletonHeight={5} noOfLines={1} width="100px" />
-                    ) : order?.pharmacy?.name ? (
-                      <Text fontSize="md">{order.pharmacy.name}</Text>
+                    ) : displayPharmacy?.name ? (
+                      <Text fontSize="md">{displayPharmacy.name}</Text>
                     ) : (
                       <Text fontSize="md" as="i" color="gray.500">
                         None
@@ -695,9 +696,9 @@ export const OrderDetailPage = () => {
                   <InfoGrid name="Phone">
                     {loading ? (
                       <SkeletonText skeletonHeight={5} noOfLines={1} width="100px" />
-                    ) : order?.pharmacy?.phone ? (
-                      <Link fontSize="md" href={`tel:${order.pharmacy.phone}`} isExternal>
-                        {formatPhone(order.pharmacy.phone)}
+                    ) : displayPharmacy?.phone ? (
+                      <Link fontSize="md" href={`tel:${displayPharmacy.phone}`} isExternal>
+                        {formatPhone(displayPharmacy.phone)}
                       </Link>
                     ) : (
                       <Text fontSize="md" as="i" color="gray.500">
@@ -709,8 +710,8 @@ export const OrderDetailPage = () => {
                   <InfoGrid name="Address">
                     {loading ? (
                       <SkeletonText skeletonHeight={5} noOfLines={1} width="100px" />
-                    ) : order?.pharmacy?.address ? (
-                      <Text fontSize="md">{formatAddress(order.pharmacy.address)}</Text>
+                    ) : displayPharmacy?.address ? (
+                      <Text fontSize="md">{formatAddress(displayPharmacy.address)}</Text>
                     ) : (
                       <Text fontSize="md" as="i" color="gray.500">
                         None
@@ -721,8 +722,8 @@ export const OrderDetailPage = () => {
                   <InfoGrid name="Id">
                     {loading ? (
                       <SkeletonText skeletonHeight={5} noOfLines={1} width="100px" />
-                    ) : order?.pharmacy?.id ? (
-                      <CopyText text={order.pharmacy.id} />
+                    ) : displayPharmacy?.id ? (
+                      <CopyText text={displayPharmacy.id} />
                     ) : (
                       <Text fontSize="md" as="i" color="gray.500">
                         None
@@ -841,10 +842,10 @@ function shouldShowSelectPharmacyButton(
 
 function inPreferredPharmacyRoutingWindow(order: OrderType, routingHistory: OrderRoutingHistory[]) {
   const isRouting = order.state === OrderState.Routing;
-  const hasPharmacy = !!order.pharmacy;
+  const hasPreferredPharmacy = order.patient.preferredPharmacies?.length;
   const isInitialRoute = !routingHistory.length;
 
-  return isRouting && hasPharmacy && isInitialRoute;
+  return isRouting && hasPreferredPharmacy && isInitialRoute;
 }
 
 function isRequestingRerouteFromPatient(order: OrderType, routingHistory: OrderRoutingHistory[]) {

--- a/apps/app/src/views/routes/Order.tsx
+++ b/apps/app/src/views/routes/Order.tsx
@@ -679,59 +679,61 @@ export const OrderDetailPage = () => {
                 </>
               ) : null}
 
-              {displayPharmacy && (
-                <>
-                  <InfoGrid name="Name">
-                    {loading ? (
-                      <SkeletonText skeletonHeight={5} noOfLines={1} width="100px" />
-                    ) : displayPharmacy?.name ? (
-                      <Text fontSize="md">{displayPharmacy.name}</Text>
-                    ) : (
-                      <Text fontSize="md" as="i" color="gray.500">
-                        None
-                      </Text>
-                    )}
-                  </InfoGrid>
+              {order &&
+                displayPharmacy &&
+                !isRequestingRerouteFromPatient(order, routingHistory) && (
+                  <>
+                    <InfoGrid name="Name">
+                      {loading ? (
+                        <SkeletonText skeletonHeight={5} noOfLines={1} width="100px" />
+                      ) : displayPharmacy?.name ? (
+                        <Text fontSize="md">{displayPharmacy.name}</Text>
+                      ) : (
+                        <Text fontSize="md" as="i" color="gray.500">
+                          None
+                        </Text>
+                      )}
+                    </InfoGrid>
 
-                  <InfoGrid name="Phone">
-                    {loading ? (
-                      <SkeletonText skeletonHeight={5} noOfLines={1} width="100px" />
-                    ) : displayPharmacy?.phone ? (
-                      <Link fontSize="md" href={`tel:${displayPharmacy.phone}`} isExternal>
-                        {formatPhone(displayPharmacy.phone)}
-                      </Link>
-                    ) : (
-                      <Text fontSize="md" as="i" color="gray.500">
-                        None
-                      </Text>
-                    )}
-                  </InfoGrid>
+                    <InfoGrid name="Phone">
+                      {loading ? (
+                        <SkeletonText skeletonHeight={5} noOfLines={1} width="100px" />
+                      ) : displayPharmacy?.phone ? (
+                        <Link fontSize="md" href={`tel:${displayPharmacy.phone}`} isExternal>
+                          {formatPhone(displayPharmacy.phone)}
+                        </Link>
+                      ) : (
+                        <Text fontSize="md" as="i" color="gray.500">
+                          None
+                        </Text>
+                      )}
+                    </InfoGrid>
 
-                  <InfoGrid name="Address">
-                    {loading ? (
-                      <SkeletonText skeletonHeight={5} noOfLines={1} width="100px" />
-                    ) : displayPharmacy?.address ? (
-                      <Text fontSize="md">{formatAddress(displayPharmacy.address)}</Text>
-                    ) : (
-                      <Text fontSize="md" as="i" color="gray.500">
-                        None
-                      </Text>
-                    )}
-                  </InfoGrid>
+                    <InfoGrid name="Address">
+                      {loading ? (
+                        <SkeletonText skeletonHeight={5} noOfLines={1} width="100px" />
+                      ) : displayPharmacy?.address ? (
+                        <Text fontSize="md">{formatAddress(displayPharmacy.address)}</Text>
+                      ) : (
+                        <Text fontSize="md" as="i" color="gray.500">
+                          None
+                        </Text>
+                      )}
+                    </InfoGrid>
 
-                  <InfoGrid name="Id">
-                    {loading ? (
-                      <SkeletonText skeletonHeight={5} noOfLines={1} width="100px" />
-                    ) : displayPharmacy?.id ? (
-                      <CopyText text={displayPharmacy.id} />
-                    ) : (
-                      <Text fontSize="md" as="i" color="gray.500">
-                        None
-                      </Text>
-                    )}
-                  </InfoGrid>
-                </>
-              )}
+                    <InfoGrid name="Id">
+                      {loading ? (
+                        <SkeletonText skeletonHeight={5} noOfLines={1} width="100px" />
+                      ) : displayPharmacy?.id ? (
+                        <CopyText text={displayPharmacy.id} />
+                      ) : (
+                        <Text fontSize="md" as="i" color="gray.500">
+                          None
+                        </Text>
+                      )}
+                    </InfoGrid>
+                  </>
+                )}
 
               {!loading && order?.fulfillment?.type === 'MAIL_ORDER' ? (
                 <>
@@ -834,10 +836,7 @@ function shouldShowSelectPharmacyButton(
   order: OrderType,
   routingHistory: OrderRoutingHistory[]
 ): boolean {
-  return (
-    inPreferredPharmacyRoutingWindow(order, routingHistory) ||
-    !isRequestingRerouteFromPatient(order, routingHistory)
-  );
+  return !order.pharmacy || isRequestingRerouteFromPatient(order, routingHistory);
 }
 
 function inPreferredPharmacyRoutingWindow(order: OrderType, routingHistory: OrderRoutingHistory[]) {

--- a/apps/app/src/views/routes/Order.tsx
+++ b/apps/app/src/views/routes/Order.tsx
@@ -835,7 +835,7 @@ function shouldShowSelectPharmacyButton(
 ): boolean {
   return (
     inPreferredPharmacyRoutingWindow(order, routingHistory) ||
-    isRequestingRerouteFromPatient(order, routingHistory)
+    !isRequestingRerouteFromPatient(order, routingHistory)
   );
 }
 


### PR DESCRIPTION
Users are expecting to see the old "Select a pharmacy" cta under the pharmacy section description while it's in the initial "Send to Patient" flow or is waiting on preferred pharmacy. When changing the logic I made this too specific and also tried to infer if the order was waiting preferred pharmacy routing. 

Changing this to show the select a pharmacy cta whenever the order pharmacy is missing or if it is in the Reroute STP flow. Also fetching preferred pharmacies of the patient via subresolver to directly determine if this routing state is in the preferred pharmacy window. 

All states look as they should now for ROUTING


### STP (Initial Route) 
<img width="747" height="213" alt="Screenshot 2026-05-22 at 3 30 44 PM" src="https://github.com/user-attachments/assets/ca7a29f7-7c20-47a1-9823-f7a4e53bedfb" />


### Preferred Pharmacy Window
<img width="800" height="370" alt="Screenshot 2026-05-22 at 3 30 50 PM" src="https://github.com/user-attachments/assets/954fe7f6-e21c-479b-a9b8-d28584f9dcbd" />


### Reroute STP
<img width="701" height="267" alt="Screenshot 2026-05-22 at 3 32 30 PM" src="https://github.com/user-attachments/assets/95e37b5b-9273-4627-9074-1156e350afe2" />
