### PR TITLE
remove feature flag; update tests

### DIFF
--- a/apps/patient/e2e/select-pharmacy.spec.ts
+++ b/apps/patient/e2e/select-pharmacy.spec.ts
@@ -24,8 +24,6 @@ test('displays order status for a freshly created order', async ({ page }) => {
   const selectedPharmacyName = await pharmacyCardToSelect.getAttribute('aria-label');
   await pharmacyCardToSelect.click();
   await page.getByRole('button', { name: /select pharmacy/i }).click();
-  await page.getByText('Urgent').click();
-  await page.getByRole('button', { name: /next/i }).click();
 
   await expect(page.getByText(/Order placed/i)).toBeVisible();
   await expect(page.getByText(selectedPharmacyName)).toBeVisible();

--- a/apps/patient/e2e/select-pharmacy.spec.ts
+++ b/apps/patient/e2e/select-pharmacy.spec.ts
@@ -13,9 +13,6 @@ test('displays order status for a freshly created order', async ({ page }) => {
     // as "open order" combining. So most tests after the first run of the day will hit the "placed" page
     // todo: figure out how to avoid this for e2e tests - organization setting "enableOpenOrderMerges" probably?
     return;
-  } else if (landingPage === 'review-your-prescription') {
-    await expect(page.getByText(/Amoxicillin Oral Capsule 250 MG/i)).toBeVisible();
-    await page.getByRole('button', { name: /search for a pharmacy/i }).click();
   }
 
   await expect(page.getByRole('heading', { name: /select a pharmacy/i })).toBeVisible({
@@ -35,15 +32,11 @@ test('displays order status for a freshly created order', async ({ page }) => {
   await expect(page.getByText(/Amoxicillin/i)).toBeVisible();
 });
 
-type LandingPageNames = 'review-your-prescription' | 'pharmacy-select' | 'order-placed';
+type LandingPageNames = 'pharmacy-select' | 'order-placed';
 async function getLandingPage(page: Page): Promise<LandingPageNames> {
   await expect(page.locator('body')).not.toContainText('Loading', { timeout: 15_000 });
 
   return Promise.race([
-    page
-      .getByText(/review your prescription/i)
-      .waitFor({ timeout: 15_000 })
-      .then(() => 'review-your-prescription' as const),
     page
       .getByText(/select a pharmacy/i)
       .waitFor({ timeout: 15_000 })

--- a/apps/patient/src/Navigation.test.tsx
+++ b/apps/patient/src/Navigation.test.tsx
@@ -101,7 +101,7 @@ describe('App', () => {
     resetFeatureFlagMocks();
   });
 
-  test('For Local Pickup Pharmacies: navigate from review > pharmacy > readyBy > status', async () => {
+  test('For Local Pickup Pharmacies: navigate from pharmacy > readyBy > status', async () => {
     const { getPharmaciesByLocation, setOrderPharmacy, getOrder } = await import('./api');
     const getOrderMock = vi.mocked(getOrder);
     getOrderMock.mockResolvedValue(testOrder);
@@ -121,18 +121,14 @@ describe('App', () => {
 
     renderApp({ order: testOrder });
 
-    expect(await screen.findByText('Review your prescription')).toBeInTheDocument();
-    expect(mockPatientAnalytics.getFlagValue).toHaveBeenCalledWith('remove_review_your_rx_page');
-    await expectTotalPageViewAnalyticsCountToBe(1);
-    await userEvent.click(screen.getByRole('button', { name: 'Search for a pharmacy' }));
     expect(await screen.findByText('Select a pharmacy')).toBeInTheDocument();
-    expect(screen.queryByTestId('PrescriptionsSummary')).not.toBeInTheDocument();
-    await expectTotalPageViewAnalyticsCountToBe(2);
+    expect(screen.getByTestId('PrescriptionsSummary')).toBeInTheDocument();
+    await expectTotalPageViewAnalyticsCountToBe(1);
     await userEvent.click(screen.getByText('Test Local Pickup Pharmacy'));
     await userEvent.click(screen.getByText('Select pharmacy'));
     expect(setOrderPharmacyMock).not.toHaveBeenCalled();
     expect(await screen.findByText('When do you need your order ready by?')).toBeInTheDocument();
-    await expectTotalPageViewAnalyticsCountToBe(3);
+    await expectTotalPageViewAnalyticsCountToBe(2);
     await userEvent.click(screen.getByText('Urgent'));
     await userEvent.click(screen.getByText('Next'));
     expect(setOrderPharmacyMock).toHaveBeenCalledWith(
@@ -145,7 +141,7 @@ describe('App', () => {
     );
     await waitFor(() => screen.findByText('Preparing order...'), { timeout: 2500 });
     expect(await screen.findByText('Preparing order...')).toBeInTheDocument();
-    await expectTotalPageViewAnalyticsCountToBe(4);
+    await expectTotalPageViewAnalyticsCountToBe(3);
   }, 10_000);
 
   test('For Mail Order Pharmacies: skips the readyBy page', async () => {
@@ -169,8 +165,6 @@ describe('App', () => {
 
     renderApp({ order: testOrder });
 
-    expect(await screen.findByText('Review your prescription')).toBeInTheDocument();
-    await userEvent.click(screen.getByRole('button', { name: 'Search for a pharmacy' }));
     expect(await screen.findByText('Select a pharmacy')).toBeInTheDocument();
     await userEvent.click(screen.getByText('Test Mail Order Pharmacy'));
     await userEvent.click(screen.getByText('Select pharmacy'));
@@ -188,17 +182,7 @@ describe('App', () => {
     expect(await screen.findByText('Preparing order...')).toBeInTheDocument();
   }, 10_000);
 
-  test('skips review and lands on pharmacy when the experiment enables it', async () => {
-    mockPatientAnalytics.getFlagValue.mockResolvedValue({
-      skipReviewPage: true,
-      showRxSummaryOnPharmacyPage: true
-    });
-
-    mockPatientAnalytics.getFlagValueSync.mockReturnValue({
-      skipReviewPage: true,
-      showRxSummaryOnPharmacyPage: true
-    });
-
+  test('skips review and lands on pharmacy when patient has address', async () => {
     const { getOrder } = await import('./api');
     vi.mocked(getOrder).mockResolvedValue(testOrder);
 
@@ -211,6 +195,24 @@ describe('App', () => {
     expect(screen.queryByText('Review your prescription')).not.toBeInTheDocument();
     expect(await screen.findByText('Select a pharmacy')).toBeInTheDocument();
     expect(screen.getByTestId('PrescriptionsSummary')).toBeInTheDocument();
+  });
+
+  test('lands on review when patient has no address', async () => {
+    const { getOrder } = await import('./api');
+    const noAddressOrder = {
+      ...testOrder,
+      patient: generatePatient({ name: { full: 'Jane Doe' }, address: undefined })
+    };
+    vi.mocked(getOrder).mockResolvedValue(noAddressOrder);
+
+    const { memoryRouter } = renderApp();
+
+    await waitFor(() => {
+      expect(memoryRouter.state.location.pathname).toBe('/review');
+    });
+
+    expect(await screen.findByText('Review your prescription')).toBeInTheDocument();
+    expect(screen.getByText('Add your address')).toBeInTheDocument();
   });
 });
 

--- a/apps/patient/src/configs/featureFlags.ts
+++ b/apps/patient/src/configs/featureFlags.ts
@@ -1,8 +1,4 @@
 export type FlagValues = {
-  remove_review_your_rx_page: {
-    skipReviewPage: boolean;
-    showRxSummaryOnPharmacyPage: boolean;
-  };
   remove_ready_by_selection_page: {
     skipReadyBySelectionPage: boolean;
   };
@@ -11,10 +7,6 @@ export type FlagValues = {
 export type FlagKeys = keyof FlagValues;
 
 export const FEATURE_FLAG_DEFAULTS: FlagValues = {
-  remove_review_your_rx_page: {
-    skipReviewPage: false,
-    showRxSummaryOnPharmacyPage: false
-  },
   remove_ready_by_selection_page: {
     skipReadyBySelectionPage: false
   }

--- a/apps/patient/src/views/Main.tsx
+++ b/apps/patient/src/views/Main.tsx
@@ -179,10 +179,7 @@ export const Main = () => {
       if (hasPharmacy) {
         redirectPath = '/status';
       } else if (newOrder.patient.address) {
-        const removeReviewStepExperiment = await patientAnalytics.getFlagValue(
-          'remove_review_your_rx_page'
-        );
-        redirectPath = removeReviewStepExperiment.skipReviewPage ? '/pharmacy' : '/review';
+        redirectPath = '/pharmacy';
       } else {
         redirectPath = '/review';
       }

--- a/apps/patient/src/views/Pharmacy.test.tsx
+++ b/apps/patient/src/views/Pharmacy.test.tsx
@@ -740,7 +740,5 @@ const renderApp = () => {
 };
 
 async function navigateToPharmacyScreen() {
-  expect(await screen.findByText(/^Review your prescription/gi)).toBeInTheDocument();
-  await userEvent.click(screen.getByRole('button', { name: 'Search for a pharmacy' }));
   expect(await screen.findByText('Select a pharmacy')).toBeInTheDocument();
 }

--- a/apps/patient/src/views/Pharmacy.tsx
+++ b/apps/patient/src/views/Pharmacy.tsx
@@ -1046,11 +1046,6 @@ export const Pharmacy = () => {
   const showPickupHeading =
     (enableCourier || enableMailOrder || brandedOptionsOverride !== undefined) ?? false;
 
-  let removeReviewPageExperiment;
-  if (order.patient.address) {
-    removeReviewPageExperiment = patientAnalytics.getFlagValueSync('remove_review_your_rx_page');
-  }
-
   return (
     <Box>
       {!isDemo && <LocationModal isOpen={locationModalOpen} onClose={handleModalClose} />}
@@ -1068,13 +1063,11 @@ export const Pharmacy = () => {
         options={patientMailOrderOptions}
       />
 
-      {removeReviewPageExperiment?.showRxSummaryOnPharmacyPage && (
-        <Box bgColor="white" p={4} borderBottom="1px" borderColor="gray.200">
-          <Container px={-3}>
-            <PrescriptionsSummary />
-          </Container>
-        </Box>
-      )}
+      <Box bgColor="white" p={4} borderBottom="1px" borderColor="gray.200">
+        <Container px={-3}>
+          <PrescriptionsSummary />
+        </Container>
+      </Box>
 
       <Box bgColor="white">
         <VStack spacing={4} align="span" p={4}>

--- a/apps/patient/src/views/Review.test.tsx
+++ b/apps/patient/src/views/Review.test.tsx
@@ -71,55 +71,6 @@ describe('Review Page - Address Form', () => {
     vi.clearAllMocks();
   });
 
-  describe('when patient has an address', () => {
-    const patientWithAddress = generatePatient({
-      id: 'pat_test123',
-      name: { full: 'John Doe' },
-      address: generateAddress()
-    });
-
-    const orderWithPatientAddress = generateOrder({
-      id: 'ord_test123',
-      state: 'ROUTING',
-      patient: patientWithAddress,
-      fills: [testFill]
-    });
-
-    beforeEach(() => {
-      mockGetOrder.mockResolvedValue(orderWithPatientAddress);
-    });
-
-    it('does not show the address form', async () => {
-      renderApp('ord_test123');
-
-      // Wait for the review page to load
-      await waitFor(() => {
-        expect(screen.getByText('Review your prescription')).toBeInTheDocument();
-      });
-
-      // Address form should not be present
-      expect(screen.queryByText('Add your address')).not.toBeInTheDocument();
-
-      // Search pharmacy button should be visible
-      expect(screen.getByRole('button', { name: /search for a pharmacy/i })).toBeInTheDocument();
-    });
-
-    it('navigates to pharmacy page when clicking search button', async () => {
-      const { memoryRouter } = renderApp('ord_test123');
-
-      await waitFor(() => {
-        expect(screen.getByText('Review your prescription')).toBeInTheDocument();
-      });
-
-      const searchButton = screen.getByRole('button', { name: /search for a pharmacy/i });
-      await userEvent.click(searchButton);
-
-      await waitFor(() => {
-        expect(memoryRouter.state.location.pathname).toBe('/pharmacy');
-      });
-    });
-  });
-
   describe('when patient does not have an address', () => {
     const patientWithoutAddress = generatePatient({
       id: 'pat_test456',


### PR DESCRIPTION
remove review your prescription experiment is done. We're skipping the review page for patients that have an address. We're also always showing the prescription summary at the top of the pharmacy page for everyone.