### PR TITLE
preventing scroll in number inputs

### DIFF
--- a/packages/elements/src/photon-multirx-form/components/PrescriptionCard/DraftPrescriptionForm.tsx
+++ b/packages/elements/src/photon-multirx-form/components/PrescriptionCard/DraftPrescriptionForm.tsx
@@ -250,6 +250,7 @@ export const DraftPrescriptionForm = (props: {
                 inputMode="decimal"
                 value={props.store.dispenseQuantity?.value ?? undefined}
                 min={0}
+                onWheel={(e) => e.preventDefault()}
                 onInput={(e: InputEvent & { currentTarget: HTMLInputElement }) => {
                   props.actions.updateFormValue({
                     key: 'dispenseQuantity',
@@ -334,6 +335,7 @@ export const DraftPrescriptionForm = (props: {
             inputMode="numeric"
             value={props.store.daysSupply?.value ?? undefined}
             min={0}
+            onWheel={(e) => e.preventDefault()}
             onInput={(e: InputEvent & { currentTarget: HTMLInputElement }) => {
               props.actions.updateFormValue({
                 key: 'daysSupply',
@@ -358,6 +360,7 @@ export const DraftPrescriptionForm = (props: {
             value={props.store.refills?.value ?? undefined}
             min={0}
             max={11}
+            onWheel={(e) => e.preventDefault()}
             onInput={(e: InputEvent & { currentTarget: HTMLInputElement }) => {
               props.actions.updateFormValue({
                 key: 'refills',


### PR DESCRIPTION
by default, an input of type 'number' is scrollable. looks like it's causing issue when users are drafting a prescription:
- select a template
- click on quantity and enter a number
- WITHOUT clicking outside of the quantity input to change focus, scroll with the cursor in the input
outcome: changes the quantity value (usually by 3-5 depending on scroll speed)


Before:
https://github.com/user-attachments/assets/28e8379d-01a7-431a-aaeb-9a92577ae6a6


After:
https://github.com/user-attachments/assets/6781cc83-9c77-4541-a11c-ef9668d7a880
*isn't obvious in the video but I am trying to scroll inside of the input after setting the value


