### PR TITLE
Fix User when no org ID is set

### DIFF
--- a/packages/components/src/store.ts
+++ b/packages/components/src/store.ts
@@ -283,6 +283,10 @@ export class PhotonClientStore {
         isAuthenticated: authenticated
       });
       const user = await this.sdk.authentication.getUser();
+      // If no org was configured upfront, derive it from the authenticated user
+      if (!this.sdk.organization && user?.org_id) {
+        this.sdk.setOrganization(user.org_id);
+      }
       // @ts-ignore TODO: store will be updated soon, so this will change
       const hasOrgs = !!this.sdk?.organization && !!user?.org_id;
 

--- a/packages/components/src/store.ts
+++ b/packages/components/src/store.ts
@@ -283,12 +283,15 @@ export class PhotonClientStore {
         isAuthenticated: authenticated
       });
       const user = await this.sdk.authentication.getUser();
-      // If no org was configured upfront, derive it from the authenticated user
-      if (!this.sdk.organization && user?.org_id) {
-        this.sdk.setOrganization(user.org_id);
-      }
+
       // @ts-ignore TODO: store will be updated soon, so this will change
       const hasOrgs = !!this.sdk?.organization && !!user?.org_id;
+
+      // If no org was configured upfront but the user has one,
+      // derive it from the authenticated user.
+      if (!this.sdk.organization && hasOrgs) {
+        this.sdk.setOrganization(user.org_id);
+      }
 
       let permissions: Permission[] = [];
       if (this.autoLogin || authenticated) {

--- a/packages/components/src/store.ts
+++ b/packages/components/src/store.ts
@@ -285,11 +285,12 @@ export class PhotonClientStore {
       const user = await this.sdk.authentication.getUser();
 
       // @ts-ignore TODO: store will be updated soon, so this will change
-      const hasOrgs = !!this.sdk?.organization && !!user?.org_id;
+      const isUserLoggedIntoAnOrganization = !!user?.org_id;
+      const isOrganizationIdSelectedInPhotonClient = !!this.sdk?.organization;
 
-      // If no org was configured upfront but the user has one,
+      // If no org was configured upfront but the user was logged into one,
       // derive it from the authenticated user.
-      if (!this.sdk.organization && hasOrgs) {
+      if (!isOrganizationIdSelectedInPhotonClient && isUserLoggedIntoAnOrganization) {
         this.sdk.setOrganization(user.org_id);
       }
 
@@ -306,7 +307,12 @@ export class PhotonClientStore {
       }
 
       // @ts-ignore TODO store will be updated soon, so this will change
-      const isInOrg = authenticated && hasOrgs && this.sdk.organization === user.org_id;
+      const selectedOrganizationId = this.sdk?.organization;
+      const isInOrg =
+        authenticated &&
+        isOrganizationIdSelectedInPhotonClient &&
+        isUserLoggedIntoAnOrganization &&
+        selectedOrganizationId === user.org_id;
 
       this.setStore('authentication', {
         ...this.store.authentication,

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@photonhealth/elements",
-  "version": "0.23.4",
+  "version": "0.23.5",
   "description": "",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
Automatically set the organizationId for a user who is logged into an organization, when there is no organizationID passed into the `<photon-client>`. This allows a new user who was assigned to an organization on the backend (via the new `createUser` Account API) to login more smoothly to their first organization.