### PR TITLE
Resend Order Button

### DIFF
--- a/apps/app/src/hooks/useHighestUserRole.ts
+++ b/apps/app/src/hooks/useHighestUserRole.ts
@@ -1,0 +1,27 @@
+import { useMemo } from 'react';
+import { useProviderAnalytics } from './useProviderAnalytics';
+
+export function useHighestUserRole() {
+  const { contextData } = useProviderAnalytics();
+
+  return useMemo(() => {
+    if (!contextData.providerRoles) return;
+
+    switch (true) {
+      case contextData.providerRoles.includes('Administrator'):
+        return 'ADMIN';
+      case contextData.providerRoles.includes('Prescriber'):
+        return 'PROVIDER';
+      case contextData.providerRoles.includes('Medical Operations'):
+        return 'MED_OPS';
+      case contextData.providerRoles.includes('Staff'):
+        return 'STAFF';
+      case contextData.providerRoles.includes('Support'):
+        return 'SUPPORT';
+      case contextData.providerRoles.includes('Developer'):
+        return 'DEVELOPER';
+      default:
+        return 'UNKNOWN';
+    }
+  }, [contextData.providerRoles]);
+}

--- a/apps/app/src/hooks/useOrderUniqueTreatments.ts
+++ b/apps/app/src/hooks/useOrderUniqueTreatments.ts
@@ -1,0 +1,16 @@
+import { useMemo } from 'react';
+import { Order, Treatment } from '@photonhealth/sdk/dist/types';
+
+export function useOrderUniqueTreatments(order: Order) {
+  return useMemo(() => {
+    const medicationLookup = order.fills.reduce<Record<string, Treatment>>((acc, cur) => {
+      if (!acc[cur.treatment.id]) {
+        acc[cur.treatment.id] = cur.treatment;
+      }
+
+      return acc;
+    }, {});
+
+    return Object.values(medicationLookup);
+  }, [order]);
+}

--- a/apps/app/src/mutations/clinical-api/orders.ts
+++ b/apps/app/src/mutations/clinical-api/orders.ts
@@ -5,3 +5,9 @@ export const rerouteOrderMutation = graphql(/* GraphQL */ `
     rerouteOrder(orderId: $orderId, pharmacyId: $pharmacyId)
   }
 `);
+
+export const resendOrderMutation = graphql(/* GraphQL */ `
+  mutation ResendOrder($orderId: ID!) {
+    resendOrder(orderId: $orderId)
+  }
+`);

--- a/apps/app/src/views/components/RerouteOrderButton.tsx
+++ b/apps/app/src/views/components/RerouteOrderButton.tsx
@@ -3,7 +3,7 @@ import { useApolloClient, useMutation, useQuery } from '@apollo/client';
 import { Button, useToast } from '@chakra-ui/react';
 import { getOrgMailOrderPharms } from '@client/settings';
 import { usePhoton } from '@photonhealth/react';
-import { Order, Treatment } from '@photonhealth/sdk/dist/types';
+import { Order } from '@photonhealth/sdk/dist/types';
 import { FulfillmentType, OrderState } from 'packages/sdk/src/types';
 
 import { Dialog } from './Dialog';
@@ -12,6 +12,8 @@ import { rerouteOrderMutation } from '../../mutations/clinical-api/orders';
 import { formatAddress } from '../../utils';
 import { useProviderAnalytics } from '../../hooks/useProviderAnalytics';
 import { GET_ORDER, getOrderRoutingHistory, PHARMACY_QUERY } from '../../queries';
+import { useOrderUniqueTreatments } from '../../hooks/useOrderUniqueTreatments';
+import { useHighestUserRole } from '../../hooks/useHighestUserRole';
 
 interface RerouteOrderButtonProps {
   order: Order;
@@ -44,8 +46,8 @@ export function RerouteOrderButton({ order, organizationId }: RerouteOrderButton
   const [fulfillmentType, setFulfillmentType] = useState<string | undefined>(undefined);
   const confirmButtonDisabled = !!fulfillmentType && !pharmacyId;
 
-  const uniqueTreatments = useUniqueMeds(order);
-  const selector = useRerouteSelector();
+  const uniqueTreatments = useOrderUniqueTreatments(order);
+  const selector = useHighestUserRole();
 
   const routingHistory = useRoutingHistory(order.id);
   const [rerouteOrder] = useRerouteOrderMutation({ order, rerouteTo: pharmacyId });
@@ -266,45 +268,6 @@ function useRoutingHistory(id: string) {
   });
   const routingHistory = routingHistoryRes.data?.order?.routingHistory ?? [];
   return routingHistory;
-}
-
-function useUniqueMeds(order: Order) {
-  return useMemo(() => {
-    const medicationLookup = order.fills.reduce<Record<string, Treatment>>((acc, cur) => {
-      if (!acc[cur.treatment.id]) {
-        acc[cur.treatment.id] = cur.treatment;
-      }
-
-      return acc;
-    }, {});
-
-    return Object.values(medicationLookup);
-  }, [order]);
-}
-
-function useRerouteSelector() {
-  const { contextData } = useProviderAnalytics();
-
-  return useMemo(() => {
-    if (!contextData.providerRoles) return;
-
-    switch (true) {
-      case contextData.providerRoles.includes('Administrator'):
-        return 'ADMIN';
-      case contextData.providerRoles.includes('Prescriber'):
-        return 'PROVIDER';
-      case contextData.providerRoles.includes('Medical Operations'):
-        return 'MED_OPS';
-      case contextData.providerRoles.includes('Staff'):
-        return 'STAFF';
-      case contextData.providerRoles.includes('Support'):
-        return 'SUPPORT';
-      case contextData.providerRoles.includes('Developer'):
-        return 'DEVELOPER';
-      default:
-        return 'UNKNOWN';
-    }
-  }, [contextData.providerRoles]);
 }
 
 function routingTypeLabel(type?: string) {

--- a/apps/app/src/views/components/ResendOrderButton.test.tsx
+++ b/apps/app/src/views/components/ResendOrderButton.test.tsx
@@ -1,0 +1,131 @@
+import { clinicalGql } from '@photonhealth/sdk/test-utils';
+import { screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { HttpResponse } from 'msw';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import { makeOrder, makePatient, makePharmacy, setupHarness } from '../../test-utils';
+import { ResendOrderButton } from './ResendOrderButton';
+
+const ORDER_ID = 'ord_test';
+const PATIENT_ID = 'pat_456';
+const PHARMACY_ID = 'phr_original';
+
+const pharmacy = makePharmacy({ id: PHARMACY_ID, name: 'Original Pharmacy' });
+const order = makeOrder({
+  id: ORDER_ID,
+  patient: makePatient({ id: PATIENT_ID }),
+  pharmacy
+}) as Parameters<typeof ResendOrderButton>[0]['order'];
+
+const resendOrderSpy = vi.fn();
+
+const { server, trackSpy, renderWithProviders } = setupHarness();
+
+beforeEach(() => {
+  resendOrderSpy.mockClear();
+
+  server.use(
+    clinicalGql.mutation('ResendOrder', ({ variables }) => {
+      resendOrderSpy(variables);
+      return HttpResponse.json({ data: { resendOrder: true } });
+    })
+  );
+});
+
+async function openResend() {
+  renderWithProviders(<ResendOrderButton order={order} />);
+  const user = userEvent.setup();
+  await user.click(screen.getByRole('button', { name: /resend order/i }));
+  return user;
+}
+
+test('renders the Resend Order trigger button', () => {
+  renderWithProviders(<ResendOrderButton order={order} />);
+  expect(screen.getByRole('button', { name: /resend order/i })).toBeInTheDocument();
+});
+
+test('opens the dialog with pharmacy details and fires open analytics', async () => {
+  await openResend();
+
+  expect(await screen.findByRole('dialog')).toBeInTheDocument();
+  expect(screen.getByText(/confirm resend to existing pharmacy/i)).toBeInTheDocument();
+  expect(screen.getByText('Original Pharmacy')).toBeInTheDocument();
+
+  expect(trackSpy).toHaveBeenCalledWith(
+    'Customer Clicked Resend Order',
+    expect.objectContaining({
+      orderId: ORDER_ID,
+      patientId: PATIENT_ID
+    })
+  );
+});
+
+test('Cancel closes the dialog, fires cancel analytics, and does not call the mutation', async () => {
+  const user = await openResend();
+  await screen.findByRole('dialog');
+
+  await user.click(screen.getByRole('button', { name: /^cancel$/i }));
+
+  await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+  expect(trackSpy).toHaveBeenCalledWith(
+    'Cancel Resend Order Clicked',
+    expect.objectContaining({ orderId: ORDER_ID, patientId: PATIENT_ID })
+  );
+  expect(resendOrderSpy).not.toHaveBeenCalled();
+});
+
+test('Confirm fires mutation, shows success toast, and fires analytics on success', async () => {
+  const user = await openResend();
+  const dialog = await screen.findByRole('dialog');
+
+  await user.click(within(dialog).getByRole('button', { name: /^resend order$/i }));
+
+  await waitFor(() => {
+    expect(resendOrderSpy).toHaveBeenCalledWith({ orderId: ORDER_ID });
+  });
+
+  expect(await screen.findByText(/resend successful/i)).toBeInTheDocument();
+  expect(screen.getByText(/we've initiated a resend to the pharmacy/i)).toBeInTheDocument();
+
+  expect(trackSpy).toHaveBeenCalledWith(
+    'Confirm Resend Order Clicked',
+    expect.objectContaining({
+      buttonText: 'Resend order',
+      orderId: ORDER_ID,
+      patientId: PATIENT_ID,
+      pharmacyId: PHARMACY_ID,
+      pharmacyName: 'Original Pharmacy'
+    })
+  );
+
+  await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+});
+
+test('Confirm shows error toast and fires error analytics on mutation failure', async () => {
+  server.use(
+    clinicalGql.mutation('ResendOrder', () =>
+      HttpResponse.json({
+        data: null,
+        errors: [{ message: 'pharmacy not accepting orders' }]
+      })
+    )
+  );
+
+  const user = await openResend();
+  const dialog = await screen.findByRole('dialog');
+
+  await user.click(within(dialog).getByRole('button', { name: /^resend order$/i }));
+
+  expect(await screen.findByText(/error resending order/i)).toBeInTheDocument();
+  expect(screen.getByText(/pharmacy not accepting orders/i)).toBeInTheDocument();
+
+  expect(trackSpy).toHaveBeenCalledWith(
+    'Resend Error Message Viewed',
+    expect.objectContaining({
+      orderId: ORDER_ID,
+      patientId: PATIENT_ID,
+      pharmacyId: PHARMACY_ID
+    })
+  );
+});

--- a/apps/app/src/views/components/ResendOrderButton.tsx
+++ b/apps/app/src/views/components/ResendOrderButton.tsx
@@ -1,0 +1,185 @@
+import {
+  Button,
+  HStack,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalHeader,
+  ModalOverlay,
+  Text,
+  useToast,
+  VStack
+} from '@chakra-ui/react';
+import { useMutation } from '@apollo/client';
+import { usePhoton } from '@photonhealth/react';
+import { useState } from 'react';
+import { Order } from 'packages/sdk/dist/types';
+
+import { StyledToast } from './StyledToast';
+import { formatAddress } from '../../utils';
+import { useProviderAnalytics } from '../../hooks/useProviderAnalytics';
+import { useOrderUniqueTreatments } from '../../hooks/useOrderUniqueTreatments';
+import { resendOrderMutation } from '../../mutations/clinical-api';
+import { useHighestUserRole } from '../../hooks/useHighestUserRole';
+
+type ResendOrderButtonProps = {
+  order: Order & { pharmacy: NonNullable<Order['pharmacy']> };
+};
+
+const CONFIRMATION_CTA_TEXT = 'Resend order';
+
+export function ResendOrderButton({ order }: ResendOrderButtonProps) {
+  const [resending, setResending] = useState(false);
+  const [resendModalOpen, setResendModalOpen] = useState(false);
+
+  const toast = useToast();
+  const { clinicalClient } = usePhoton();
+  const providerAnalytics = useProviderAnalytics();
+  const uniqueTreatments = useOrderUniqueTreatments(order);
+  const userRole = useHighestUserRole();
+
+  const [resendOrder] = useMutation(resendOrderMutation, {
+    client: clinicalClient
+  });
+
+  const handleResendButtonClick = () => {
+    setResendModalOpen(true);
+
+    providerAnalytics.track('Customer Clicked Resend Order', {
+      selector: userRole,
+      orderId: order.id,
+      patientId: order.patient.id,
+      medicationIds: uniqueTreatments.map(({ id }) => id),
+      medicationNames: uniqueTreatments.map(({ name }) => name)
+    });
+  };
+
+  const handleResendConfirmation = async () => {
+    if (resending) return;
+
+    try {
+      setResending(true);
+      await resendOrder({ variables: { orderId: order.id } });
+
+      toast({
+        position: 'top-right',
+        duration: 3000,
+        render: ({ onClose: onToastClose }) => (
+          <StyledToast
+            onClose={onToastClose}
+            type="success"
+            title="Resend Successful"
+            description="We've initiated a resend to the pharmacy"
+          />
+        )
+      });
+
+      providerAnalytics.track('Confirm Resend Order Clicked', {
+        buttonText: CONFIRMATION_CTA_TEXT,
+        orderId: order.id,
+        patientId: order.patient.id,
+        pharmacyId: order.pharmacy.id,
+        pharmacyName: order.pharmacy.name,
+        medicationIds: uniqueTreatments.map(({ id }) => id),
+        medicationNames: uniqueTreatments.map(({ name }) => name)
+      });
+    } catch (error) {
+      handleResendFailure(error as Error);
+    } finally {
+      setResending(false);
+      setResendModalOpen(false);
+    }
+  };
+
+  const handleResendFailure = (error: Error) => {
+    console.error(error);
+    const message = error instanceof Error ? error.message : `${error}`;
+
+    toast({
+      position: 'top-right',
+      duration: 5000,
+      render: ({ onClose: onToastClose }) => (
+        <StyledToast
+          onClose={onToastClose}
+          type="error"
+          title="Error Resending Order"
+          description={message}
+        />
+      )
+    });
+
+    providerAnalytics.track('Resend Error Message Viewed', {
+      message,
+      orderId: order.id,
+      patientId: order.patient.id,
+      pharmacyId: order.pharmacy.id
+    });
+  };
+
+  const handleResendCancel = () => {
+    setResendModalOpen(false);
+
+    providerAnalytics.track('Cancel Resend Order Clicked', {
+      orderId: order.id,
+      patientId: order.patient.id,
+      medicationIds: uniqueTreatments.map(({ id }) => id),
+      medicationNames: uniqueTreatments.map(({ name }) => name)
+    });
+  };
+
+  return (
+    <>
+      <Button
+        onClick={handleResendButtonClick}
+        variant="outline"
+        colorScheme="gray"
+        borderColor="gray.300"
+        borderRadius="lg"
+        paddingY="1"
+        paddingX="3"
+      >
+        Resend Order
+      </Button>
+
+      <Modal isOpen={resendModalOpen} onClose={handleResendCancel} size="xl" isCentered>
+        <ModalOverlay />
+        <ModalContent>
+          <ModalHeader borderBottom="1px" borderColor="gray.300">
+            <HStack justify="space-between" width="full">
+              <Text fontSize="md" fontWeight="normal" color="gray.500">
+                Confirm resend to existing pharmacy
+              </Text>
+              <HStack justify="right">
+                <Button disabled={resending} variant="ghost" onClick={handleResendCancel}>
+                  Cancel
+                </Button>
+                <Button isLoading={resending} onClick={handleResendConfirmation}>
+                  {CONFIRMATION_CTA_TEXT}
+                </Button>
+              </HStack>
+            </HStack>
+          </ModalHeader>
+          <ModalBody p="6">
+            <VStack
+              alignItems="flex-start"
+              border="1px"
+              borderColor="gray.300"
+              borderRadius="xl"
+              spacing="0"
+              padding="4"
+            >
+              <Text as="span" fontWeight="medium">
+                {order.pharmacy.name}
+              </Text>
+              {order.pharmacy.address && (
+                <Text as="span" color="gray.600">
+                  {formatAddress(order.pharmacy.address)}
+                </Text>
+              )}
+            </VStack>
+          </ModalBody>
+        </ModalContent>
+      </Modal>
+    </>
+  );
+}

--- a/apps/app/src/views/components/ResendOrderButton.tsx
+++ b/apps/app/src/views/components/ResendOrderButton.tsx
@@ -4,9 +4,11 @@ import {
   Modal,
   ModalBody,
   ModalContent,
+  ModalFooter,
   ModalHeader,
   ModalOverlay,
   Text,
+  useBreakpointValue,
   useToast,
   VStack
 } from '@chakra-ui/react';
@@ -127,6 +129,19 @@ export function ResendOrderButton({ order }: ResendOrderButtonProps) {
     });
   };
 
+  const showCTAsInHeader = useBreakpointValue({ base: false, md: true });
+
+  const CTAs = (
+    <HStack justify="flex-end" justifySelf="flex-end">
+      <Button disabled={resending} variant="outline" onClick={handleResendCancel}>
+        Cancel
+      </Button>
+      <Button isLoading={resending} onClick={handleResendConfirmation}>
+        {CONFIRMATION_CTA_TEXT}
+      </Button>
+    </HStack>
+  );
+
   return (
     <>
       <Button
@@ -143,23 +158,20 @@ export function ResendOrderButton({ order }: ResendOrderButtonProps) {
 
       <Modal isOpen={resendModalOpen} onClose={handleResendCancel} size="xl" isCentered>
         <ModalOverlay />
-        <ModalContent>
-          <ModalHeader borderBottom="1px" borderColor="gray.300">
-            <HStack justify="space-between" width="full">
+        <ModalContent marginX="3">
+          <ModalHeader
+            borderBottom="1px"
+            borderColor="gray.300"
+            px={useBreakpointValue({ base: '3', md: '6' })}
+          >
+            <HStack justify="space-between" width="full" flexWrap="wrap">
               <Text fontSize="md" fontWeight="normal" color="gray.500">
                 Confirm resend to existing pharmacy
               </Text>
-              <HStack justify="right">
-                <Button disabled={resending} variant="ghost" onClick={handleResendCancel}>
-                  Cancel
-                </Button>
-                <Button isLoading={resending} onClick={handleResendConfirmation}>
-                  {CONFIRMATION_CTA_TEXT}
-                </Button>
-              </HStack>
+              {showCTAsInHeader && CTAs}
             </HStack>
           </ModalHeader>
-          <ModalBody p="6">
+          <ModalBody p={useBreakpointValue({ base: '3', md: '6' })}>
             <VStack
               alignItems="flex-start"
               border="1px"
@@ -178,6 +190,7 @@ export function ResendOrderButton({ order }: ResendOrderButtonProps) {
               )}
             </VStack>
           </ModalBody>
+          {!showCTAsInHeader && <ModalFooter px="3">{CTAs}</ModalFooter>}
         </ModalContent>
       </Modal>
     </>

--- a/apps/app/src/views/routes/Order.tsx
+++ b/apps/app/src/views/routes/Order.tsx
@@ -64,6 +64,7 @@ import {
 import { OrderRoutingHistory } from '../../gql/graphql';
 import { OrderState } from 'packages/sdk/src/types';
 import usePermissions from '../../hooks/usePermissions';
+import { ResendOrderButton } from '../components/ResendOrderButton';
 
 export const ORDER_FULFILLMENT_TYPE_MAP = {
   [types.FulfillmentType.PickUp]: 'Pick up',
@@ -551,7 +552,10 @@ export const OrderDetailPage = () => {
                 headerText="Pharmacy Information"
                 rightElement={
                   canRerouteOrder && order && order?.state !== 'ROUTING' ? (
-                    <RerouteOrderButton organizationId={user.org_id} order={order} />
+                    <HStack justify="right" spacing="2">
+                      {order.pharmacy && <ResendOrderButton order={order} />}
+                      <RerouteOrderButton organizationId={user.org_id} order={order} />
+                    </HStack>
                   ) : undefined
                 }
               />


### PR DESCRIPTION
To support [this linear ticket](https://linear.app/photon-health/issue/X-129/enable-customers-to-resend-orders-faxes-only)

Adding a quick cute little button to trigger the fax resend from the clinical ui. Tracking and error handling etc.


### Success

https://github.com/user-attachments/assets/0e21cfb6-fc07-43d8-a757-bd29626891b3


### Error - a transmission is still in `new` or `sending` state

https://github.com/user-attachments/assets/2850b64d-a0c6-4320-ba08-35784f3b99e8


### Error - blocking when a transmission successfully sent within the last hour
https://github.com/user-attachments/assets/a94a899e-58ad-43ca-8d74-38f1df28b395

