### PR TITLE
use new patient copy resolver

### DIFF
--- a/apps/patient/src/Navigation.test.tsx
+++ b/apps/patient/src/Navigation.test.tsx
@@ -37,6 +37,7 @@ vi.mock('./api', () => ({
   getPharmacies: vi.fn().mockResolvedValue({ pharmacies: [] }),
   getPharmaciesByLocation: vi.fn().mockResolvedValue({ pharmaciesByLocation: [] }),
   getOfferBundles: vi.fn().mockResolvedValue([]),
+  getPatientCopy: vi.fn().mockResolvedValue({ faqs: [], copy: {} }),
   rerouteOrder: vi.fn(),
   setOrderPharmacy: vi.fn(),
   setPreferredPharmacy: vi.fn(),

--- a/apps/patient/src/Reroute.test.tsx
+++ b/apps/patient/src/Reroute.test.tsx
@@ -26,6 +26,7 @@ vi.mock('./api', () => ({
   getPharmacies: vi.fn().mockResolvedValue({ pharmacies: [] }),
   getPharmaciesByLocation: vi.fn().mockResolvedValue({ pharmaciesByLocation: [] }),
   getOfferBundles: vi.fn().mockResolvedValue([]),
+  getPatientCopy: vi.fn().mockResolvedValue({ faqs: [], copy: {} }),
   rerouteOrder: vi.fn().mockReturnValue(Promise.resolve(true)),
   setOrderPharmacy: vi.fn(),
   setPreferredPharmacy: vi.fn(),

--- a/apps/patient/src/SendToPatientDemo.test.tsx
+++ b/apps/patient/src/SendToPatientDemo.test.tsx
@@ -14,6 +14,7 @@ vi.mock('./api', () => ({
   }),
   getPharmacies: vi.fn().mockResolvedValue({ pharmacies: [] }),
   getOfferBundles: vi.fn().mockResolvedValue([]),
+  getPatientCopy: vi.fn().mockResolvedValue({ faqs: [], copy: {} }),
   triggerDemoNotification: vi.fn()
 }));
 

--- a/apps/patient/src/api/internal.ts
+++ b/apps/patient/src/api/internal.ts
@@ -22,9 +22,15 @@ export const getOfferBundles = async (orderId: string) => {
   return response.offerBundles;
 };
 
-export const getFaqs = async (orderId: string) => {
-  const response = await graphQLClient.GetFaqs({ orderId });
-  return response.faqs;
+export const getPatientCopy = async (orderId: string) => {
+  const {
+    patientCopy: { faqs, copy }
+  } = await graphQLClient.GetPatientCopy({ orderId });
+  const copyRecord: Record<string, string> = {};
+  for (const { key, value } of copy) {
+    copyRecord[key] = value;
+  }
+  return { faqs, copy: copyRecord };
 };
 
 export const getPharmaciesByLocation = async ({

--- a/apps/patient/src/components/FAQModal.tsx
+++ b/apps/patient/src/components/FAQModal.tsx
@@ -15,12 +15,10 @@ import {
   useToast,
   VStack
 } from '@chakra-ui/react';
-import { useEffect, useState } from 'react';
 import { Card } from './Card';
-import { FAQContents, FAQEntry } from './FAQ';
+import { FAQContents } from './FAQ';
 import { useOrderContext } from '../views/Main';
 import { usePatientAnalytics } from '../hooks/usePatientAnalytics';
-import { getFaqs } from '../api';
 
 export const FAQModal = ({
   isOpen,
@@ -31,24 +29,9 @@ export const FAQModal = ({
   onClose: () => void;
   allowMessageSupport?: boolean;
 }) => {
-  const { order, isDemo } = useOrderContext();
+  const { order, isDemo, faqs } = useOrderContext();
   const toast = useToast();
   const patientAnalytics = usePatientAnalytics();
-
-  const [faqs, setFaqs] = useState<FAQEntry[] | undefined>(undefined);
-  const [loading, setLoading] = useState(false);
-
-  useEffect(() => {
-    if (!isOpen || !order?.id) {
-      return;
-    }
-    setLoading(true);
-    (async () => {
-      const result = await getFaqs(order.id);
-      setFaqs(result);
-      setLoading(false);
-    })();
-  }, [isOpen, order?.id]);
 
   const handleMessageSupport = () => {
     if (isDemo) {
@@ -75,13 +58,13 @@ export const FAQModal = ({
           <Container>
             <VStack alignItems="stretch" spacing={6} w="full">
               <VStack bgColor="white" borderRadius="xl" px={4} py={1} alignItems={'start'} w="full">
-                {loading ? (
+                {faqs ? (
+                  <FAQContents faqs={faqs} />
+                ) : (
                   <Stack w="full" py={2} spacing={3}>
                     <Skeleton height="20px" />
                     <SkeletonText noOfLines={2} spacing="2" />
                   </Stack>
-                ) : (
-                  <FAQContents faqs={faqs || []} />
                 )}
               </VStack>
 

--- a/apps/patient/src/components/order-details/OrderDetailsModal.tsx
+++ b/apps/patient/src/components/order-details/OrderDetailsModal.tsx
@@ -29,21 +29,16 @@ export interface PrescriptionData {
 
 export interface OrderDetailsProps {
   pharmacyName: string;
-  pharmacyId?: string;
   pharmacyLogo?: string;
   prescriptions: PrescriptionData[];
   fulfillmentState?: PrescriptionFulfillment['state'] | 'DELAYED' | 'FILLING' | 'SHIPPED';
+  nextSteps?: string;
 }
 
 export interface OrderDetailsModalProps {
   isOpen: boolean;
   onClose: () => void;
 }
-
-const NEXT_STEPS_BY_PHARMACY: Record<string, string> = {
-  [import.meta.env.VITE_AMAZON_PHARMACY_ID as string]:
-    'Amazon Pharmacy will text you shortly — no action needed.\n\nNo text? Log in at [amazon.com/pharmacy](https://amazon.com/pharmacy) to view your prescription or create an account. Your prescription should show up soon.\n\nStill have trouble? Contact support. You can also switch pharmacies if needed.'
-};
 
 const Row = ({ k, value }: { k: string; value: ReactNode }) => {
   return (
@@ -80,7 +75,6 @@ const defaultIcon = (
 );
 
 export const OrderDetailsModal = (props: OrderDetailsProps & OrderDetailsModalProps) => {
-  const nextSteps = props.pharmacyId ? NEXT_STEPS_BY_PHARMACY[props.pharmacyId] : undefined;
   const handleClose = () => {
     props.onClose();
   };
@@ -133,14 +127,14 @@ export const OrderDetailsModal = (props: OrderDetailsProps & OrderDetailsModalPr
                   <PrescriptionBlock key={`${p.rxName}-${i}`} rx={p} />
                 ))}
               </VStack>
-              {nextSteps &&
+              {props.nextSteps &&
                 (props.fulfillmentState === 'CREATED' || props.fulfillmentState === 'SENT') && (
                   <VStack alignItems="stretch" spacing={2} w="full">
                     <Text fontWeight="bold" fontSize="lg">
                       Next Steps
                     </Text>
                     <Box bgColor="blue.50" borderRadius="xl" p={4}>
-                      <Text whiteSpace="pre-wrap">{renderWithLinks(nextSteps)}</Text>
+                      <Text whiteSpace="pre-wrap">{renderWithLinks(props.nextSteps)}</Text>
                     </Box>
                   </VStack>
                 )}

--- a/apps/patient/src/graphql/queries.ts
+++ b/apps/patient/src/graphql/queries.ts
@@ -501,11 +501,17 @@ export const GET_OFFER_BUNDLES = gql`
   }
 `;
 
-export const GET_FAQS = gql`
-  query GetFaqs($orderId: ID!) {
-    faqs(orderId: $orderId) {
-      question
-      answer
+export const GET_PATIENT_COPY = gql`
+  query GetPatientCopy($orderId: ID!) {
+    patientCopy(orderId: $orderId) {
+      faqs {
+        question
+        answer
+      }
+      copy {
+        key
+        value
+      }
     }
   }
 `;

--- a/apps/patient/src/views/Canceled.test.tsx
+++ b/apps/patient/src/views/Canceled.test.tsx
@@ -61,6 +61,8 @@ const renderCanceled = (orderContextValueOverride: Partial<OrderContextType> = {
     setEnablePrice(enablePrice: boolean): void {},
     reason: '',
     setReason: () => {},
+    faqs: [],
+    copy: {},
     ...orderContextValueOverride
   };
   return render(

--- a/apps/patient/src/views/Main.tsx
+++ b/apps/patient/src/views/Main.tsx
@@ -9,8 +9,9 @@ import {
 } from 'react-router-dom';
 import queryString from 'query-string';
 
-import { AUTH_HEADER_ERRORS, getOrder } from '../api';
+import { AUTH_HEADER_ERRORS, getOrder, getPatientCopy } from '../api';
 import { Nav } from '../components';
+import { FAQEntry } from '../components/FAQ';
 import { setAuthHeader } from '../configs/graphqlClient';
 import theme from '../configs/theme';
 import { demoOrder } from '../data/demoOrder';
@@ -43,6 +44,8 @@ export interface OrderContextType {
   setFaqModalIsOpen: (isOpen: boolean) => void;
   reason: string;
   setReason: (reason: string) => void;
+  faqs: FAQEntry[] | undefined;
+  copy: Record<string, string>;
 }
 export const OrderContext = createContext<OrderContextType | null>(null);
 export const useOrderContext = () =>
@@ -101,6 +104,8 @@ export const Main = () => {
   usePageAnalytics({ pageName: 'Main' });
   const [faqModalIsOpen, setFaqModalIsOpen] = useState(false);
   const [reason, setReason] = useState<string>('');
+  const [faqs, setFaqs] = useState<FAQEntry[]>([]);
+  const [copy, setCopy] = useState<Record<string, string>>({});
 
   const orgId = order?.organization.id;
   const settings = order?.organization.settings;
@@ -243,6 +248,16 @@ export const Main = () => {
     }
   }, [order, orderId, fetchOrder, isDemo]);
 
+  useEffect(() => {
+    if (!orderId) return;
+    const fetchPatientCopy = async () => {
+      const patientCopy = await getPatientCopy(orderId);
+      setFaqs(patientCopy.faqs);
+      setCopy(patientCopy.copy);
+    };
+    fetchPatientCopy();
+  }, [orderId, order?.pharmacy?.id]);
+
   const fetchLogo = useCallback(async (fileName: string) => {
     if (fileName === 'photon') {
       setLogo('photon');
@@ -297,7 +312,9 @@ export const Main = () => {
     fetchOrder,
     setFaqModalIsOpen,
     reason,
-    setReason
+    setReason,
+    faqs,
+    copy
   };
 
   const isAutomatedOrder = order.organization.settings?.patientUx.enableAutomatedOps;

--- a/apps/patient/src/views/Pharmacy.test.tsx
+++ b/apps/patient/src/views/Pharmacy.test.tsx
@@ -40,6 +40,7 @@ vi.mock('../api', () => ({
   getPharmaciesByLocation: vi.fn().mockResolvedValue({ pharmaciesByLocation: [] }),
   getPharmacies: vi.fn().mockResolvedValue({ pharmacies: [] }),
   getOfferBundles: vi.fn().mockResolvedValue([]),
+  getPatientCopy: vi.fn().mockResolvedValue({ faqs: [], copy: {} }),
   rerouteOrder: vi.fn(),
   setOrderPharmacy: vi.fn(),
   setPreferredPharmacy: vi.fn(),

--- a/apps/patient/src/views/ReadyBy.test.tsx
+++ b/apps/patient/src/views/ReadyBy.test.tsx
@@ -60,6 +60,8 @@ const renderReadyBy = (orderContextValueOverride: Partial<OrderContextType> = {}
     setEnablePrice(enablePrice: boolean): void {},
     reason: '',
     setReason: () => {},
+    faqs: [],
+    copy: {},
     ...orderContextValueOverride
   };
   return render(

--- a/apps/patient/src/views/Review.test.tsx
+++ b/apps/patient/src/views/Review.test.tsx
@@ -25,6 +25,7 @@ vi.mock('../api', () => ({
   getPharmacies: vi.fn().mockResolvedValue({ pharmacies: [] }),
   getPharmaciesByLocation: vi.fn().mockResolvedValue({ pharmaciesByLocation: [] }),
   getOfferBundles: vi.fn().mockResolvedValue([]),
+  getPatientCopy: vi.fn().mockResolvedValue({ faqs: [], copy: {} }),
   AUTH_HEADER_ERRORS: []
 }));
 

--- a/apps/patient/src/views/Status.test.tsx
+++ b/apps/patient/src/views/Status.test.tsx
@@ -26,6 +26,7 @@ vi.mock('../api', () => ({
   getPharmaciesByLocation: vi.fn().mockResolvedValue({ pharmaciesByLocation: [] }),
   getPharmacies: vi.fn().mockResolvedValue([]),
   getOfferBundles: vi.fn().mockResolvedValue([]),
+  getPatientCopy: vi.fn().mockResolvedValue({ faqs: [], copy: {} }),
   AUTH_HEADER_ERRORS: []
 }));
 

--- a/apps/patient/src/views/Status.tsx
+++ b/apps/patient/src/views/Status.tsx
@@ -27,7 +27,7 @@ import { OrderState } from 'packages/sdk/src/types';
 
 export const Status = () => {
   const navigate = useNavigate();
-  const { order, setOrder, isDemo, setFaqModalIsOpen, setReason } = useOrderContext();
+  const { order, setOrder, isDemo, setFaqModalIsOpen, setReason, copy } = useOrderContext();
   const patientAnalytics = usePatientAnalytics();
   const { enablePatientRerouting } = order?.organization?.settings?.patientUx ?? {};
   const rerouteReasonDialog = useDisclosure();
@@ -285,10 +285,10 @@ export const Status = () => {
         isOpen={orderDetailsIsOpen}
         onClose={() => setOrderDetailsIsOpen(false)}
         pharmacyName={displayPharmacy?.name ?? 'My Pharmacy'}
-        pharmacyId={displayPharmacy?.id}
         pharmacyLogo={displayPharmacy?.logo}
         prescriptions={prescriptions}
         fulfillmentState={fulfillmentState}
+        nextSteps={copy.nextSteps}
       />
       <Helmet>
         <title>{t.track}</title>


### PR DESCRIPTION
- using new patient copy resovler instead of faqs resolver and we're adding the response to context now instead of multiple calls per page where it's needed. 
- next steps is no longer hardcoded
- updating tangentially affected tests now that we're fetching copy in Main