### PR TITLE
Add claim assisted login when no Org is passed to the photon-client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30570,7 +30570,7 @@
     },
     "packages/elements": {
       "name": "@photonhealth/elements",
-      "version": "0.23.5",
+      "version": "0.23.6",
       "license": "ISC",
       "dependencies": {
         "@shoelace-style/shoelace": "^2.4.0",

--- a/packages/components/src/store.ts
+++ b/packages/components/src/store.ts
@@ -299,7 +299,25 @@ export class PhotonClientStore {
         // getAccessToken is triggering the SSO screen to appear, so for auto-login=false, we don't want to call it
         try {
           const token = await this.sdk.authentication.getAccessToken();
-          const decoded: { permissions: Permission[] } = jwtDecode(token);
+          const decoded: {
+            permissions: Permission[];
+            'https://photon.health/assigned_org_id'?: string;
+          } = jwtDecode(token);
+          const assignedOrgId = decoded['https://photon.health/assigned_org_id'];
+          if (
+            !isOrganizationIdSelectedInPhotonClient &&
+            !isUserLoggedIntoAnOrganization &&
+            assignedOrgId
+          ) {
+            // No org was configured upfront and the user isn't logged into one, but the
+            // token assigns them an org — re-login scoped to that org. Once the redirect
+            // comes back, user.org_id is set, so this only happens once.
+            this.sdk.setOrganization(assignedOrgId);
+            await this.sdk.authentication.login({
+              appState: { returnTo: `${window.location.pathname}${window.location.search}` }
+            });
+            return;
+          }
           permissions = decoded?.permissions || [];
         } catch (_err) {
           permissions = [];

--- a/packages/components/src/store.ts
+++ b/packages/components/src/store.ts
@@ -127,6 +127,10 @@ export class PhotonClientStore {
 
   public autoLogin: boolean;
 
+  // appState recovered from the most recent Auth0 redirect, held so checkSession can
+  // preserve the original returnTo if it triggers a second, org-scoped login.
+  private redirectAppState?: { returnTo?: string };
+
   public constructor(sdk: PhotonClient, autoLogin = false) {
     this.sdk = sdk;
     this.autoLogin = autoLogin;
@@ -214,7 +218,12 @@ export class PhotonClientStore {
         try {
           const result = await this.sdk.authentication.handleRedirect(url);
           defaultOnRedirectCallback(result?.appState);
-          await this.authentication.checkSession();
+          this.redirectAppState = result?.appState;
+          try {
+            await this.authentication.checkSession();
+          } finally {
+            this.redirectAppState = undefined;
+          }
         } catch (err: any) {
           const urlParams = new URLSearchParams(window.location.search);
           const errorMessage = urlParams.get('error_description');
@@ -309,12 +318,19 @@ export class PhotonClientStore {
             !isUserLoggedIntoAnOrganization &&
             assignedOrgId
           ) {
+            console.log('ZAC SETTING ORG AND LOGGIN IN');
             // No org was configured upfront and the user isn't logged into one, but the
             // token assigns them an org — re-login scoped to that org. Once the redirect
             // comes back, user.org_id is set, so this only happens once.
             this.sdk.setOrganization(assignedOrgId);
             await this.sdk.authentication.login({
-              appState: { returnTo: `${window.location.pathname}${window.location.search}` }
+              appState: {
+                // Preserve the original login's returnTo (recovered by handleRedirect)
+                // so the destination survives the second, org-scoped login.
+                returnTo:
+                  this.redirectAppState?.returnTo ??
+                  `${window.location.pathname}${window.location.search}`
+              }
             });
             return;
           }
@@ -324,11 +340,13 @@ export class PhotonClientStore {
         }
       }
 
+      // Read the org off the SDK here (rather than isOrganizationIdSelectedInPhotonClient,
+      // captured above) so an org derived from user.org_id during this call counts too.
       // @ts-ignore TODO store will be updated soon, so this will change
       const selectedOrganizationId = this.sdk?.organization;
       const isInOrg =
         authenticated &&
-        isOrganizationIdSelectedInPhotonClient &&
+        !!selectedOrganizationId &&
         isUserLoggedIntoAnOrganization &&
         selectedOrganizationId === user.org_id;
 

--- a/packages/components/src/store.ts
+++ b/packages/components/src/store.ts
@@ -299,9 +299,9 @@ export class PhotonClientStore {
 
       // If no org was configured upfront but the user was logged into one,
       // derive it from the authenticated user.
-      // if (!isOrganizationIdSelectedInPhotonClient && isUserLoggedIntoAnOrganization) {
-      //   this.sdk.setOrganization(user.org_id);
-      // }
+      if (!isOrganizationIdSelectedInPhotonClient && isUserLoggedIntoAnOrganization) {
+        this.sdk.setOrganization(user.org_id);
+      }
 
       let permissions: Permission[] = [];
       if (this.autoLogin || authenticated) {

--- a/packages/components/src/store.ts
+++ b/packages/components/src/store.ts
@@ -299,9 +299,9 @@ export class PhotonClientStore {
 
       // If no org was configured upfront but the user was logged into one,
       // derive it from the authenticated user.
-      if (!isOrganizationIdSelectedInPhotonClient && isUserLoggedIntoAnOrganization) {
-        this.sdk.setOrganization(user.org_id);
-      }
+      // if (!isOrganizationIdSelectedInPhotonClient && isUserLoggedIntoAnOrganization) {
+      //   this.sdk.setOrganization(user.org_id);
+      // }
 
       let permissions: Permission[] = [];
       if (this.autoLogin || authenticated) {
@@ -318,7 +318,6 @@ export class PhotonClientStore {
             !isUserLoggedIntoAnOrganization &&
             assignedOrgId
           ) {
-            console.log('ZAC SETTING ORG AND LOGGIN IN');
             // No org was configured upfront and the user isn't logged into one, but the
             // token assigns them an org — re-login scoped to that org. Once the redirect
             // comes back, user.org_id is set, so this only happens once.

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@photonhealth/elements",
-  "version": "0.23.5",
+  "version": "0.23.6",
   "description": "",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
This is an extension of the work originally done in https://github.com/Photon-Health/client/pull/2704

The initial approach had some issues with the auto-assigning not properly re-logging in to reset permissions, this change makes use of a new custom claim on our Access Token set on login to an assigned Org. For the best results this should only be used in single-organization contexts. Multi-Org users should still pass the Organization ID in to the Photon Client explicitly.