### PR TITLE
Limit pharmacy notes to 210 characters In prescribe form

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30570,7 +30570,7 @@
     },
     "packages/elements": {
       "name": "@photonhealth/elements",
-      "version": "0.23.7",
+      "version": "0.23.8",
       "license": "ISC",
       "dependencies": {
         "@shoelace-style/shoelace": "^2.4.0",

--- a/packages/components/src/particles/InputGroup/index.tsx
+++ b/packages/components/src/particles/InputGroup/index.tsx
@@ -89,6 +89,7 @@ export interface InputGroupProps {
   subLabel?: string;
   error?: string;
   showOptionalSubtext?: boolean;
+  headingSubLabel?: string;
   helpText?: string | JSX.Element;
   children?: JSX.Element;
   loading?: boolean;
@@ -146,6 +147,9 @@ function InputGroupWrapper(props: InputGroupProps) {
             <div class="text-xs leading-6 text-gray-500">{props.subLabel}</div>
           </Show>
         </div>
+        <Show when={props.headingSubLabel}>
+          <span class="text-xs text-gray-400">{props.headingSubLabel}</span>
+        </Show>
       </div>
 
       {props.children}

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@photonhealth/elements",
-  "version": "0.23.7",
+  "version": "0.23.8",
   "description": "",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/elements/src/photon-multirx-form/components/PrescriptionCard/DraftPrescriptionForm.tsx
+++ b/packages/elements/src/photon-multirx-form/components/PrescriptionCard/DraftPrescriptionForm.tsx
@@ -36,6 +36,7 @@ import clearForm from './util/clearForm';
 import repopulateForm from './util/repopulateForm';
 import { DisableList } from '../PrescribeWorkflow';
 import { afterDate, message } from '../../../validators';
+import { formatCharacterCount } from './util/formatCharacterCount';
 
 const validators = {
   treatment: message(record(string(), any()), 'Please select a treatment'),
@@ -47,6 +48,10 @@ const validators = {
   daysSupply: message(min(number(), 0), 'Days Supply must be at least 0'),
   refills: message(intersection([min(number(), 0), max(number(), 11)]), 'Refills must be 0 to 11'),
   instructions: message(nonempty(string()), 'Please enter instructions for the patient'),
+  notes: message(
+    refine(string(), 'Note length', (value) => value.length <= 210),
+    'Note cannot be longer than 210 characters'
+  ),
   doNotFillBeforeDate: message(
     optional(afterDate(new Date())),
     "Please choose a date that isn't in the past"
@@ -404,7 +409,12 @@ export const DraftPrescriptionForm = (props: {
           }}
         />
       </InputGroup>
-      <InputGroup label="Pharmacy Note" showOptionalSubtext>
+      <InputGroup
+        label="Pharmacy Note"
+        subLabel={formatCharacterCount(props.store.notes?.value?.length ?? 0)}
+        showOptionalSubtext
+        error={props.store.notes?.error}
+      >
         <Textarea
           placeholder="Enter pharmacy note"
           value={props.store.notes?.value}

--- a/packages/elements/src/photon-multirx-form/components/PrescriptionCard/DraftPrescriptionForm.tsx
+++ b/packages/elements/src/photon-multirx-form/components/PrescriptionCard/DraftPrescriptionForm.tsx
@@ -412,7 +412,7 @@ export const DraftPrescriptionForm = (props: {
       </InputGroup>
       <InputGroup
         label="Pharmacy Note"
-        subLabel={formatCharacterCount(props.store.notes?.value?.length ?? 0)}
+        headingSubLabel={formatCharacterCount(props.store.notes?.value?.length ?? 0)}
         showOptionalSubtext
         error={props.store.notes?.error}
       >

--- a/packages/elements/src/photon-multirx-form/components/PrescriptionCard/util/formatCharacterCount.ts
+++ b/packages/elements/src/photon-multirx-form/components/PrescriptionCard/util/formatCharacterCount.ts
@@ -1,0 +1,1 @@
+export const formatCharacterCount = (current: number = 0, max: number = 210) => `${current}/${max}`;


### PR DESCRIPTION
PR changes:
- Added a 210 char limit validation to Pharmacy note on front end
- Display Pharmacy notes character count
<img width="1512" height="866" alt="Screenshot 2026-06-18 at 3 52 19 PM" src="https://github.com/user-attachments/assets/e1d3db33-1669-4b6e-a003-04d5c44599c0" />

