### PR TITLE
fix ws vuln (CVE-2026-48779)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -133,7 +133,7 @@
         "vite-plugin-solid": "2.11.6",
         "vite-tsconfig-paths": "^5.1.4",
         "vitest": "^4.1.8",
-        "ws": "^8.19.0"
+        "ws": "^8.21.0"
       },
       "optionalDependencies": {
         "@rollup/rollup-linux-x64-gnu": "^4.37.0"
@@ -7420,28 +7420,6 @@
         }
       }
     },
-    "node_modules/@module-federation/dts-plugin/node_modules/ws": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@module-federation/enhanced": {
       "version": "0.21.6",
       "resolved": "https://registry.npmjs.org/@module-federation/enhanced/-/enhanced-0.21.6.tgz",
@@ -7862,28 +7840,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/@module-federation/node/node_modules/ws": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
       }
     },
     "node_modules/@module-federation/rspack": {

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "vite-plugin-solid": "2.11.6",
     "vite-tsconfig-paths": "^5.1.4",
     "vitest": "^4.1.8",
-    "ws": "^8.19.0"
+    "ws": "^8.21.0"
   },
   "dependencies": {
     "@apollo/client": "^3.7.10",
@@ -160,6 +160,7 @@
     "lodash": "^4.18.1",
     "undici": "^7.28.0",
     "markdown-it": "^14.2.0",
+    "ws": "^8.21.0",
     "picomatch": "4.0.4",
     "@chakra-ui/react": {
       "@zag-js/focus-visible": "^1.18.0"


### PR DESCRIPTION
Force ws to ^8.21.0 via overrides to collapse the nested ws@8.18.0 copies pinned by @module-federation/dts-plugin and @module-federation/node.

TripleKey found this, not dependabot