### PR TITLE
Filter out canceled fills/prescriptions/fulfillments on the order for patients

### DIFF
--- a/apps/patient/src/components/status/Header.tsx
+++ b/apps/patient/src/components/status/Header.tsx
@@ -80,6 +80,8 @@ function headerText(props: OrderStatusHeaderProps) {
       return 'Order delivered';
     case 'SHIPPED':
       return 'Order in transit';
+    case 'CANCELED':
+      return 'Order canceled';
     default: {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const _: never = status;

--- a/apps/patient/src/data/demoOrder.ts
+++ b/apps/patient/src/data/demoOrder.ts
@@ -19,6 +19,7 @@ export const demoOrder: Order = {
   fills: [
     {
       id: 'fil_01H91JWEAPK8ZHF0H35JE59RQY',
+      state: 'SENT',
       prescription: {
         daysSupply: 10,
         dispenseUnit: 'ML',
@@ -36,6 +37,7 @@ export const demoOrder: Order = {
     },
     {
       id: 'fil_01sH91JWEAPK8ZHF0H35sfwe3JE59RQY',
+      state: 'SENT',
       prescription: {
         daysSupply: 2,
         dispenseUnit: 'tablets',

--- a/apps/patient/src/graphql/queries.ts
+++ b/apps/patient/src/graphql/queries.ts
@@ -146,6 +146,7 @@ export const GET_ORDER = gql`
       }
       fills {
         id
+        state
         treatment {
           ... on Medication {
             id

--- a/apps/patient/src/test-utils/generators.ts
+++ b/apps/patient/src/test-utils/generators.ts
@@ -71,6 +71,7 @@ export const generateFill = (treatmentName: string): Order['fills'][number] => {
   fillIdCounter += 1;
   return {
     id: `fil_testIdDefault_${fillIdCounter}`,
+    state: 'SENT',
     treatment: {
       id: `med_testIdDefault_${fillIdCounter}`,
       name: treatmentName
@@ -120,6 +121,7 @@ export const generatePrescription = (): Prescription => ({
 
 export const generateFlattenedFill = (override: Partial<FillWithCount>): FillWithCount => ({
   id: `fil_testIdDefault`,
+  state: 'SENT',
   count: 1,
   treatment: generateTreatment(),
   ...override

--- a/apps/patient/src/views/Main.tsx
+++ b/apps/patient/src/views/Main.tsx
@@ -196,6 +196,10 @@ export const Main = () => {
       try {
         const result = await getOrder(orderId!);
         if (result) {
+          result.fills = result.fills.filter((fill) => fill.state !== 'CANCELED');
+          result.fulfillments = result.fulfillments.filter(
+            (fulfillment) => fulfillment.state !== 'CANCELED'
+          );
           setOrderDataLocally(result, currentPharmacy);
 
           if (options.triggerNavigationAfterFetch) {


### PR DESCRIPTION
Opted to just filter these out on the client side because the patient api uses the same prescription query service as the clinical and admin api. Felt heavy handed to automatically filter out canceled state items for those methods.  Would prefer backend filtering but this is a small amount of items to filter out on the client, and the prescription command/query services are overloaded. Also if we later decide we want to show canceled stuff in some alternate state, we'd have to undo the backend change and then make the frontend change. Can't easily parameterize "get me fulillments with this state" on the patient frontend because those entities live deeply nested as subresolvers of subresolvers. 

If we really hate this i can add a parameter on the prescription command service methods that will filter out fills and fulfillments by state when it's requested from the patient api. 


You can see here that we don't display the canceled stuff. 
<img width="926" height="611" alt="Screenshot 2026-06-29 at 2 11 43 PM" src="https://github.com/user-attachments/assets/f51bdadc-9be6-4477-a14f-b81014838782" />

<img width="604" height="769" alt="Screenshot 2026-06-29 at 2 11 32 PM" src="https://github.com/user-attachments/assets/204e6752-d9b9-42b7-b779-afe8d4b87be0" />
