### PR TITLE
Expand marketplace views to non-mail in prescriber selected Pharmacies

### DIFF
--- a/apps/patient/src/utils/getOrderFetchRedirectPath.test.ts
+++ b/apps/patient/src/utils/getOrderFetchRedirectPath.test.ts
@@ -1,8 +1,26 @@
+import { FulfillmentType } from 'packages/sdk/src/types';
 import { generateOrder, generatePatient, generatePharmacy } from '../test-utils/generators';
 import {
   getOrderFetchRedirectPath,
-  hasSingleAutoRouteWithNoReroutes
+  hasSingleAutoRouteWithNoReroutes,
+  hasSingleProviderRouteWithNoReroutes
 } from './getOrderFetchRedirectPath';
+import { Fill } from './models';
+
+describe('When the order routing history has multiple entries', () => {
+  const order = generateOrder({
+    metadata: {
+      routingHistory: [{ selector: 'AUTO' }, { selector: 'PATIENT' }]
+    }
+  });
+  test('hasSingleAutoRouteWithNoReroutes is false', () => {
+    expect(hasSingleAutoRouteWithNoReroutes(order)).toBe(false);
+  });
+
+  test('hasSingleProviderRouteWithNoReroutes is false', () => {
+    expect(hasSingleProviderRouteWithNoReroutes(order)).toBe(false);
+  });
+});
 
 test('hasSingleAutoRouteWithNoReroutes is true for sole AUTO routing history entry', () => {
   const order = generateOrder({
@@ -14,14 +32,14 @@ test('hasSingleAutoRouteWithNoReroutes is true for sole AUTO routing history ent
   expect(hasSingleAutoRouteWithNoReroutes(order)).toBe(true);
 });
 
-test('hasSingleAutoRouteWithNoReroutes is false when routing history has multiple entries', () => {
+test('hasSingleProviderRouteWithNoReroutes is true for sole PROVIDER routing history entry', () => {
   const order = generateOrder({
     metadata: {
-      routingHistory: [{ selector: 'AUTO' }, { selector: 'PATIENT' }]
+      routingHistory: [{ selector: 'PROVIDER' }]
     }
   });
 
-  expect(hasSingleAutoRouteWithNoReroutes(order)).toBe(false);
+  expect(hasSingleProviderRouteWithNoReroutes(order)).toBe(true);
 });
 
 test('getOrderFetchRedirectPath returns /canceled when order state is CANCELED', () => {
@@ -39,6 +57,54 @@ test('getOrderFetchRedirectPath returns /pharmacy when pharmacy was auto-routed 
   });
 
   expect(getOrderFetchRedirectPath(order)).toBe('/pharmacy');
+});
+
+test('getOrderFetchRedirectPath returns /pharmacy when pharmacy was provider-routed and reroutable', () => {
+  const order = generateOrder({
+    state: 'ROUTING',
+    isReroutable: true,
+    pharmacy: generatePharmacy({ id: 'phr_auto' }),
+    metadata: {
+      routingHistory: [{ selector: 'PROVIDER' }]
+    }
+  });
+
+  expect(getOrderFetchRedirectPath(order)).toBe('/pharmacy');
+});
+
+test('getOrderFetchRedirectPath returns /status when pharmacy was provider-routed and reroutable, but has a Mail-In Pharmacy', () => {
+  const order = generateOrder({
+    state: 'ROUTING',
+    isReroutable: true,
+    pharmacy: generatePharmacy({ id: 'phr_auto', fulfillmentTypes: [FulfillmentType.MailOrder] }),
+    metadata: {
+      routingHistory: [{ selector: 'PROVIDER' }]
+    }
+  });
+
+  expect(getOrderFetchRedirectPath(order)).toBe('/status');
+});
+
+test('getOrderFetchRedirectPath returns /status when pharmacy was provider-routed and reroutable, but has a Compound Treatment', () => {
+  const order = generateOrder({
+    state: 'ROUTING',
+    isReroutable: true,
+    pharmacy: generatePharmacy({ id: 'phr_auto' }),
+    fills: [
+      {
+        treatment: {
+          __typename: 'Compound',
+          name: 'Compound Treatment',
+          id: 'cmd_1234'
+        }
+      } as Fill
+    ],
+    metadata: {
+      routingHistory: [{ selector: 'PROVIDER' }]
+    }
+  });
+
+  expect(getOrderFetchRedirectPath(order)).toBe('/status');
 });
 
 test('getOrderFetchRedirectPath returns /status when auto-routed pharmacy was confirmed locally', () => {

--- a/apps/patient/src/utils/getOrderFetchRedirectPath.ts
+++ b/apps/patient/src/utils/getOrderFetchRedirectPath.ts
@@ -42,6 +42,7 @@ export const getOrderFetchRedirectPath = (
   if (order.pharmacy?.id) {
     const shouldConfirmAutoRoutedPharmacy =
       (hasSingleAutoRouteWithNoReroutes(order) || hasSingleProviderRouteWithNoReroutes(order)) &&
+      // When Mail-In is pre-chosen the Market Place UI is really confusing
       !isOrderMailIn(order) &&
       // We don't want to show the marketplace for Compound Treatments
       !isForCompoundMed(order) &&

--- a/apps/patient/src/utils/getOrderFetchRedirectPath.ts
+++ b/apps/patient/src/utils/getOrderFetchRedirectPath.ts
@@ -13,6 +13,8 @@ const hasSingleProviderRouteWithNoReroutes = (order: Order): boolean => {
   return routingHistory.length === 1 && routingHistory[0]?.selector === 'PROVIDER';
 };
 
+// We don't want to redirect to the Marketplace immediately for Mail-In Pharmacies
+// For now it's just a confusing experience, once we redesign the experience we should remove this.
 const isOrderMailIn = (order: Order): boolean => {
   return (
     order.pharmacy?.fulfillmentTypes?.every(

--- a/apps/patient/src/utils/getOrderFetchRedirectPath.ts
+++ b/apps/patient/src/utils/getOrderFetchRedirectPath.ts
@@ -8,14 +8,14 @@ export const hasSingleAutoRouteWithNoReroutes = (order: Order): boolean => {
   return routingHistory.length === 1 && routingHistory[0]?.selector === 'AUTO';
 };
 
-const hasSingleProviderRouteWithNoReroutes = (order: Order): boolean => {
+export const hasSingleProviderRouteWithNoReroutes = (order: Order): boolean => {
   const routingHistory = order.metadata?.routingHistory ?? [];
   return routingHistory.length === 1 && routingHistory[0]?.selector === 'PROVIDER';
 };
 
 // We don't want to redirect to the Marketplace immediately for Mail-In Pharmacies
 // For now it's just a confusing experience, once we redesign the experience we should remove this.
-const isOrderMailIn = (order: Order): boolean => {
+export const isOrderMailIn = (order: Order): boolean => {
   return (
     order.pharmacy?.fulfillmentTypes?.every(
       (fulfillmentType) => fulfillmentType === FulfillmentType.MailOrder

--- a/apps/patient/src/utils/getOrderFetchRedirectPath.ts
+++ b/apps/patient/src/utils/getOrderFetchRedirectPath.ts
@@ -1,3 +1,4 @@
+import { FulfillmentType } from 'packages/sdk/src/types';
 import { Order } from './models';
 
 export type OrderFetchRedirectPath = '/canceled' | '/pharmacy' | '/status' | '/review';
@@ -5,6 +6,23 @@ export type OrderFetchRedirectPath = '/canceled' | '/pharmacy' | '/status' | '/r
 export const hasSingleAutoRouteWithNoReroutes = (order: Order): boolean => {
   const routingHistory = order.metadata?.routingHistory ?? [];
   return routingHistory.length === 1 && routingHistory[0]?.selector === 'AUTO';
+};
+
+const hasSingleProviderRouteWithNoReroutes = (order: Order): boolean => {
+  const routingHistory = order.metadata?.routingHistory ?? [];
+  return routingHistory.length === 1 && routingHistory[0]?.selector === 'PROVIDER';
+};
+
+const isOrderMailIn = (order: Order): boolean => {
+  return (
+    order.pharmacy?.fulfillmentTypes?.every(
+      (fulfillmentType) => fulfillmentType === FulfillmentType.MailOrder
+    ) ?? false
+  );
+};
+
+const isForCompoundMed = (order: Order): boolean => {
+  return order.fills.some((f) => f.treatment.__typename === 'Compound');
 };
 
 type OrderFetchRedirectOptions = {
@@ -21,7 +39,10 @@ export const getOrderFetchRedirectPath = (
 
   if (order.pharmacy?.id) {
     const shouldConfirmAutoRoutedPharmacy =
-      hasSingleAutoRouteWithNoReroutes(order) &&
+      (hasSingleAutoRouteWithNoReroutes(order) || hasSingleProviderRouteWithNoReroutes(order)) &&
+      !isOrderMailIn(order) &&
+      // We don't want to show the marketplace for Compound Treatments
+      !isForCompoundMed(order) &&
       order.isReroutable &&
       !options.hasConfirmedAutoroutedPharmacy;
     return shouldConfirmAutoRoutedPharmacy ? '/pharmacy' : '/status';


### PR DESCRIPTION
We want to send Patients, for whom the provider chose a local pickup pharmacy, to the Marketplace to confirm that Pharmacy. We also want to ensure that compound medications are not re-directed either.