### PR TITLE
upgrade to node 22

### DIFF
--- a/.github/workflows/auto-bump-neutron.yml
+++ b/.github/workflows/auto-bump-neutron.yml
@@ -13,14 +13,14 @@ jobs:
     name: Bump neutron
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v5
       - uses: tibdex/github-app-token@v1
         id: generate-token
         with:
           app_id: ${{ secrets.CPR_APP_ID }}
           private_key: ${{ secrets.CPR_APP_SECRET }}
       - name: checkout neutron
-        uses: actions/checkout@v1
+        uses: actions/checkout@v5
         with:
           ref: neutron
       - name: merge

--- a/.github/workflows/auto-bump-photon.yml
+++ b/.github/workflows/auto-bump-photon.yml
@@ -13,14 +13,14 @@ jobs:
     name: Bump Photon
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v5
       - uses: tibdex/github-app-token@v1
         id: generate-token
         with:
           app_id: ${{ secrets.CPR_APP_ID }}
           private_key: ${{ secrets.CPR_APP_SECRET }}
       - name: checkout photon
-        uses: actions/checkout@v1
+        uses: actions/checkout@v5
         with:
           ref: photon
       - name: merge

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
 
       - name: Set up Node.js
         uses: actions/setup-node@v5

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Clear npm cache
         run: npm cache clean --force

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v5
         with:
           node-version: 22
 

--- a/.github/workflows/merge-bot.yml
+++ b/.github/workflows/merge-bot.yml
@@ -17,7 +17,7 @@ jobs:
     name: Merge
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
         with:
           ref: ${{ github.head_ref }}
       - uses: tibdex/github-app-token@v1

--- a/.github/workflows/npm-publish-test.yml
+++ b/.github/workflows/npm-publish-test.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
 

--- a/.github/workflows/npm-publish-test.yml
+++ b/.github/workflows/npm-publish-test.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Clear npm cache
         run: npm cache clean --force

--- a/.github/workflows/npm-publish-test.yml
+++ b/.github/workflows/npm-publish-test.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Node.js
         uses: actions/setup-node@v5

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -22,7 +22,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: photon
           fetch-depth: 0

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           registry-url: "https://registry.npmjs.org"
 
       - name: Update npm for trusted publishing

--- a/.github/workflows/pr-e2e-tests.yml
+++ b/.github/workflows/pr-e2e-tests.yml
@@ -57,7 +57,7 @@ jobs:
       options: --user 1001
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ inputs.sha }}
 

--- a/.github/workflows/pr-e2e-tests.yml
+++ b/.github/workflows/pr-e2e-tests.yml
@@ -84,8 +84,8 @@ jobs:
             const scripts = require('./.github/scripts/add-e2e-test-checks.js')
             return await scripts.createCheck({github, context, core})
 
-      - name: Use Node.js 20.x
-        uses: actions/setup-node@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: 'npm'

--- a/.github/workflows/pr-e2e-tests.yml
+++ b/.github/workflows/pr-e2e-tests.yml
@@ -87,7 +87,7 @@ jobs:
       - name: Use Node.js 20.x
         uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: 22
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set up Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v5
         with:
           node-version: 22
 

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
 
       - name: Set up Node.js
         uses: actions/setup-node@v5

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Install Dependencies
         run: npm ci

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -24,7 +24,7 @@ jobs:
       TARGET_ENV: ${{ github.event.client_payload.environment || inputs.environment || 'boson' }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Node.js
         uses: actions/setup-node@v5

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Use Node.js 20.x
         uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: 22
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -26,8 +26,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Use Node.js 20.x
-        uses: actions/setup-node@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: 'npm'

--- a/.github/workflows/type-check.yml
+++ b/.github/workflows/type-check.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 20
+          node-version: 22
 
       # there was an issue with the rollup binary not being available in the runner https://github.com/npm/cli/issues/4828
       - name: Install Rollup

--- a/.github/workflows/type-check.yml
+++ b/.github/workflows/type-check.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
 
       - name: Set up Node.js
         uses: actions/setup-node@v5

--- a/.github/workflows/type-check.yml
+++ b/.github/workflows/type-check.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v5
         with:
           node-version: 22
 

--- a/.github/workflows/vitest.yml
+++ b/.github/workflows/vitest.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: 22
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/.github/workflows/vitest.yml
+++ b/.github/workflows/vitest.yml
@@ -12,17 +12,13 @@ jobs:
     name: Vitest
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: 22
-        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
-
     steps:
       - uses: actions/checkout@v3
-      - name: Use Node.js ${{ matrix.node-version }}
+
+      - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 22
           cache: 'npm'
       # there was an issue with the rollup binary not being available in the runner https://github.com/npm/cli/issues/4828
       - name: Install Rollup

--- a/.github/workflows/vitest.yml
+++ b/.github/workflows/vitest.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
 
       - name: Set up Node.js
         uses: actions/setup-node@v5

--- a/.github/workflows/vitest.yml
+++ b/.github/workflows/vitest.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: 'npm'

--- a/packages/elements/index.html
+++ b/packages/elements/index.html
@@ -36,12 +36,12 @@
   </head>
   <body style="margin: 0px">
     <photon-client
-      id="EY6fay2mZV0VgYA0dTqgmSjEGzmBSblL"
-      org="org_kVS7AP4iuItESdMA"
-      domain="auth.neutron.health"
-      env="neutron"
-      audience="https://api.neutron.health"
-      uri="https://api.neutron.health/graphql"
+      id="7N9QZujlNJHL8EIPqXpu1wq8OuXqoxKb"
+      org="org_KzSVZBQixLRkqj5d"
+      domain="auth.boson.health"
+      env="boson"
+      audience="https://api.boson.health"
+      uri="https://api.boson.health/graphql"
       auto-login="true"
       emit-user-token="true"
     >

--- a/packages/elements/index.html
+++ b/packages/elements/index.html
@@ -36,12 +36,12 @@
   </head>
   <body style="margin: 0px">
     <photon-client
-      id="7N9QZujlNJHL8EIPqXpu1wq8OuXqoxKb"
-      org="org_KzSVZBQixLRkqj5d"
-      domain="auth.boson.health"
-      env="boson"
-      audience="https://api.boson.health"
-      uri="https://api.boson.health/graphql"
+      id="EY6fay2mZV0VgYA0dTqgmSjEGzmBSblL"
+      org="org_kVS7AP4iuItESdMA"
+      domain="auth.neutron.health"
+      env="neutron"
+      audience="https://api.neutron.health"
+      uri="https://api.neutron.health/graphql"
       auto-login="true"
       emit-user-token="true"
     >


### PR DESCRIPTION
Part of TECH-749

Publish GHA failed due to incompatible node version: https://github.com/Photon-Health/client/actions/runs/29954432386/job/89039805411
The minimum required Node version is 22.x