### PR TITLE
actions/create-github-app-token app-id > client-id

### DIFF
--- a/.github/workflows/auto-bump-neutron.yml
+++ b/.github/workflows/auto-bump-neutron.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/create-github-app-token@v3
         id: generate-token
         with:
-          app-id: ${{ secrets.CPR_APP_ID }}
+          client-id: ${{ secrets.CPR_APP_ID }}
           private-key: ${{ secrets.CPR_APP_SECRET }}
       - name: checkout neutron
         uses: actions/checkout@v5

--- a/.github/workflows/auto-bump-photon.yml
+++ b/.github/workflows/auto-bump-photon.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/create-github-app-token@v3
         id: generate-token
         with:
-          app-id: ${{ secrets.CPR_APP_ID }}
+          client-id: ${{ secrets.CPR_APP_ID }}
           private-key: ${{ secrets.CPR_APP_SECRET }}
       - name: checkout photon
         uses: actions/checkout@v5

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -22,7 +22,7 @@ jobs:
         id: generate-token
         with:
           # configured at https://github.com/organizations/Photon-Health/settings/secrets/dependabot
-          app-id: ${{ secrets.CPR_APP_ID_DEPENDABOT }}
+          client-id: ${{ secrets.CPR_APP_ID_DEPENDABOT }}
           private-key: ${{ secrets.CPR_APP_SECRET_DEPENDABOT }}
 
       - name: Approve PR

--- a/.github/workflows/merge-bot.yml
+++ b/.github/workflows/merge-bot.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/create-github-app-token@v3
         id: generate-token
         with:
-          app-id: ${{ secrets.CPR_APP_ID }}
+          client-id: ${{ secrets.CPR_APP_ID }}
           private-key: ${{ secrets.CPR_APP_SECRET }}
       - name: Fail if not ready
         if: ${{ !(contains(github.event.pull_request.labels.*.name, 'ready') || contains(github.event.pull_request.labels.*.name, 'ready to merge')) }}


### PR DESCRIPTION
Part of TECH-749

app-id is technically supported but the docs recommend switching to client-id, just getting ahead of it: https://github.com/actions/create-github-app-token#client-id-or-app-id