### PR TITLE
update from v1 > v5 needs additional fetch-depth

### DIFF
--- a/.github/workflows/auto-bump-neutron.yml
+++ b/.github/workflows/auto-bump-neutron.yml
@@ -13,7 +13,6 @@ jobs:
     name: Bump neutron
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
       - name: Generate token
         uses: actions/create-github-app-token@v3
         id: generate-token
@@ -24,6 +23,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           ref: neutron
+          fetch-depth: 0
       - name: merge
         run: |
           git config user.name 'GitHub'

--- a/.github/workflows/auto-bump-photon.yml
+++ b/.github/workflows/auto-bump-photon.yml
@@ -13,7 +13,6 @@ jobs:
     name: Bump Photon
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
       - name: Generate token
         uses: actions/create-github-app-token@v3
         id: generate-token
@@ -24,6 +23,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           ref: photon
+          fetch-depth: 0
       - name: merge
         run: |
           git config user.name 'GitHub'


### PR DESCRIPTION
Part of TECH-749

Bumps still failing, found this comment about v1 > v2: https://github.com/actions/checkout/issues/125#issuecomment-570254411

The bump GHA were the only actions upgrading from v1 to v5.