### PR TITLE
prescription-overrides prop

### DIFF
--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -23,6 +23,7 @@ import {
   DraftPrescriptionLayout,
   DraftPrescriptionsProvider,
   type PrescriptionFormData,
+  type PrescriptionOverrides,
   type TemplateOverrides,
   type TryCreatePrescriptionTemplateOptions,
   useDraftPrescriptions
@@ -176,6 +177,7 @@ export type {
   PharmacyOption,
   RoutingConstraint,
   TemplateOverrides,
+  PrescriptionOverrides,
   PrescriptionFormData,
   CoverageOption,
   SupervisorPrefill,

--- a/packages/components/src/systems/DraftPrescriptions/DraftPrescriptionsProvider.tsx
+++ b/packages/components/src/systems/DraftPrescriptions/DraftPrescriptionsProvider.tsx
@@ -121,7 +121,7 @@ function isTreatmentInDraftPrescriptions(
   return draftedPrescriptions.some((draft) => draft.treatment.id === treatmentId);
 }
 
-const createPrefillPrescriptionsOnApi = async ({
+const transformPrefillsToPrescriptionInputs = async ({
   client,
   patientId,
   templateIdsPrefill,
@@ -170,16 +170,7 @@ const createPrefillPrescriptionsOnApi = async ({
     rxToCreate.push(...fetchedPrescriptions);
   }
 
-  if (!rxToCreate.length) {
-    return;
-  }
-
-  const res = await client.apollo.mutate({
-    mutation: CreatePrescriptions,
-    variables: { prescriptions: rxToCreate }
-  });
-  const newRxs = res.data.createPrescriptions as Prescription[];
-  return newRxs;
+  return rxToCreate;
 };
 
 export const DraftPrescriptionsProvider = (props: DraftPrescriptionProviderProps) => {
@@ -219,7 +210,7 @@ export const DraftPrescriptionsProvider = (props: DraftPrescriptionProviderProps
       setIsLoadingPrefills(true);
 
       try {
-        const newRxs = await createPrefillPrescriptionsOnApi({
+        const prefillPrescriptionInputs = await transformPrefillsToPrescriptionInputs({
           client,
           patientId: props.patientId,
           templateIdsPrefill: props.templateIdsPrefill,
@@ -227,6 +218,17 @@ export const DraftPrescriptionsProvider = (props: DraftPrescriptionProviderProps
           prescriptionIdsPrefill: props.prescriptionIdsPrefill,
           rxNotesPrefill: rxNotesPrefill()
         });
+
+        if (!prefillPrescriptionInputs.length) {
+          return;
+        }
+
+        const res = await client.apollo.mutate({
+          mutation: CreatePrescriptions,
+          variables: { prescriptions: prefillPrescriptionInputs }
+        });
+        const newRxs = res.data.createPrescriptions as Prescription[];
+
         if (newRxs) {
           setDraftPrescriptions((prev) => [...prev, ...newRxs]);
           newRxs.forEach((rx) => {

--- a/packages/components/src/systems/DraftPrescriptions/DraftPrescriptionsProvider.tsx
+++ b/packages/components/src/systems/DraftPrescriptions/DraftPrescriptionsProvider.tsx
@@ -54,6 +54,7 @@ interface DraftPrescriptionProviderProps {
   templateIdsPrefill: string[];
   templateOverrides: TemplateOverrides;
   prescriptionIdsPrefill: string[];
+  prescriptionOverrides: PrescriptionOverrides;
   enableCombineAndDuplicate: boolean;
   additionalNotes?: string;
   weight?: number;
@@ -70,6 +71,21 @@ export type TemplateOverrides = {
     daysSupply?: number;
     instructions?: string;
     notes?: string;
+  };
+};
+
+export type PrescriptionOverrides = {
+  [prescriptionId: string]: {
+    externalId?: string;
+    treatmentId?: string;
+    dispenseQuantity?: number;
+    dispenseUnit?: string;
+    dispenseAsWritten?: boolean;
+    fillsAllowed?: number;
+    daysSupply?: number;
+    instructions?: string;
+    notes?: string;
+    doNotFillBeforeDate?: Date;
   };
 };
 
@@ -92,10 +108,14 @@ export type PrescriptionFormData = {
   diagnoseCodes: string[];
 };
 
-const mapFormDataToPrescriptionInput = (prescription: PrescriptionFormData, patientId: string) => ({
+const mapFormDataToPrescriptionInput = (
+  prescription: PrescriptionFormData,
+  treatmentId: string,
+  patientId: string
+) => ({
   externalId: prescription.externalId,
   patientId: patientId,
-  treatmentId: prescription.treatment?.id,
+  treatmentId: treatmentId,
   dispenseAsWritten: prescription.dispenseAsWritten,
   dispenseQuantity: prescription.dispenseQuantity,
   dispenseUnit: prescription.dispenseUnit,
@@ -121,12 +141,25 @@ function isTreatmentInDraftPrescriptions(
   return draftedPrescriptions.some((draft) => draft.treatment.id === treatmentId);
 }
 
+/**
+ * Ensure we always tack on the prefilled notes
+ * even if the original object's notes or override notes are blank
+ */
+function constructRxNotes(
+  original: string | null,
+  override: string | null,
+  prefill: string | null
+) {
+  return [override || original || '', prefill].filter((note) => !!note).join('\n\n');
+}
+
 const transformPrefillsToPrescriptionInputs = async ({
   client,
   patientId,
   templateIdsPrefill,
   templateOverrides,
   prescriptionIdsPrefill,
+  prescriptionOverrides,
   rxNotesPrefill
 }: {
   client: PhotonClient;
@@ -134,6 +167,7 @@ const transformPrefillsToPrescriptionInputs = async ({
   templateIdsPrefill: string[];
   templateOverrides: TemplateOverrides;
   prescriptionIdsPrefill: string[];
+  prescriptionOverrides: PrescriptionOverrides;
   rxNotesPrefill: string;
 }) => {
   const rxToCreate: MutationCreatePrescriptionsArgs['prescriptions'] = [];
@@ -142,16 +176,15 @@ const transformPrefillsToPrescriptionInputs = async ({
   if (templateIdsPrefill.length > 0) {
     const dedupedTemplateIds = Array.from(new Set(templateIdsPrefill));
     const templatedCreateRxList = dedupedTemplateIds.map((templateId) => {
-      const templateOverrideNotes = templateOverrides?.[templateId]?.notes;
-      const notes = [templateOverrideNotes || '', rxNotesPrefill]
-        .filter((note) => !!note)
-        .join('\n\n');
-
       return {
         ...templateOverrides?.[templateId],
         patientId: patientId,
         templateId,
-        notes
+        notes: constructRxNotes(
+          null,
+          templateOverrides?.[templateId]?.notes || null,
+          rxNotesPrefill
+        )
       };
     });
     rxToCreate.push(...templatedCreateRxList);
@@ -169,7 +202,20 @@ const transformPrefillsToPrescriptionInputs = async ({
           errorPolicy: 'none'
         });
         if (data?.prescription) {
-          return mapFormDataToPrescriptionInput(data.prescription, patientId);
+          const input = mapFormDataToPrescriptionInput(
+            {
+              ...data.prescription,
+              ...prescriptionOverrides?.[prescriptionId],
+              notes: constructRxNotes(
+                data.prescription.notes || null,
+                prescriptionOverrides?.[prescriptionId]?.notes || null,
+                rxNotesPrefill
+              )
+            },
+            prescriptionOverrides?.[prescriptionId]?.treatmentId || data.prescription.treatment.id,
+            patientId
+          );
+          return input;
         }
         return null;
       })
@@ -225,6 +271,7 @@ export const DraftPrescriptionsProvider = (props: DraftPrescriptionProviderProps
           templateIdsPrefill: props.templateIdsPrefill,
           templateOverrides: props.templateOverrides,
           prescriptionIdsPrefill: props.prescriptionIdsPrefill,
+          prescriptionOverrides: props.prescriptionOverrides,
           rxNotesPrefill: rxNotesPrefill()
         });
 
@@ -307,7 +354,11 @@ export const DraftPrescriptionsProvider = (props: DraftPrescriptionProviderProps
     try {
       const res = await client.apollo.mutate({
         mutation: CreatePrescription,
-        variables: mapFormDataToPrescriptionInput(prescriptionFormData, props.patientId)
+        variables: mapFormDataToPrescriptionInput(
+          prescriptionFormData,
+          prescriptionFormData.treatment.id,
+          props.patientId
+        )
       });
       const created = res.data.createPrescription as Prescription;
       createdPrescription = created;
@@ -368,7 +419,7 @@ export const DraftPrescriptionsProvider = (props: DraftPrescriptionProviderProps
     const res = await client.apollo.mutate({
       mutation: CreatePrescriptionTemplate,
       variables: {
-        ...mapFormDataToPrescriptionInput(prescription, props.patientId),
+        ...mapFormDataToPrescriptionInput(prescription, prescription.treatment.id, props.patientId),
         catalogId,
         isPrivate: true,
         ...(templateName ? { name: templateName } : {})

--- a/packages/components/src/systems/DraftPrescriptions/DraftPrescriptionsProvider.tsx
+++ b/packages/components/src/systems/DraftPrescriptions/DraftPrescriptionsProvider.tsx
@@ -123,26 +123,32 @@ function isTreatmentInDraftPrescriptions(
 
 const createPrefillPrescriptionsOnApi = async ({
   client,
-  props,
+  patientId,
+  templateIdsPrefill,
+  templateOverrides,
+  prescriptionIdsPrefill,
   rxNotesPrefill
 }: {
   client: PhotonClient;
-  props: DraftPrescriptionProviderProps;
+  patientId: string;
+  templateIdsPrefill: string[];
+  templateOverrides: TemplateOverrides;
+  prescriptionIdsPrefill: string[];
   rxNotesPrefill?: string;
 }) => {
   const rxToCreate: MutationCreatePrescriptionsArgs['prescriptions'] = [];
 
   // Create prescriptions from template ids with a few optional override values
-  if (props.templateIdsPrefill.length > 0) {
-    const dedupedTemplateIds = Array.from(new Set(props.templateIdsPrefill));
+  if (templateIdsPrefill.length > 0) {
+    const dedupedTemplateIds = Array.from(new Set(templateIdsPrefill));
     const templatedCreateRxList = dedupedTemplateIds.map((templateId) => {
-      const templateOverrideNotes = props.templateOverrides?.[templateId]?.notes;
+      const templateOverrideNotes = templateOverrides?.[templateId]?.notes;
       const notes = templateOverrideNotes
         ? `${templateOverrideNotes}\n\n${rxNotesPrefill}`
         : rxNotesPrefill;
       return {
-        ...props.templateOverrides?.[templateId],
-        patientId: props.patientId,
+        ...templateOverrides?.[templateId],
+        patientId: patientId,
         templateId,
         notes
       };
@@ -151,14 +157,14 @@ const createPrefillPrescriptionsOnApi = async ({
   }
 
   // Fetch prescriptions if needed
-  if (props.prescriptionIdsPrefill.length > 0) {
+  if (prescriptionIdsPrefill.length > 0) {
     const fetchedPrescriptions = await Promise.all(
-      props.prescriptionIdsPrefill.map(async (prescriptionId: string) => {
+      prescriptionIdsPrefill.map(async (prescriptionId: string) => {
         const { data } = await client.apollo.query({
           query: GetPrescription,
           variables: { id: prescriptionId }
         });
-        return transformPrescriptionFormData(data?.prescription, props.patientId);
+        return transformPrescriptionFormData(data?.prescription, patientId);
       })
     );
     rxToCreate.push(...fetchedPrescriptions);
@@ -215,7 +221,10 @@ export const DraftPrescriptionsProvider = (props: DraftPrescriptionProviderProps
       try {
         const newRxs = await createPrefillPrescriptionsOnApi({
           client,
-          props,
+          patientId: props.patientId,
+          templateIdsPrefill: props.templateIdsPrefill,
+          templateOverrides: props.templateOverrides,
+          prescriptionIdsPrefill: props.prescriptionIdsPrefill,
           rxNotesPrefill: rxNotesPrefill()
         });
         if (newRxs) {

--- a/packages/components/src/systems/DraftPrescriptions/DraftPrescriptionsProvider.tsx
+++ b/packages/components/src/systems/DraftPrescriptions/DraftPrescriptionsProvider.tsx
@@ -92,7 +92,7 @@ export type PrescriptionFormData = {
   diagnoseCodes: string[];
 };
 
-const transformPrescriptionFormData = (prescription: PrescriptionFormData, patientId: string) => ({
+const mapFormDataToPrescriptionInput = (prescription: PrescriptionFormData, patientId: string) => ({
   externalId: prescription.externalId,
   patientId: patientId,
   treatmentId: prescription.treatment?.id,
@@ -164,7 +164,7 @@ const transformPrefillsToPrescriptionInputs = async ({
           query: GetPrescription,
           variables: { id: prescriptionId }
         });
-        return transformPrescriptionFormData(data?.prescription, patientId);
+        return mapFormDataToPrescriptionInput(data?.prescription, patientId);
       })
     );
     rxToCreate.push(...fetchedPrescriptions);
@@ -298,7 +298,7 @@ export const DraftPrescriptionsProvider = (props: DraftPrescriptionProviderProps
     try {
       const res = await client.apollo.mutate({
         mutation: CreatePrescription,
-        variables: transformPrescriptionFormData(prescriptionFormData, props.patientId)
+        variables: mapFormDataToPrescriptionInput(prescriptionFormData, props.patientId)
       });
       const created = res.data.createPrescription as Prescription;
       createdPrescription = created;
@@ -359,7 +359,7 @@ export const DraftPrescriptionsProvider = (props: DraftPrescriptionProviderProps
     const res = await client.apollo.mutate({
       mutation: CreatePrescriptionTemplate,
       variables: {
-        ...transformPrescriptionFormData(prescription, props.patientId),
+        ...mapFormDataToPrescriptionInput(prescription, props.patientId),
         catalogId,
         isPrivate: true,
         ...(templateName ? { name: templateName } : {})

--- a/packages/components/src/systems/DraftPrescriptions/DraftPrescriptionsProvider.tsx
+++ b/packages/components/src/systems/DraftPrescriptions/DraftPrescriptionsProvider.tsx
@@ -85,7 +85,8 @@ export type PrescriptionOverrides = {
     daysSupply?: number;
     instructions?: string;
     notes?: string;
-    doNotFillBeforeDate?: Date;
+    // ISO string or date string in format ex. 2026-10-02
+    doNotFillBeforeDate?: string;
   };
 };
 
@@ -182,6 +183,7 @@ const transformPrefillsToPrescriptionInputs = async ({
   if (prescriptionIdsPrefill.length > 0) {
     const fetchedPrescriptions = await Promise.all(
       prescriptionIdsPrefill.map(async (prescriptionId: string) => {
+        const overrides = prescriptionOverrides?.[prescriptionId] || {};
         const { data } = await client.apollo.query({
           query: GetPrescription,
           variables: { id: prescriptionId },
@@ -193,14 +195,17 @@ const transformPrefillsToPrescriptionInputs = async ({
           const input = mapFormDataToPrescriptionInput(
             {
               ...data.prescription,
-              ...prescriptionOverrides?.[prescriptionId],
+              ...overrides,
               notes: constructRxNotes(
                 data.prescription.notes || null,
-                prescriptionOverrides?.[prescriptionId]?.notes || null,
+                overrides.notes || null,
                 rxNotesPrefill
-              )
+              ),
+              doNotFillBeforeDate: overrides.doNotFillBeforeDate
+                ? overrides.doNotFillBeforeDate.slice(0, 10)
+                : undefined
             },
-            prescriptionOverrides?.[prescriptionId]?.treatmentId || data.prescription.treatment.id,
+            overrides.treatmentId || data.prescription.treatment.id,
             patientId
           );
           return input;

--- a/packages/components/src/systems/DraftPrescriptions/DraftPrescriptionsProvider.tsx
+++ b/packages/components/src/systems/DraftPrescriptions/DraftPrescriptionsProvider.tsx
@@ -61,15 +61,15 @@ interface DraftPrescriptionProviderProps {
 }
 
 export type TemplateOverrides = {
-  [key: string]: {
-    daysSupply?: number;
-    dispenseAsWritten?: boolean;
+  [templateId: string]: {
+    externalId?: string;
     dispenseQuantity?: number;
     dispenseUnit?: string;
+    dispenseAsWritten?: boolean;
     fillsAllowed?: number;
+    daysSupply?: number;
     instructions?: string;
     notes?: string;
-    externalId?: string;
   };
 };
 
@@ -130,7 +130,7 @@ const createPrefillPrescriptionsOnApi = async ({
   props: DraftPrescriptionProviderProps;
   rxNotesPrefill?: string;
 }) => {
-  let rxToCreate: MutationCreatePrescriptionsArgs['prescriptions'] = [];
+  const rxToCreate: MutationCreatePrescriptionsArgs['prescriptions'] = [];
 
   // Create prescriptions from template ids with a few optional override values
   if (props.templateIdsPrefill.length > 0) {
@@ -147,7 +147,7 @@ const createPrefillPrescriptionsOnApi = async ({
         notes
       };
     });
-    rxToCreate = rxToCreate.concat(templatedCreateRxList);
+    rxToCreate.push(...templatedCreateRxList);
   }
 
   // Fetch prescriptions if needed
@@ -161,7 +161,7 @@ const createPrefillPrescriptionsOnApi = async ({
         return transformPrescriptionFormData(data?.prescription, props.patientId);
       })
     );
-    rxToCreate = rxToCreate.concat(fetchedPrescriptions);
+    rxToCreate.push(...fetchedPrescriptions);
   }
 
   if (!rxToCreate.length) {
@@ -181,7 +181,8 @@ export const DraftPrescriptionsProvider = (props: DraftPrescriptionProviderProps
     usePrescribeEventDispatch();
   const [, recentOrdersActions] = useRecentOrders();
   const client = usePhotonClient();
-  const [hasCreatedPrescriptions, setHasCreatedPrescriptions] = createSignal<boolean>(false);
+  const [hasCreatedPrefillPrescriptions, setHasCreatedPrefillPrescriptions] =
+    createSignal<boolean>(false);
   const [isLoadingPrefills, setIsLoadingPrefills] = createSignal<boolean>(false);
   const [draftPrescriptions, setDraftPrescriptions] = createSignal<Prescription[]>([]);
 
@@ -206,9 +207,9 @@ export const DraftPrescriptionsProvider = (props: DraftPrescriptionProviderProps
       // must have a patientId
       !!props.patientId &&
       // must not have created prescriptions yet
-      !hasCreatedPrescriptions()
+      !hasCreatedPrefillPrescriptions()
     ) {
-      setHasCreatedPrescriptions(true);
+      setHasCreatedPrefillPrescriptions(true);
       setIsLoadingPrefills(true);
 
       try {

--- a/packages/components/src/systems/DraftPrescriptions/DraftPrescriptionsProvider.tsx
+++ b/packages/components/src/systems/DraftPrescriptions/DraftPrescriptionsProvider.tsx
@@ -26,7 +26,7 @@ import {
   UpdatePrescriptionStates
 } from '../../fetch';
 import triggerToast from '../../utils/toastTriggers';
-import { formatPatientWeight } from './utils/formatters';
+import { constructRxNotes, formatPatientWeight } from './utils/formatters';
 
 export type DraftPrescriptionsContextType = {
   // values
@@ -139,18 +139,6 @@ function isTreatmentInDraftPrescriptions(
   draftedPrescriptions: { treatment: { id: string } }[]
 ) {
   return draftedPrescriptions.some((draft) => draft.treatment.id === treatmentId);
-}
-
-/**
- * Ensure we always tack on the prefilled notes
- * even if the original object's notes or override notes are blank
- */
-function constructRxNotes(
-  original: string | null,
-  override: string | null,
-  prefill: string | null
-) {
-  return [override || original || '', prefill].filter((note) => !!note).join('\n\n');
 }
 
 const transformPrefillsToPrescriptionInputs = async ({

--- a/packages/components/src/systems/DraftPrescriptions/DraftPrescriptionsProvider.tsx
+++ b/packages/components/src/systems/DraftPrescriptions/DraftPrescriptionsProvider.tsx
@@ -163,12 +163,18 @@ const transformPrefillsToPrescriptionInputs = async ({
       prescriptionIdsPrefill.map(async (prescriptionId: string) => {
         const { data } = await client.apollo.query({
           query: GetPrescription,
-          variables: { id: prescriptionId }
+          variables: { id: prescriptionId },
+          // request should throw if there are any errors
+          // retrieving the prescription
+          errorPolicy: 'none'
         });
-        return mapFormDataToPrescriptionInput(data?.prescription, patientId);
+        if (data?.prescription) {
+          return mapFormDataToPrescriptionInput(data.prescription, patientId);
+        }
+        return null;
       })
     );
-    rxToCreate.push(...fetchedPrescriptions);
+    rxToCreate.push(...fetchedPrescriptions.filter((rx) => !!rx));
   }
 
   return rxToCreate;

--- a/packages/components/src/systems/DraftPrescriptions/DraftPrescriptionsProvider.tsx
+++ b/packages/components/src/systems/DraftPrescriptions/DraftPrescriptionsProvider.tsx
@@ -241,10 +241,10 @@ export const DraftPrescriptionsProvider = (props: DraftPrescriptionProviderProps
           });
         }
       } catch (error) {
-        console.error('Error while trying to create prescriptions from prefill IDs', { error });
+        console.error('Error while trying to create prescriptions from prefills', { error });
         triggerToast({
           status: 'error',
-          body: 'There was an issue creating prescriptions from prefill IDs. Please check your configuration.'
+          body: 'There was an issue creating prescriptions from prefills. Please check your configuration.'
         });
       } finally {
         setIsLoadingPrefills(false);

--- a/packages/components/src/systems/DraftPrescriptions/DraftPrescriptionsProvider.tsx
+++ b/packages/components/src/systems/DraftPrescriptions/DraftPrescriptionsProvider.tsx
@@ -134,7 +134,7 @@ const transformPrefillsToPrescriptionInputs = async ({
   templateIdsPrefill: string[];
   templateOverrides: TemplateOverrides;
   prescriptionIdsPrefill: string[];
-  rxNotesPrefill?: string;
+  rxNotesPrefill: string;
 }) => {
   const rxToCreate: MutationCreatePrescriptionsArgs['prescriptions'] = [];
 
@@ -143,9 +143,10 @@ const transformPrefillsToPrescriptionInputs = async ({
     const dedupedTemplateIds = Array.from(new Set(templateIdsPrefill));
     const templatedCreateRxList = dedupedTemplateIds.map((templateId) => {
       const templateOverrideNotes = templateOverrides?.[templateId]?.notes;
-      const notes = templateOverrideNotes
-        ? `${templateOverrideNotes}\n\n${rxNotesPrefill}`
-        : rxNotesPrefill;
+      const notes = [templateOverrideNotes || '', rxNotesPrefill]
+        .filter((note) => !!note)
+        .join('\n\n');
+
       return {
         ...templateOverrides?.[templateId],
         patientId: patientId,
@@ -188,12 +189,14 @@ export const DraftPrescriptionsProvider = (props: DraftPrescriptionProviderProps
   );
 
   const rxNotesPrefill = createMemo(() => {
-    let notesPrefill = '';
-    if (props.additionalNotes) notesPrefill = `${props.additionalNotes}\n\n`;
-    if (props.weight)
-      notesPrefill = `${notesPrefill}${formatPatientWeight(props.weight, props.weightUnit)}`;
+    const notesPrefill = [
+      props.additionalNotes || '',
+      props.weight ? formatPatientWeight(props.weight, props.weightUnit) : ''
+    ]
+      .filter((note) => !!note)
+      .join('\n\n');
 
-    return notesPrefill || undefined;
+    return notesPrefill || '';
   });
 
   // Prefill new prescriptions based on templateIds or prescriptionIds when we get a patientId

--- a/packages/components/src/systems/DraftPrescriptions/utils/formatters.test.ts
+++ b/packages/components/src/systems/DraftPrescriptions/utils/formatters.test.ts
@@ -1,0 +1,55 @@
+import { constructRxNotes } from './formatters';
+
+describe('constructRxNotes', () => {
+  test('returns an empty string when all arguments are blank', () => {
+    expect(constructRxNotes(null, null, null)).toEqual('');
+    expect(constructRxNotes('', '', '')).toEqual('');
+    expect(constructRxNotes('  ', '  ', '  ')).toEqual('');
+  });
+
+  test('returns just the prefill when original and override are blank', () => {
+    expect(constructRxNotes(null, null, 'prefill note')).toEqual('prefill note');
+    expect(constructRxNotes('', '', 'prefill note')).toEqual('prefill note');
+    expect(constructRxNotes('  ', '  ', 'prefill note')).toEqual('prefill note');
+  });
+
+  test('returns just the original when override and prefill are blank', () => {
+    expect(constructRxNotes('original note', null, null)).toEqual('original note');
+    expect(constructRxNotes('original note', '', '')).toEqual('original note');
+    expect(constructRxNotes('original note', '  ', '  ')).toEqual('original note');
+  });
+
+  test('returns just the override when original and prefill are null', () => {
+    expect(constructRxNotes(null, 'override note', null)).toEqual('override note');
+    expect(constructRxNotes('', 'override note', '')).toEqual('override note');
+    expect(constructRxNotes('  ', 'override note', '  ')).toEqual('override note');
+  });
+
+  test('joins original and prefill with a blank line when override is blank', () => {
+    expect(constructRxNotes('original note', null, 'prefill note')).toEqual(
+      'original note\n\nprefill note'
+    );
+    expect(constructRxNotes('original note', '', 'prefill note')).toEqual(
+      'original note\n\nprefill note'
+    );
+    expect(constructRxNotes('original note', '  ', 'prefill note')).toEqual(
+      'original note\n\nprefill note'
+    );
+  });
+
+  test('prefers override over original when both are provided, dropping original entirely', () => {
+    expect(constructRxNotes('original note', 'override note', 'prefill note')).toEqual(
+      'override note\n\nprefill note'
+    );
+  });
+
+  test('falls back to original when override is an empty string', () => {
+    expect(constructRxNotes('original note', '', 'prefill note')).toEqual(
+      'original note\n\nprefill note'
+    );
+  });
+
+  test('does not trim leading/trailing whitespace within a note', () => {
+    expect(constructRxNotes(null, '  padded note  ', null)).toEqual('  padded note  ');
+  });
+});

--- a/packages/components/src/systems/DraftPrescriptions/utils/formatters.ts
+++ b/packages/components/src/systems/DraftPrescriptions/utils/formatters.ts
@@ -5,7 +5,7 @@ export const formatPatientWeight = (weight: number, weightUnit = 'lb') =>
  * Ensure we always tack on the prefilled notes
  * even if the original object's notes or override notes are blank.
  * Blank means null, empty, or whitespace-only.
- * @returns an empty string if all provided arguments are null
+ * @returns an empty string if all provided arguments are blank
  */
 export function constructRxNotes(
   original: string | null,

--- a/packages/components/src/systems/DraftPrescriptions/utils/formatters.ts
+++ b/packages/components/src/systems/DraftPrescriptions/utils/formatters.ts
@@ -1,2 +1,21 @@
 export const formatPatientWeight = (weight: number, weightUnit = 'lb') =>
   `Patient weight: ${weight} ${weightUnit}`;
+
+/**
+ * Ensure we always tack on the prefilled notes
+ * even if the original object's notes or override notes are blank.
+ * Blank means null, empty, or whitespace-only.
+ * @returns an empty string if all provided arguments are null
+ */
+export function constructRxNotes(
+  original: string | null,
+  override: string | null,
+  prefill: string | null
+): string {
+  const isBlank = (note: string | null) => !note || !note.trim();
+  override = !isBlank(override) ? override : null;
+  original = !isBlank(original) ? original : null;
+  prefill = !isBlank(prefill) ? prefill : null;
+
+  return [override || original, prefill].filter((note) => !!note).join('\n\n');
+}

--- a/packages/components/src/systems/TestMocks/MockDraftPrescriptionsProvider.tsx
+++ b/packages/components/src/systems/TestMocks/MockDraftPrescriptionsProvider.tsx
@@ -9,7 +9,7 @@ export const mockDraftPrescriptionsContextValues = () => {
     draftPrescriptions: () => [],
     prescriptionIds: () => [],
     isLoadingPrefills: () => false,
-    rxNotesPrefill: () => undefined,
+    rxNotesPrefill: () => '',
     deletePrescription: vi.fn(),
     tryCreatePrescription: vi.fn(),
     tryUpdatePrescriptionStates: vi.fn(),

--- a/packages/elements/index.html
+++ b/packages/elements/index.html
@@ -59,6 +59,7 @@
           enable-local-pickup="true"
           disable-list='[{"treatmentIds": ["med_01J6ZE5RSPDRXZRX7SEFHJSMDB"], "reason": "Not covered by patient insurance"}, {"treatmentIds": ["med_01J6ZE5RTEB5FK0CES2DDQWYV2"], "reason": "Too expensive"}]'
           id="one"
+          prescription-ids="tmp_01HHDP9WH6BGC2YBATFQQP79YT"
         ></photon-prescribe-workflow>
       </div>
     </photon-client>

--- a/packages/elements/index.html
+++ b/packages/elements/index.html
@@ -59,7 +59,7 @@
           enable-local-pickup="true"
           disable-list='[{"treatmentIds": ["med_01J6ZE5RSPDRXZRX7SEFHJSMDB"], "reason": "Not covered by patient insurance"}, {"treatmentIds": ["med_01J6ZE5RTEB5FK0CES2DDQWYV2"], "reason": "Too expensive"}]'
           id="one"
-          prescription-ids="tmp_01HHDP9WH6BGC2YBATFQQP79YT"
+          supervisor='{"firstName": "Testembed"}'
         ></photon-prescribe-workflow>
       </div>
     </photon-client>

--- a/packages/elements/index.html
+++ b/packages/elements/index.html
@@ -59,7 +59,6 @@
           enable-local-pickup="true"
           disable-list='[{"treatmentIds": ["med_01J6ZE5RSPDRXZRX7SEFHJSMDB"], "reason": "Not covered by patient insurance"}, {"treatmentIds": ["med_01J6ZE5RTEB5FK0CES2DDQWYV2"], "reason": "Too expensive"}]'
           id="one"
-          supervisor='{"firstName": "Testembed"}'
         ></photon-prescribe-workflow>
       </div>
     </photon-client>

--- a/packages/elements/src/photon-multirx-form/components/PrescribeWorkflow.tsx
+++ b/packages/elements/src/photon-multirx-form/components/PrescribeWorkflow.tsx
@@ -578,7 +578,6 @@ export function PrescribeWorkflow(props: PrescribeProps) {
                   store={props.formStore}
                   weight={props.weight}
                   weightUnit={props.weightUnit}
-                  prefillNotes={rxNotesPrefill()}
                   enableOrder={props.enableOrder}
                   catalogId={props.catalogId}
                   allowOffCatalogSearch={props.allowOffCatalogSearch}

--- a/packages/elements/src/photon-multirx-form/components/PrescriptionCard/DraftPrescriptionForm.tsx
+++ b/packages/elements/src/photon-multirx-form/components/PrescriptionCard/DraftPrescriptionForm.tsx
@@ -64,13 +64,12 @@ export const DraftPrescriptionForm = (props: {
   store: Record<string, any>;
   weight?: number;
   weightUnit?: string;
-  prefillNotes?: string;
   catalogId?: string;
   allowOffCatalogSearch?: boolean;
   disableList?: DisableList;
   onHideForm: () => void;
 }) => {
-  const { tryCreatePrescription, draftPrescriptions } = useDraftPrescriptions();
+  const { tryCreatePrescription, draftPrescriptions, rxNotesPrefill } = useDraftPrescriptions();
   const { dispatchOrderError, dispatchAnalyticsTrackEvent } = usePrescribeEventDispatch();
   const { screenDraftedPrescriptions, screeningAlerts } = usePrescriptionScreening();
   const [offCatalog, setOffCatalog] = createSignal<Medication | undefined>(undefined);
@@ -87,14 +86,14 @@ export const DraftPrescriptionForm = (props: {
     }
 
     // initialize values in the prescribe form
-    clearForm(props.actions, { notes: props.prefillNotes });
+    clearForm(props.actions, { notes: rxNotesPrefill() });
   });
 
   const handleTreatmentSelected = (e: any) => {
     if (e.detail.data.__typename === 'PrescriptionTemplate') {
       repopulateForm(props.actions, {
         ...e.detail.data,
-        notes: [e.detail.data?.notes, props.prefillNotes].filter((x) => x).join('\n\n')
+        notes: [e.detail.data?.notes, rxNotesPrefill()].filter((x) => x).join('\n\n')
       });
     } else {
       props.actions.updateFormValue({
@@ -176,14 +175,14 @@ export const DraftPrescriptionForm = (props: {
 
     // RESET THE FORM
     setOffCatalog(undefined);
-    clearForm(props.actions, { notes: props.prefillNotes });
+    clearForm(props.actions, { notes: rxNotesPrefill() });
 
     setSearchText('');
   };
 
   const handleCancel = () => {
     props.onHideForm();
-    clearForm(props.actions, { notes: props.prefillNotes });
+    clearForm(props.actions, { notes: rxNotesPrefill() });
   };
 
   createEffect(() => {
@@ -206,7 +205,7 @@ export const DraftPrescriptionForm = (props: {
         disable-list={props.disableList}
         on:photon-treatment-selected={handleTreatmentSelected}
         on:photon-treatment-unselected={() => {
-          clearForm(props.actions, { notes: props.prefillNotes });
+          clearForm(props.actions, { notes: rxNotesPrefill() });
 
           screenDraftedPrescriptions();
         }}

--- a/packages/elements/src/photon-multirx-form/components/PrescriptionCard/PrescriptionCard.tsx
+++ b/packages/elements/src/photon-multirx-form/components/PrescriptionCard/PrescriptionCard.tsx
@@ -18,7 +18,6 @@ export const PrescriptionCard = (props: {
   hideAddToTemplates: boolean;
   weight?: number;
   weightUnit?: string;
-  prefillNotes?: string;
   enableOrder: boolean;
   catalogId?: string;
   allowOffCatalogSearch?: boolean;
@@ -96,7 +95,6 @@ export const PrescriptionCard = (props: {
                 store={props.store}
                 weight={props.weight}
                 weightUnit={props.weightUnit}
-                prefillNotes={props.prefillNotes}
                 catalogId={props.catalogId}
                 allowOffCatalogSearch={props.allowOffCatalogSearch}
                 disableList={props.disableList}

--- a/packages/elements/src/photon-multirx-form/photon-prescribe-workflow-component.tsx
+++ b/packages/elements/src/photon-multirx-form/photon-prescribe-workflow-component.tsx
@@ -4,6 +4,7 @@ import {
   PharmacySelectionProvider,
   PrescribeEventDispatchProvider,
   PrescribeProvider,
+  PrescriptionOverrides,
   PrescriptionScreeningProvider,
   RecentOrders,
   SupervisorPrefill,
@@ -31,6 +32,7 @@ export interface PrescribeWorkflowComponentProps extends PrescribeProps {
   templateIds?: string;
   templateOverrides?: TemplateOverrides;
   prescriptionIds?: string;
+  prescriptionOverrides?: PrescriptionOverrides;
   enableCoverageCheck: boolean;
   pharmacyId?: string;
   enableLocalPickup: boolean;
@@ -66,6 +68,7 @@ export const PhotonPrescribeWorkflowComponent = (props: PrescribeWorkflowCompone
           templateIdsPrefill={props.templateIds?.split(',').map((id) => id.trim()) || []}
           templateOverrides={props.templateOverrides || {}}
           prescriptionIdsPrefill={props.prescriptionIds?.split(',').map((id) => id.trim()) || []}
+          prescriptionOverrides={props.prescriptionOverrides || {}}
           enableCombineAndDuplicate={props.enableCombineAndDuplicate}
           additionalNotes={props.additionalNotes}
           weight={props.weight}
@@ -138,6 +141,7 @@ customElement(
     templateIds: undefined,
     templateOverrides: undefined,
     prescriptionIds: undefined,
+    prescriptionOverrides: undefined,
     hideSubmit: false,
     hideTemplates: false,
     hidePatientCard: false,

--- a/packages/elements/src/photon-multirx-form/prescribe-workflow-prescription-prefill.test.tsx
+++ b/packages/elements/src/photon-multirx-form/prescribe-workflow-prescription-prefill.test.tsx
@@ -83,7 +83,7 @@ test('prefill a draft prescription from an existing prescriptionId', async () =>
   expect(sent.fillsAllowed).toBe(PRESCRIPTION.fillsAllowed);
 });
 
-test('additonalNotes are merged into draft prescriptions from an existing prescriptionId', async () => {
+test('additionalNotes are merged into draft prescriptions from an existing prescriptionId', async () => {
   const capturedPrescriptions: PrescriptionInput[] = [];
   let capturedPrescriptionQueryVariables: { id: string } | undefined;
 
@@ -138,7 +138,8 @@ test('prefill a draft prescription from an existing prescriptionId with override
     fillsAllowed: 5,
     daysSupply: 60,
     instructions: 'Take two tablets by mouth twice daily',
-    notes: 'Override note for prescription'
+    notes: 'Override note for prescription',
+    doNotFillBeforeDate: new Date('2026-10-02').toISOString()
   };
 
   server.use(
@@ -183,9 +184,10 @@ test('prefill a draft prescription from an existing prescriptionId with override
   expect(sent.daysSupply).toBe(overrides.daysSupply);
   expect(sent.instructions).toBe(overrides.instructions);
   expect(sent.notes).toBe(overrides.notes);
+  expect(sent.doNotFillBeforeDate).toBe('2026-10-02');
 });
 
-test('additonalNotes are merged into draft prescriptions from an existing prescriptionId with overrides', async () => {
+test('additionalNotes are merged into draft prescriptions from an existing prescriptionId with overrides', async () => {
   const capturedPrescriptions: PrescriptionInput[] = [];
   let capturedPrescriptionQueryVariables: { id: string } | undefined;
 

--- a/packages/elements/src/photon-multirx-form/prescribe-workflow-prescription-prefill.test.tsx
+++ b/packages/elements/src/photon-multirx-form/prescribe-workflow-prescription-prefill.test.tsx
@@ -36,18 +36,27 @@ afterEach(async () => {
 
 afterAll(() => server.close());
 
-test('additionalNotes are merged into prescriptions prefilled from templateIds', async () => {
-  const capturedPrescriptionInputs: PrescriptionInput[] = [];
+test('prefill a draft prescription from an existing prescriptionId', async () => {
+  const capturedPrescriptions: PrescriptionInput[] = [];
+  let capturedPrescriptionQueryVariables: { id: string } | undefined;
 
   server.use(
+    lambdasGql.query('GetPrescription', ({ variables }) => {
+      capturedPrescriptionQueryVariables = variables as { id: string };
+      return HttpResponse.json({
+        data: {
+          prescription: PRESCRIPTION
+        }
+      });
+    }),
     lambdasGql.mutation('CreatePrescriptions', ({ variables }) => {
       const prescriptions = variables.prescriptions as PrescriptionInput[];
-      capturedPrescriptionInputs.push(...prescriptions);
+      capturedPrescriptions.push(...prescriptions);
       return HttpResponse.json({
         data: {
           createPrescriptions: prescriptions.map((p, i) => ({
             ...PRESCRIPTION,
-            id: `rx_tpl_${i}`
+            id: `rx_${i}`
           }))
         }
       });
@@ -55,27 +64,38 @@ test('additionalNotes are merged into prescriptions prefilled from templateIds',
   );
 
   const { waitForDraftPrescription } = renderPrescribeWorkflow({
-    templateIds: 'tpl_1',
-    templateOverrides: { tpl_1: { notes: 'Template override note' } },
-    additionalNotes: 'Clinical additional note from host app'
+    prescriptionIds: PRESCRIPTION.id
   });
 
   await waitForDraftPrescription();
 
-  const [sent] = capturedPrescriptionInputs;
-  expect(sent.templateId).toBe('tpl_1');
-  // Bug: additionalNotes never reach the CreatePrescriptions mutation for
-  // template-prefilled rxs — only templateOverrides notes make it through.
-  expect(sent.notes).toContain('Clinical additional note from host app');
+  expect(capturedPrescriptionQueryVariables?.id).toBe(PRESCRIPTION.id);
+
+  const [sent] = capturedPrescriptions;
+  expect(sent.treatmentId).toBe(PRESCRIPTION.treatment.id);
+  expect(sent.daysSupply).toBe(PRESCRIPTION.daysSupply);
+  expect(sent.dispenseAsWritten).toBe(PRESCRIPTION.dispenseAsWritten);
+  expect(sent.dispenseQuantity).toBe(PRESCRIPTION.dispenseQuantity);
+  expect(sent.dispenseUnit).toBe(PRESCRIPTION.dispenseUnit);
+  expect(sent.instructions).toBe(PRESCRIPTION.instructions);
+  expect(sent.notes).toBe(PRESCRIPTION.notes);
+  expect(sent.fillsAllowed).toBe(PRESCRIPTION.fillsAllowed);
 });
 
-test('if prefilling from templateIds fails, render the prescription form', async () => {
-  const capturedPrescriptionInputs: PrescriptionInput[] = [];
+test('if prefilling from prescriptionIds fails, render the prescription form', async () => {
+  const capturedPrescriptions: PrescriptionInput[] = [];
 
   server.use(
+    lambdasGql.query('GetPrescription', () => {
+      return HttpResponse.json({
+        data: {
+          prescription: PRESCRIPTION
+        }
+      });
+    }),
     lambdasGql.mutation('CreatePrescriptions', ({ variables }) => {
       const prescriptions = variables.prescriptions as PrescriptionInput[];
-      capturedPrescriptionInputs.push(...prescriptions);
+      capturedPrescriptions.push(...prescriptions);
       return HttpResponse.json({
         data: null,
         errors: [
@@ -95,9 +115,7 @@ test('if prefilling from templateIds fails, render the prescription form', async
   );
 
   const { waitForPrescribeForm } = renderPrescribeWorkflow({
-    templateIds: 'tpl_1',
-    // Invalid dispense unit
-    templateOverrides: { tpl_1: { dispenseUnit: 'asdfsdfsf' } }
+    prescriptionIds: PRESCRIPTION.id
   });
 
   // Since creating the draft prescription failed,
@@ -105,7 +123,6 @@ test('if prefilling from templateIds fails, render the prescription form', async
   await waitForPrescribeForm();
 
   // Check that the prefill values made it to the mutation
-  const [sent] = capturedPrescriptionInputs;
-  expect(sent.templateId).toBe('tpl_1');
-  expect(sent.dispenseUnit).toBe('asdfsdfsf');
+  const [sent] = capturedPrescriptions;
+  expect(sent.treatmentId).toBe(PRESCRIPTION.treatment.id);
 });

--- a/packages/elements/src/photon-multirx-form/prescribe-workflow-prescription-prefill.test.tsx
+++ b/packages/elements/src/photon-multirx-form/prescribe-workflow-prescription-prefill.test.tsx
@@ -8,6 +8,7 @@ import { MockMedicationSearchElement } from '../test-utils/mock-medication-searc
 import { renderPrescribeWorkflow } from './test-utils/test-element-setup';
 import { stubGoogleMaps } from '../test-utils/stub-google-maps';
 import { PrescriptionInput } from '@photonhealth/sdk/dist/types';
+import { PrescriptionOverrides } from '@photonhealth/components';
 
 vi.mock('solid-element', () => ({
   customElement: vi.fn()
@@ -80,6 +81,153 @@ test('prefill a draft prescription from an existing prescriptionId', async () =>
   expect(sent.instructions).toBe(PRESCRIPTION.instructions);
   expect(sent.notes).toBe(PRESCRIPTION.notes);
   expect(sent.fillsAllowed).toBe(PRESCRIPTION.fillsAllowed);
+});
+
+test('additonalNotes are merged into draft prescriptions from an existing prescriptionId', async () => {
+  const capturedPrescriptions: PrescriptionInput[] = [];
+  let capturedPrescriptionQueryVariables: { id: string } | undefined;
+
+  server.use(
+    lambdasGql.query('GetPrescription', ({ variables }) => {
+      capturedPrescriptionQueryVariables = variables as { id: string };
+      return HttpResponse.json({
+        data: {
+          prescription: PRESCRIPTION
+        }
+      });
+    }),
+    lambdasGql.mutation('CreatePrescriptions', ({ variables }) => {
+      const prescriptions = variables.prescriptions as PrescriptionInput[];
+      capturedPrescriptions.push(...prescriptions);
+      return HttpResponse.json({
+        data: {
+          createPrescriptions: prescriptions.map((p, i) => ({
+            ...PRESCRIPTION,
+            id: `rx_${i}`
+          }))
+        }
+      });
+    })
+  );
+
+  const { waitForDraftPrescription } = renderPrescribeWorkflow({
+    prescriptionIds: PRESCRIPTION.id,
+    additionalNotes: 'Clinical additional note from host app'
+  });
+
+  await waitForDraftPrescription();
+
+  expect(capturedPrescriptionQueryVariables?.id).toBe(PRESCRIPTION.id);
+
+  const [sent] = capturedPrescriptions;
+  expect(sent.notes).toBe(
+    [PRESCRIPTION.notes, 'Clinical additional note from host app'].join('\n\n')
+  );
+});
+
+test('prefill a draft prescription from an existing prescriptionId with overrides', async () => {
+  const capturedPrescriptions: PrescriptionInput[] = [];
+  let capturedPrescriptionQueryVariables: { id: string } | undefined;
+
+  const overrides: PrescriptionOverrides['rx_123'] = {
+    externalId: 'ext_456',
+    treatmentId: 'trt_override',
+    dispenseQuantity: 60,
+    dispenseUnit: 'Tablets',
+    dispenseAsWritten: true,
+    fillsAllowed: 5,
+    daysSupply: 60,
+    instructions: 'Take two tablets by mouth twice daily',
+    notes: 'Override note for prescription'
+  };
+
+  server.use(
+    lambdasGql.query('GetPrescription', ({ variables }) => {
+      capturedPrescriptionQueryVariables = variables as { id: string };
+      return HttpResponse.json({
+        data: {
+          prescription: PRESCRIPTION
+        }
+      });
+    }),
+    lambdasGql.mutation('CreatePrescriptions', ({ variables }) => {
+      const prescriptions = variables.prescriptions as PrescriptionInput[];
+      capturedPrescriptions.push(...prescriptions);
+      return HttpResponse.json({
+        data: {
+          createPrescriptions: prescriptions.map((p, i) => ({
+            ...PRESCRIPTION,
+            id: `rx_${i}`
+          }))
+        }
+      });
+    })
+  );
+
+  const { waitForDraftPrescription } = renderPrescribeWorkflow({
+    prescriptionIds: PRESCRIPTION.id,
+    prescriptionOverrides: { [PRESCRIPTION.id]: overrides }
+  });
+
+  await waitForDraftPrescription();
+
+  expect(capturedPrescriptionQueryVariables?.id).toBe(PRESCRIPTION.id);
+
+  const [sent] = capturedPrescriptions;
+  expect(sent.treatmentId).toBe(overrides.treatmentId);
+  expect(sent.externalId).toBe(overrides.externalId);
+  expect(sent.dispenseQuantity).toBe(overrides.dispenseQuantity);
+  expect(sent.dispenseUnit).toBe(overrides.dispenseUnit);
+  expect(sent.dispenseAsWritten).toBe(overrides.dispenseAsWritten);
+  expect(sent.fillsAllowed).toBe(overrides.fillsAllowed);
+  expect(sent.daysSupply).toBe(overrides.daysSupply);
+  expect(sent.instructions).toBe(overrides.instructions);
+  expect(sent.notes).toBe(overrides.notes);
+});
+
+test('additonalNotes are merged into draft prescriptions from an existing prescriptionId with overrides', async () => {
+  const capturedPrescriptions: PrescriptionInput[] = [];
+  let capturedPrescriptionQueryVariables: { id: string } | undefined;
+
+  const overrides: PrescriptionOverrides['rx_123'] = {
+    notes: 'Override note for prescription'
+  };
+
+  server.use(
+    lambdasGql.query('GetPrescription', ({ variables }) => {
+      capturedPrescriptionQueryVariables = variables as { id: string };
+      return HttpResponse.json({
+        data: {
+          prescription: PRESCRIPTION
+        }
+      });
+    }),
+    lambdasGql.mutation('CreatePrescriptions', ({ variables }) => {
+      const prescriptions = variables.prescriptions as PrescriptionInput[];
+      capturedPrescriptions.push(...prescriptions);
+      return HttpResponse.json({
+        data: {
+          createPrescriptions: prescriptions.map((p, i) => ({
+            ...PRESCRIPTION,
+            id: `rx_${i}`
+          }))
+        }
+      });
+    })
+  );
+
+  const { waitForDraftPrescription } = renderPrescribeWorkflow({
+    prescriptionIds: PRESCRIPTION.id,
+    prescriptionOverrides: { [PRESCRIPTION.id]: overrides },
+    additionalNotes: 'Clinical additional note from host app'
+  });
+
+  await waitForDraftPrescription();
+
+  expect(capturedPrescriptionQueryVariables?.id).toBe(PRESCRIPTION.id);
+
+  const [sent] = capturedPrescriptions;
+  expect(sent.notes).toBe([overrides.notes, 'Clinical additional note from host app'].join('\n\n'));
 });
 
 test('if prescriptionId cannot be found, render the prescription form', async () => {

--- a/packages/elements/src/photon-multirx-form/prescribe-workflow-prescription-prefill.test.tsx
+++ b/packages/elements/src/photon-multirx-form/prescribe-workflow-prescription-prefill.test.tsx
@@ -82,32 +82,26 @@ test('prefill a draft prescription from an existing prescriptionId', async () =>
   expect(sent.fillsAllowed).toBe(PRESCRIPTION.fillsAllowed);
 });
 
-test('if prefilling from prescriptionIds fails, render the prescription form', async () => {
-  const capturedPrescriptions: PrescriptionInput[] = [];
+test('if prescriptionId cannot be found, render the prescription form', async () => {
+  let capturedPrescriptionQueryVariables: { id: string } | undefined;
 
   server.use(
-    lambdasGql.query('GetPrescription', () => {
+    lambdasGql.query('GetPrescription', ({ variables }) => {
+      capturedPrescriptionQueryVariables = variables as { id: string };
       return HttpResponse.json({
         data: {
-          prescription: PRESCRIPTION
-        }
-      });
-    }),
-    lambdasGql.mutation('CreatePrescriptions', ({ variables }) => {
-      const prescriptions = variables.prescriptions as PrescriptionInput[];
-      capturedPrescriptions.push(...prescriptions);
-      return HttpResponse.json({
-        data: null,
+          prescription: null
+        },
         errors: [
           {
-            path: ['createPrescriptions'],
+            path: ['prescription'],
             locations: [
               {
                 line: 2,
                 column: 3
               }
             ],
-            message: 'sdfsdfsdfs is not a valid dispense unit'
+            message: 'No prescription found with id tmp_01HHDP9WH6BGC2YBATFQQP79YT'
           }
         ]
       });
@@ -122,7 +116,5 @@ test('if prefilling from prescriptionIds fails, render the prescription form', a
   // the prescribe workflow should render with the form expanded
   await waitForPrescribeForm();
 
-  // Check that the prefill values made it to the mutation
-  const [sent] = capturedPrescriptions;
-  expect(sent.treatmentId).toBe(PRESCRIPTION.treatment.id);
+  expect(capturedPrescriptionQueryVariables?.id).toBe(PRESCRIPTION.id);
 });

--- a/packages/elements/src/photon-multirx-form/prescribe-workflow-template-prefill.test.tsx
+++ b/packages/elements/src/photon-multirx-form/prescribe-workflow-template-prefill.test.tsx
@@ -3,10 +3,11 @@ import { afterAll, afterEach, beforeAll, expect, test, vi } from 'vitest';
 import { setupServer } from 'msw/node';
 import { HttpResponse } from 'msw';
 import { PatientStore } from '../stores/patient';
-import { defaultHandlers, lambdasGql, TREATMENT } from '@photonhealth/sdk/test-utils';
+import { defaultHandlers, lambdasGql, PRESCRIPTION } from '@photonhealth/sdk/test-utils';
 import { MockMedicationSearchElement } from '../test-utils/mock-medication-search.element';
 import { renderPrescribeWorkflow } from './test-utils/test-element-setup';
 import { stubGoogleMaps } from '../test-utils/stub-google-maps';
+import { PrescriptionInput } from '@photonhealth/sdk/dist/types';
 
 vi.mock('solid-element', () => ({
   customElement: vi.fn()
@@ -35,57 +36,76 @@ afterEach(async () => {
 
 afterAll(() => server.close());
 
-type PrescriptionInput = {
-  templateId?: string;
-  patientId?: string;
-  notes?: string;
-};
-
 test('additionalNotes are merged into prescriptions prefilled from templateIds', async () => {
-  const capturedPrescriptions: PrescriptionInput[] = [];
+  const capturedPrescriptionInputs: PrescriptionInput[] = [];
 
   server.use(
     lambdasGql.mutation('CreatePrescriptions', ({ variables }) => {
       const prescriptions = variables.prescriptions as PrescriptionInput[];
-      capturedPrescriptions.push(...prescriptions);
+      capturedPrescriptionInputs.push(...prescriptions);
       return HttpResponse.json({
         data: {
           createPrescriptions: prescriptions.map((p, i) => ({
-            __typename: 'Prescription',
-            id: `rx_tpl_${i}`,
-            externalId: null,
-            dispenseAsWritten: false,
-            dispenseQuantity: 30,
-            dispenseUnit: 'Tablet',
-            fillsAllowed: 1,
-            daysSupply: 30,
-            instructions: 'Take one daily',
-            notes: p.notes ?? '',
-            doNotFillBeforeDate: null,
-            diagnoses: [],
-            treatment: TREATMENT
+            ...PRESCRIPTION,
+            id: `rx_tpl_${i}`
           }))
         }
       });
     })
   );
 
-  renderPrescribeWorkflow({
+  const { waitForDraftPrescription } = renderPrescribeWorkflow({
     templateIds: 'tpl_1',
     templateOverrides: { tpl_1: { notes: 'Template override note' } },
     additionalNotes: 'Clinical additional note from host app'
   });
 
-  await waitFor(
-    () => {
-      expect(capturedPrescriptions).toHaveLength(1);
-    },
-    { timeout: 3000 }
-  );
+  await waitForDraftPrescription();
 
-  const [sent] = capturedPrescriptions;
+  const [sent] = capturedPrescriptionInputs;
   expect(sent.templateId).toBe('tpl_1');
   // Bug: additionalNotes never reach the CreatePrescriptions mutation for
   // template-prefilled rxs — only templateOverrides notes make it through.
   expect(sent.notes).toContain('Clinical additional note from host app');
+});
+
+test('if prefilling from templateIds fails, render the prescription form', async () => {
+  const capturedPrescriptionInputs: PrescriptionInput[] = [];
+
+  server.use(
+    lambdasGql.mutation('CreatePrescriptions', ({ variables }) => {
+      const prescriptions = variables.prescriptions as PrescriptionInput[];
+      capturedPrescriptionInputs.push(...prescriptions);
+      return HttpResponse.json({
+        data: null,
+        errors: [
+          {
+            path: ['createPrescriptions'],
+            locations: [
+              {
+                line: 2,
+                column: 3
+              }
+            ],
+            message: 'sdfsdfsdfs is not a valid dispense unit'
+          }
+        ]
+      });
+    })
+  );
+
+  const { waitForPrescribeForm } = renderPrescribeWorkflow({
+    templateIds: 'tpl_1',
+    // Invalid dispense unit
+    templateOverrides: { tpl_1: { dispenseUnit: 'asdfsdfsf' } }
+  });
+
+  // Since creating the draft prescription failed,
+  // the prescribe workflow should render with the form expanded
+  await waitForPrescribeForm();
+
+  // Check that the prefill values made it to the mutation
+  const [sent] = capturedPrescriptionInputs;
+  expect(sent.templateId).toBe('tpl_1');
+  expect(sent.dispenseUnit).toBe('asdfsdfsf');
 });

--- a/packages/elements/src/photon-multirx-form/prescribe-workflow-template-prefill.test.tsx
+++ b/packages/elements/src/photon-multirx-form/prescribe-workflow-template-prefill.test.tsx
@@ -105,7 +105,6 @@ test('additionalNotes are merged into prescriptions prefilled from templateIds',
 
   const { waitForDraftPrescription } = renderPrescribeWorkflow({
     templateIds: 'tpl_1',
-    templateOverrides: { tpl_1: { notes: 'Template override note' } },
     additionalNotes: 'Clinical additional note from host app'
   });
 
@@ -113,9 +112,42 @@ test('additionalNotes are merged into prescriptions prefilled from templateIds',
 
   const [sent] = capturedPrescriptionInputs;
   expect(sent.templateId).toBe('tpl_1');
-  // Bug: additionalNotes never reach the CreatePrescriptions mutation for
-  // template-prefilled rxs — only templateOverrides notes make it through.
-  expect(sent.notes).toContain('Clinical additional note from host app');
+  expect(sent.notes).toBe('Clinical additional note from host app');
+});
+
+test('additionalNotes are merged into prescriptions prefilled from templateIds with overrides', async () => {
+  const capturedPrescriptionInputs: PrescriptionInput[] = [];
+
+  const overrides: TemplateOverrides['tpl_1'] = {
+    notes: 'Override note for tpl_1'
+  };
+
+  server.use(
+    lambdasGql.mutation('CreatePrescriptions', ({ variables }) => {
+      const prescriptions = variables.prescriptions as PrescriptionInput[];
+      capturedPrescriptionInputs.push(...prescriptions);
+      return HttpResponse.json({
+        data: {
+          createPrescriptions: prescriptions.map((p, i) => ({
+            ...PRESCRIPTION,
+            id: `rx_tpl_${i}`
+          }))
+        }
+      });
+    })
+  );
+
+  const { waitForDraftPrescription } = renderPrescribeWorkflow({
+    templateIds: 'tpl_1',
+    templateOverrides: { tpl_1: overrides },
+    additionalNotes: 'Clinical additional note from host app'
+  });
+
+  await waitForDraftPrescription();
+
+  const [sent] = capturedPrescriptionInputs;
+  expect(sent.templateId).toBe('tpl_1');
+  expect(sent.notes).toBe([overrides.notes, 'Clinical additional note from host app'].join('\n\n'));
 });
 
 test('if prefilling from templateIds fails, render the prescription form', async () => {

--- a/packages/elements/src/photon-multirx-form/prescribe-workflow-template-prefill.test.tsx
+++ b/packages/elements/src/photon-multirx-form/prescribe-workflow-template-prefill.test.tsx
@@ -8,6 +8,7 @@ import { MockMedicationSearchElement } from '../test-utils/mock-medication-searc
 import { renderPrescribeWorkflow } from './test-utils/test-element-setup';
 import { stubGoogleMaps } from '../test-utils/stub-google-maps';
 import { PrescriptionInput } from '@photonhealth/sdk/dist/types';
+import { TemplateOverrides } from '@photonhealth/components';
 
 vi.mock('solid-element', () => ({
   customElement: vi.fn()
@@ -35,6 +36,54 @@ afterEach(async () => {
 });
 
 afterAll(() => server.close());
+
+test('prefill a draft prescription from templateIds with overrides', async () => {
+  const capturedPrescriptionInputs: PrescriptionInput[] = [];
+
+  const overrides: TemplateOverrides['tpl_1'] = {
+    externalId: 'ext_123',
+    dispenseQuantity: 60,
+    dispenseUnit: 'Tablets',
+    dispenseAsWritten: true,
+    fillsAllowed: 3,
+    daysSupply: 30,
+    instructions: 'Take two tablets by mouth twice daily',
+    notes: 'Override note for tpl_1'
+  };
+
+  server.use(
+    lambdasGql.mutation('CreatePrescriptions', ({ variables }) => {
+      const prescriptions = variables.prescriptions as PrescriptionInput[];
+      capturedPrescriptionInputs.push(...prescriptions);
+      return HttpResponse.json({
+        data: {
+          createPrescriptions: prescriptions.map((p, i) => ({
+            ...PRESCRIPTION,
+            id: `rx_tpl_${i}`
+          }))
+        }
+      });
+    })
+  );
+
+  const { waitForDraftPrescription } = renderPrescribeWorkflow({
+    templateIds: 'tpl_1',
+    templateOverrides: { tpl_1: overrides }
+  });
+
+  await waitForDraftPrescription();
+
+  const [sent] = capturedPrescriptionInputs;
+  expect(sent.templateId).toBe('tpl_1');
+  expect(sent.externalId).toBe(overrides.externalId);
+  expect(sent.dispenseQuantity).toBe(overrides.dispenseQuantity);
+  expect(sent.dispenseUnit).toBe(overrides.dispenseUnit);
+  expect(sent.dispenseAsWritten).toBe(overrides.dispenseAsWritten);
+  expect(sent.fillsAllowed).toBe(overrides.fillsAllowed);
+  expect(sent.daysSupply).toBe(overrides.daysSupply);
+  expect(sent.instructions).toBe(overrides.instructions);
+  expect(sent.notes).toBe(overrides.notes);
+});
 
 test('additionalNotes are merged into prescriptions prefilled from templateIds', async () => {
   const capturedPrescriptionInputs: PrescriptionInput[] = [];

--- a/packages/elements/src/photon-pharmacy-select/photon-pharmacy-select.tsx
+++ b/packages/elements/src/photon-pharmacy-select/photon-pharmacy-select.tsx
@@ -92,6 +92,7 @@ const PhotonPharmacySelectComponent = (props: PhotonPharmacySelectProps) => {
             templateIdsPrefill={[]}
             templateOverrides={{}}
             prescriptionIdsPrefill={[]}
+            prescriptionOverrides={{}}
             enableCombineAndDuplicate={false}
           >
             <PharmacySelectionProvider

--- a/packages/sdk/src/test-utils/fixtures.ts
+++ b/packages/sdk/src/test-utils/fixtures.ts
@@ -1,4 +1,4 @@
-import { Patient } from '../types';
+import { Patient, Prescription, PrescriptionState } from '../types';
 
 export const PATIENT = {
   __typename: 'Patient',
@@ -34,6 +34,7 @@ export const DISPENSE_UNIT = {
 };
 
 export const PROVIDER = {
+  __typename: 'Provider',
   id: 'usr_1',
   email: 'doc@test.com',
   credentials: 'MD',
@@ -43,7 +44,13 @@ export const PROVIDER = {
     last: 'Doc',
     middle: null,
     title: 'Dr. '
-  }
+  },
+  NPI: null,
+  address: null,
+  externalId: null,
+  fax: null,
+  phone: '+17185559876',
+  organizations: []
 };
 
 export const ORGANIZATION = {
@@ -51,3 +58,27 @@ export const ORGANIZATION = {
   name: 'Test Org',
   customer: { id: 'cust_1', name: 'Test Customer' }
 };
+
+export const PRESCRIPTION = {
+  __typename: 'Prescription',
+  id: 'rx_123',
+  externalId: 'ext_rx_123',
+  daysSupply: 30,
+  diagnoses: [],
+  dispenseAsWritten: false,
+  dispenseQuantity: 30,
+  dispenseUnit: 'Tablet',
+  effectiveDate: '2026-01-01',
+  doNotFillBeforeDate: null,
+  expirationDate: '2027-01-01',
+  fills: [],
+  fillsAllowed: 3,
+  fillsRemaining: 3,
+  instructions: 'Take 1 tablet by mouth once daily',
+  notes: null,
+  state: PrescriptionState.Active,
+  writtenAt: '2026-01-01T00:00:00.000Z',
+  patient: PATIENT,
+  prescriber: PROVIDER,
+  treatment: TREATMENT
+} as Prescription;

--- a/packages/sdk/src/test-utils/fixtures.ts
+++ b/packages/sdk/src/test-utils/fixtures.ts
@@ -75,7 +75,7 @@ export const PRESCRIPTION = {
   fillsAllowed: 3,
   fillsRemaining: 3,
   instructions: 'Take 1 tablet by mouth once daily',
-  notes: null,
+  notes: 'Misc notes',
   state: PrescriptionState.Active,
   writtenAt: '2026-01-01T00:00:00.000Z',
   patient: PATIENT,

--- a/packages/sdk/src/test-utils/index.ts
+++ b/packages/sdk/src/test-utils/index.ts
@@ -1,2 +1,9 @@
-export { PATIENT, TREATMENT, DISPENSE_UNIT, PROVIDER, ORGANIZATION } from './fixtures';
+export {
+  PATIENT,
+  TREATMENT,
+  DISPENSE_UNIT,
+  PROVIDER,
+  ORGANIZATION,
+  PRESCRIPTION
+} from './fixtures';
 export { defaultHandlers, clinicalGql, lambdasGql } from './msw-handlers';


### PR DESCRIPTION
Part of TECH-757

Core changes:
- `prescription-overrides` embed prop that allows overrides on draft prescriptions prefilled from `prescription-ids`
- test coverage for template ID prefill and prescription ID prefill behavior

Going to bump elements after building out `initial-prescriptions` so we can deploy those new props together