### PR TITLE
group alerts by med name

### DIFF
--- a/packages/components/src/systems/ScreeningAlerts/ScreeningAlertsByPrescription.test.tsx
+++ b/packages/components/src/systems/ScreeningAlerts/ScreeningAlertsByPrescription.test.tsx
@@ -1,0 +1,35 @@
+import { groupAlertsByPrescription } from './ScreeningAlertsByPrescription';
+import { PrescriptionScreeningAlert } from '@photonhealth/sdk/dist/clinical-api/types';
+
+const drafted = (id: string, name: string) => ({
+  __typename: 'PrescriptionScreeningAlertInvolvedDraftedPrescription',
+  id,
+  name
+});
+
+const alert = (id: string, involvedEntities: unknown[]): PrescriptionScreeningAlert =>
+  ({
+    id,
+    involvedEntities
+  } as unknown as PrescriptionScreeningAlert);
+
+describe('groupAlertsByPrescription', () => {
+  it('groups alerts for the same medication name under one entry', () => {
+    const alert1 = alert('alert-1', [drafted('rx-1', 'Lisinopril')]);
+    const alert2 = alert('alert-2', [drafted('rx-2', 'Lisinopril')]);
+
+    const groups = groupAlertsByPrescription([alert1, alert2]);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].alerts).toEqual([alert1, alert2]);
+  });
+
+  it('keeps alerts for different medication names in separate groups', () => {
+    const alert1 = alert('alert-1', [drafted('rx-1', 'Lisinopril')]);
+    const alert2 = alert('alert-2', [drafted('rx-2', 'Metformin')]);
+
+    const groups = groupAlertsByPrescription([alert1, alert2]);
+
+    expect(groups).toHaveLength(2);
+  });
+});

--- a/packages/components/src/systems/ScreeningAlerts/ScreeningAlertsByPrescription.tsx
+++ b/packages/components/src/systems/ScreeningAlerts/ScreeningAlertsByPrescription.tsx
@@ -23,11 +23,12 @@ function groupAlertsByPrescription(
   const prescriptionMap = new Map<string, AlertsForPrescription>();
 
   for (const alert of screeningAlerts) {
-    // loop through alerts for the drafted prescriptions in the order and organize by prescription id
+    // loop through alerts for the drafted prescriptions and organize by prescription name
+    // so multiple alerts for the same medication share a single group
     for (const prescription of alert.involvedEntities.filter(isDraftedPrescription)) {
-      const group = prescriptionMap.get(prescription.id) ?? { prescription, alerts: [] };
+      const group = prescriptionMap.get(prescription.name) ?? { prescription, alerts: [] };
       if (!group.alerts.includes(alert)) group.alerts.push(alert);
-      prescriptionMap.set(prescription.id, group);
+      prescriptionMap.set(prescription.name, group);
     }
   }
 

--- a/packages/components/src/systems/ScreeningAlerts/ScreeningAlertsByPrescription.tsx
+++ b/packages/components/src/systems/ScreeningAlerts/ScreeningAlertsByPrescription.tsx
@@ -17,7 +17,7 @@ const isDraftedPrescription = (
   (entity as PrescriptionScreeningAlertInvolvedDraftedPrescription).__typename ===
   'PrescriptionScreeningAlertInvolvedDraftedPrescription';
 
-function groupAlertsByPrescription(
+export function groupAlertsByPrescription(
   screeningAlerts: PrescriptionScreeningAlert[]
 ): AlertsForPrescription[] {
   const prescriptionMap = new Map<string, AlertsForPrescription>();


### PR DESCRIPTION
<img width="386" height="774" alt="Screenshot 2026-07-30 at 11 54 06 AM" src="https://github.com/user-attachments/assets/f2aa35af-b69f-4624-ae0b-d70f0c263440" />

We're doing this to reduce the duplicated alert names. Before this change, we would show two Zepbounds (one for auto-injector and one for solution). We show the brand name so we would still show "Zepbound Kwikpen" AND "Zepbound" but at least this is a step in the right direction.